### PR TITLE
use loadbalancer and metallb for quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ CONTAINER_TOOL ?= docker
 
 KIND_CLUSTER_NAME ?= coraza-kubernetes-operator-integration
 ISTIO_VERSION ?= 1.28.2
+METALLB_VERSION ?= 0.15.3
+METALLB_POOL_SIZE ?= 128 # Defines the size of MetalLB pool, when being used
 
 VERSION ?= dev
 CONTROLLER_MANAGER_CONTAINER_IMAGE_BASE ?= ghcr.io/networking-incubator/coraza-kubernetes-operator
@@ -137,7 +139,7 @@ lint.config: golangci-lint
 
 .PHONY: cluster.kind
 cluster.kind:
-	ISTIO_VERSION=${ISTIO_VERSION} python3 hack/kind_cluster.py setup
+	ISTIO_VERSION=${ISTIO_VERSION} METALLB_VERSION=${METALLB_VERSION} METALLB_POOL_SIZE=${METALLB_POOL_SIZE} python3 hack/kind_cluster.py setup
 
 .PHONY: cluster.load-images
 cluster.load-images:

--- a/config/samples/gateway.yaml
+++ b/config/samples/gateway.yaml
@@ -4,8 +4,9 @@ metadata:
   name: coraza-gateway
   labels:
     istio.io/rev: "coraza"
-  annotations:
-    networking.istio.io/service-type: ClusterIP
+  ## Uncomment below if you do not want to use LoadBalancer service type
+  #annotations:
+  #  networking.istio.io/service-type: ClusterIP
 spec:
   gatewayClassName: istio
   listeners:


### PR DESCRIPTION
Start using metallb for quickstart and kind clusters.

This way instead of constantly needing clusterIP we can simply rely on a local LoadBalancer for tests