### PR TITLE
docs(samples): add end-to-end sample with echo backend

### DIFF
--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -1,0 +1,64 @@
+# Sample: Coraza WAF with Istio Gateway
+
+This sample deploys a Coraza WAF Engine in front of a simple echo service
+using the Kubernetes Gateway API and Istio.
+
+## What's included
+
+| File | Description |
+|------|-------------|
+| `ruleset.yaml` | ConfigMaps with SecRule directives (base config, SQLi, XSS, custom) and a `RuleSet` CR that aggregates them |
+| `engine.yaml` | `Engine` CR that references the RuleSet and configures the Istio WASM driver |
+| `gateway.yaml` | Kubernetes Gateway API `Gateway` using the Istio gateway class |
+| `httproute.yaml` | `HTTPRoute` that sends all traffic through the gateway to the echo service |
+| `echo.yaml` | A simple echo Deployment and Service to act as the backend |
+
+## Prerequisites
+
+- A Kubernetes cluster with Istio installed
+- The coraza-kubernetes-operator running in the cluster
+- The Kubernetes Gateway API CRDs installed
+
+## Deploy
+
+```bash
+kubectl apply -f config/samples/
+```
+
+## Test
+
+Port-forward to the gateway:
+
+```bash
+kubectl port-forward svc/coraza-gateway-istio 8080:80
+```
+
+Normal request (should return "hello from echo"):
+
+```bash
+curl http://localhost:8080/
+```
+
+SQLi attempt (should be blocked by rule 1001):
+
+```bash
+curl "http://localhost:8080/?q=select+*+from+users"
+```
+
+XSS attempt (should be blocked by rule 2001):
+
+```bash
+curl "http://localhost:8080/?q=<script>alert(1)</script>"
+```
+
+Evil monkey (should be blocked by rule 3001):
+
+```bash
+curl "http://localhost:8080/?q=evilmonkey"
+```
+
+## Cleanup
+
+```bash
+kubectl delete -f config/samples/
+```

--- a/config/samples/echo.yaml
+++ b/config/samples/echo.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+spec:
+  selector:
+    app: echo
+  ports:
+    - port: 80
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+        - name: echo
+          image: registry.k8s.io/gateway-api/echo-basic:v20251204-v1.4.1
+          ports:
+            - containerPort: 3000

--- a/config/samples/httproute.yaml
+++ b/config/samples/httproute.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo
+spec:
+  parentRefs:
+    - name: coraza-gateway
+  rules:
+    - backendRefs:
+        - name: echo
+          port: 80


### PR DESCRIPTION
The existing samples defined the CRDs but had no backend service or HTTPRoute, so they couldn't actually route traffic through the WAF. Add an echo Deployment/Service, an HTTPRoute, and a README with deploy/test instructions.
