### PR TITLE
fix(rbac): grant events permission for events.k8s.io API group

### DIFF
--- a/charts/coraza-kubernetes-operator/templates/clusterrole.yaml
+++ b/charts/coraza-kubernetes-operator/templates/clusterrole.yaml
@@ -14,7 +14,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
+      - events.k8s.io
     resources:
       - events
     verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,13 +13,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -31,6 +24,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - extensions.istio.io
   resources:

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -29,7 +29,7 @@ import (
 // Global RBAC
 // -----------------------------------------------------------------------------
 
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**Describe the pull request**

The event broadcaster uses the modern events.k8s.io API group, but the ClusterRole only granted create/patch on core ("") events. This caused "Server rejected event" errors when the operator tried to record events in dynamically-created namespaces.
