### PR TITLE
build(helm): add helm.sync-rbac target to prevent ClusterRole drift

### DIFF
--- a/.github/instructions/helm.instructions.md
+++ b/.github/instructions/helm.instructions.md
@@ -2,8 +2,8 @@
 applyTo: "charts/**"
 ---
 
-- CRDs in `crds/` must be identical to `config/crd/bases/`. Run `make helm.sync-crds` after any API type change and verify the copied files match.
-- RBAC rules in the ClusterRole template must stay in sync with `config/rbac/role.yaml`. Changes to controller RBAC markers (`kubebuilder:rbac`) require updating the chart.
+- CRDs in `crds/` must be identical to `config/crd/bases/`. Run `make helm.sync` after any API type change and verify the copied files match.
+- RBAC rules in the ClusterRole template must stay in sync with `config/rbac/role.yaml`. Run `make helm.sync` after any change to `kubebuilder:rbac` markers.
 - All configurable values must appear in `values.yaml` with sensible defaults. Helpers that reference `.Values.*` keys not present in `values.yaml` should be avoided.
 - Istio-specific resources (ServiceEntry, DestinationRule) must be gated behind `{{ if .Values.istio.enabled }}`.
 - PDB defaults must be safe for the default `replicaCount`. A PDB with `minAvailable >= replicaCount` blocks voluntary evictions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           go-version-file: "go.mod"
 
       - name: build and generate manifests
-        run: make manifests generate
+        run: make manifests generate helm.sync
 
       - name: check for uncommitted changes
-        run: git diff --exit-code || (echo "generated files have uncommitted changes. run 'make manifests generate' and commit the results." && exit 1)
+        run: git diff --exit-code || (echo "generated files have uncommitted changes. run 'make manifests generate helm.sync' and commit the results." && exit 1)
 
   lint:
     name: lint

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,17 @@ helm.template: ## Render the Helm chart templates locally
 helm.sync-crds: manifests ## Copy generated CRDs into the Helm chart
 	cp config/crd/bases/*.yaml $(HELM_CHART_DIR)/crds/
 
+.PHONY: helm.sync-rbac
+helm.sync-rbac: manifests ## Sync generated RBAC rules into the Helm chart ClusterRole
+	@GEN=config/rbac/role.yaml; \
+	CHART=$(HELM_CHART_DIR)/templates/clusterrole.yaml; \
+	sed '/^rules:/q' "$$CHART" > "$$CHART.tmp" && \
+	sed '1,/^rules:/d' "$$GEN" >> "$$CHART.tmp" && \
+	mv "$$CHART.tmp" "$$CHART"
+
+.PHONY: helm.sync
+helm.sync: helm.sync-crds helm.sync-rbac ## Sync all generated resources into the Helm chart
+
 # -------------------------------------------------------------------------------
 # Dependencies
 # -------------------------------------------------------------------------------

--- a/charts/coraza-kubernetes-operator/templates/clusterrole.yaml
+++ b/charts/coraza-kubernetes-operator/templates/clusterrole.yaml
@@ -5,69 +5,69 @@ metadata:
   labels:
     {{- include "coraza-operator.labels" . | nindent 4 }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-      - events.k8s.io
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - extensions.istio.io
-    resources:
-      - wasmplugins
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - waf.k8s.coraza.io
-    resources:
-      - engines
-      - rulesets
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - waf.k8s.coraza.io
-    resources:
-      - engines/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - waf.k8s.coraza.io
-    resources:
-      - engines/status
-      - rulesets/status
-    verbs:
-      - get
-      - patch
-      - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - extensions.istio.io
+  resources:
+  - wasmplugins
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - waf.k8s.coraza.io
+  resources:
+  - engines
+  - rulesets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - waf.k8s.coraza.io
+  resources:
+  - engines/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - waf.k8s.coraza.io
+  resources:
+  - engines/status
+  - rulesets/status
+  verbs:
+  - get
+  - patch
+  - update


### PR DESCRIPTION
**Describe the pull request**

The chart's ClusterRole rules were a hand-maintained copy of the controller-gen generated config/rbac/role.yaml with nothing enforcing sync. helm.sync-rbac extracts the rules block from the generated file and patches it into the chart template, preserving the Helm metadata header. A new helm.sync umbrella target runs both CRD and RBAC sync.

**Which issue this resolves**

Related to #71

**Additional context**

Minor step in the kustomize to helm migration