### PR TITLE
fix(ftw): add coraza-proxy-wasm bootstrap rules to CRS base config

### DIFF
--- a/hack/generate_coreruleset_configmaps.py
+++ b/hack/generate_coreruleset_configmaps.py
@@ -32,6 +32,48 @@ data:
     SecAuditLog /dev/stdout
     SecAuditLogFormat JSON
     SecAuditEngine RelevantOnly
+    SecRequestBodyLimit 131072
+    SecRequestBodyInMemoryLimit 131072
+    SecRequestBodyLimitAction Reject
+    SecRule REQUEST_HEADERS:Content-Type "^(?:application(?:/soap\\+|/)|text/)xml" \\
+     "id:200000,\\
+     phase:1,\\
+     t:none,t:lowercase,\\
+     pass,\\
+     nolog,\\
+     ctl:requestBodyProcessor=XML"
+    SecRule REQUEST_HEADERS:Content-Type "^application/json" \\
+     "id:200001,\\
+     phase:1,\\
+     t:none,t:lowercase,\\
+     pass,\\
+     nolog,\\
+     ctl:requestBodyProcessor=JSON"
+    SecRule REQUEST_HEADERS:Content-Type "^application/[a-z0-9.-]+[+]json" \\
+     "id:200006,\\
+     phase:1,\\
+     t:none,t:lowercase,\\
+     pass,\\
+     nolog,\\
+     ctl:requestBodyProcessor=JSON"
+    SecRule REQBODY_ERROR "!@eq 0" \\
+     "id:200002,\\
+     phase:2,\\
+     t:none,\\
+     log,\\
+     deny,\\
+     status:400,\\
+     msg:'Failed to parse request body.',\\
+     logdata:'%{reqbody_error_msg}',\\
+     severity:2"
+    SecRule MULTIPART_STRICT_ERROR "!@eq 0" \\
+     "id:200003,\\
+     phase:2,\\
+     t:none,\\
+     log,\\
+     deny,\\
+     status:400,\\
+     msg:'Multipart request body failed strict validation.'"
     SecDefaultAction "phase:2,log,auditlog,deny,status:403"
     SecAction \\
      "id:900990,\\


### PR DESCRIPTION
**Describe the pull request**

The generated BASE_RULES_CONFIGMAP was missing the standard coraza-proxy-wasm body processing directives. Without them, CRS rules that inspect XML, JSON, or multipart request bodies find nothing because no body processor is activated, causing ~242 FTW test failures at PL1.

Add the recommended directives from coraza-proxy-wasm's coraza.conf-recommended.conf: XML/JSON/JSON-subtype body processor rules (200000, 200001, 200006), request body error handling (200002), multipart strict validation (200003), and body size limits.

**Which issue this resolves**

Related to #103
