### PR TITLE
feat: add event assertions to test framework and tests

### DIFF
--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -110,10 +110,11 @@ func TestEngineReconciler_ReconcileIstioDriver(t *testing.T) {
 	}()
 
 	t.Log("Reconciling Istio Engine")
+	recorder := utils.NewFakeRecorder()
 	reconciler := &EngineReconciler{
 		Client:                    k8sClient,
 		Scheme:                    scheme,
-		Recorder:                  utils.NewTestRecorder(),
+		Recorder:                  recorder,
 		ruleSetCacheServerCluster: "test-cluster",
 	}
 	result, err := reconciler.Reconcile(ctx, ctrl.Request{
@@ -137,6 +138,9 @@ func TestEngineReconciler_ReconcileIstioDriver(t *testing.T) {
 	assert.Equal(t, "Ready", condition.Type)
 	assert.Equal(t, metav1.ConditionTrue, condition.Status)
 	assert.Equal(t, "Configured", condition.Reason)
+
+	assert.True(t, recorder.HasEvent("Normal", "WasmPluginCreated"),
+		"expected Normal/WasmPluginCreated event; got: %v", recorder.Events)
 }
 
 func TestEngineReconciler_StatusUpdateHandling(t *testing.T) {

--- a/test/framework/README.md
+++ b/test/framework/README.md
@@ -107,6 +107,9 @@ SecRule ARGS "@contains attack" "id:1,phase:2,deny,status:403"`)
 | `ExpectResourceGone(ns, name, gvr)` | Poll until resource is deleted |
 | `ExpectCondition(ns, name, gvr, type, status)` | Generic condition poll |
 | `ExpectCreateFails(msg, fn)` | Assert fn returns error containing msg |
+| `GetEvents(ns)` | List all events.k8s.io/v1 events in namespace |
+| `ExpectEvent(ns, match)` | Poll until a matching event exists |
+| `ExpectNoEvent(ns, match)` | Assert no matching event currently exists (point-in-time) |
 
 ### GatewayProxy - Traffic Assertions
 

--- a/test/framework/events.go
+++ b/test/framework/events.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 Shane Utt.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EventMatch specifies criteria for matching Kubernetes events.
+// Empty fields are treated as wildcards (match any value).
+type EventMatch struct {
+	Type   string // "Normal" or "Warning"
+	Reason string
+}
+
+// GetEvents returns all events.k8s.io/v1 events in the given namespace.
+func (s *Scenario) GetEvents(namespace string) []eventsv1.Event {
+	s.T.Helper()
+	events, err := s.F.KubeClient.EventsV1().Events(namespace).List(
+		s.T.Context(), metav1.ListOptions{},
+	)
+	require.NoError(s.T, err, "list events in namespace %s", namespace)
+	return events.Items
+}
+
+// ExpectEvent polls until at least one event matching the criteria exists in
+// the namespace.
+func (s *Scenario) ExpectEvent(namespace string, match EventMatch) {
+	s.T.Helper()
+	s.T.Logf("Waiting for %s event with reason %q in %s", match.Type, match.Reason, namespace)
+	require.EventuallyWithT(s.T, func(collect *assert.CollectT) {
+		events, err := s.F.KubeClient.EventsV1().Events(namespace).List(
+			s.T.Context(), metav1.ListOptions{},
+		)
+		if !assert.NoError(collect, err) {
+			return
+		}
+		found := false
+		for _, e := range events.Items {
+			if matchesEvent(e, match) {
+				found = true
+				break
+			}
+		}
+		assert.True(collect, found,
+			"no %s event with reason %q found in %s; existing events: [%s]",
+			match.Type, match.Reason, namespace, summarizeEvents(events.Items),
+		)
+	}, DefaultTimeout, DefaultInterval)
+}
+
+// ExpectNoEvent asserts that no event matching the criteria currently exists
+// in the namespace. This is a point-in-time check — call it after the system
+// has settled (e.g., after ExpectEngineReady).
+func (s *Scenario) ExpectNoEvent(namespace string, match EventMatch) {
+	s.T.Helper()
+	events := s.GetEvents(namespace)
+	for _, e := range events {
+		if matchesEvent(e, match) {
+			s.T.Errorf("unexpected %s event with reason %q in %s: %s",
+				e.Type, e.Reason, namespace, e.Note)
+		}
+	}
+}
+
+func matchesEvent(e eventsv1.Event, m EventMatch) bool {
+	if m.Type != "" && e.Type != m.Type {
+		return false
+	}
+	if m.Reason != "" && e.Reason != m.Reason {
+		return false
+	}
+	return true
+}
+
+func summarizeEvents(events []eventsv1.Event) string {
+	if len(events) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(events))
+	for _, e := range events {
+		parts = append(parts, fmt.Sprintf("%s/%s: %s", e.Type, e.Reason, e.Note))
+	}
+	return strings.Join(parts, "; ")
+}

--- a/test/integration/coreruleset_test.go
+++ b/test/integration/coreruleset_test.go
@@ -103,6 +103,10 @@ SecRule ARGS "@rx (?i:<script[^>]*>)" \
 	s.ExpectEngineReady(ns, "crs-engine")
 	s.ExpectWasmPluginExists(ns, "coraza-engine-crs-engine")
 
+	s.Step("verify operator emitted expected events")
+	s.ExpectEvent(ns, framework.EventMatch{Type: "Normal", Reason: "RulesCached"})
+	s.ExpectEvent(ns, framework.EventMatch{Type: "Normal", Reason: "WasmPluginCreated"})
+
 	// -------------------------------------------------------------------------
 	// Step 4: Deploy backend and verify WAF enforcement
 	// -------------------------------------------------------------------------

--- a/test/integration/reconcile_test.go
+++ b/test/integration/reconcile_test.go
@@ -53,6 +53,10 @@ func TestReconciliation(t *testing.T) {
 	s.ExpectEngineReady(ns, "engine")
 	s.ExpectWasmPluginExists(ns, "coraza-engine-engine")
 
+	s.Step("verify operator emitted expected events")
+	s.ExpectEvent(ns, framework.EventMatch{Type: "Normal", Reason: "RulesCached"})
+	s.ExpectEvent(ns, framework.EventMatch{Type: "Normal", Reason: "WasmPluginCreated"})
+
 	s.Step("deploy echo backend")
 	s.CreateEchoBackend(ns, "echo")
 	s.CreateHTTPRoute(ns, "echo-route", "reconcile-gw", "echo")


### PR DESCRIPTION
**Describe the pull request**

Add event querying and assertion helpers to the integration test framework (GetEvents, ExpectEvent, ExpectNoEvent) and a FakeRecorder to the unit test utilities that captures events for inspection.

Use these in existing unit tests (RuleSet and Engine controller) and integration tests (reconcile, coreruleset) to verify the operator emits expected events during reconciliation. This catches RBAC regressions like #84 where event creation silently failed.

**Which issue this resolves**

Resolves #86

