### PR TITLE
fix: replace broken CRD printer columns with working fields

### DIFF
--- a/api/v1alpha1/engine_types.go
+++ b/api/v1alpha1/engine_types.go
@@ -37,8 +37,10 @@ func init() {
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Instance",type=string,JSONPath=`.spec.instance`
+// +kubebuilder:printcolumn:name="RuleSet",type=string,JSONPath=`.spec.ruleSet.name`
+// +kubebuilder:printcolumn:name="Failure Policy",type=string,JSONPath=`.spec.failurePolicy`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type Engine struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/api/v1alpha1/ruleset_types.go
+++ b/api/v1alpha1/ruleset_types.go
@@ -37,7 +37,6 @@ func init() {
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Instance",type=string,JSONPath=`.spec.instance`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type RuleSet struct {

--- a/config/crd/bases/waf.k8s.coraza.io_engines.yaml
+++ b/config/crd/bases/waf.k8s.coraza.io_engines.yaml
@@ -15,12 +15,18 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.instance
-      name: Instance
+    - jsonPath: .spec.ruleSet.name
+      name: RuleSet
+      type: string
+    - jsonPath: .spec.failurePolicy
+      name: Failure Policy
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/waf.k8s.coraza.io_rulesets.yaml
+++ b/config/crd/bases/waf.k8s.coraza.io_rulesets.yaml
@@ -15,9 +15,6 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.instance
-      name: Instance
-      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string


### PR DESCRIPTION
Both Engine and RuleSet CRDs defined an additionalPrinterColumn referencing `.spec.instance`, which does not exist in the API types. This caused `kubectl get engines` and `kubectl get rulesets` to show empty custom columns.

Engine:
- Replace "Instance" with "RuleSet" (`.spec.ruleSet.name`)
- Add "Failure Policy" (`.spec.failurePolicy`)
- Add "Age" (`.metadata.creationTimestamp`)
- Keep "Ready"

RuleSet:
- Remove broken "Instance" column
- Keep "Ready" and "Age"

Fixes #30
