### PR TITLE
test(integration): Updated reconcile scenario with degraded `RuleSet`

### DIFF
--- a/test/framework/assertions.go
+++ b/test/framework/assertions.go
@@ -65,6 +65,20 @@ func (s *Scenario) ExpectEngineDegraded(namespace, name string) {
 	s.ExpectCondition(namespace, name, EngineGVR, "Degraded", "True")
 }
 
+// ExpectRuleSetReady polls until the RuleSet has condition Ready=True.
+func (s *Scenario) ExpectRuleSetReady(namespace, name string) {
+	s.T.Helper()
+	s.T.Logf("Waiting for Rule Set %s/%s to be Ready", namespace, name)
+	s.ExpectCondition(namespace, name, RuleSetGVR, "Ready", "True")
+}
+
+// ExpectRuleSetDegraded polls until the RuleSet has condition Degraded=True.
+func (s *Scenario) ExpectRuleSetDegraded(namespace, name string) {
+	s.T.Helper()
+	s.T.Logf("Waiting for RuleSet %s/%s to be Degraded", namespace, name)
+	s.ExpectCondition(namespace, name, RuleSetGVR, "Degraded", "True")
+}
+
 // ExpectGatewayProgrammed polls until the Gateway has condition
 // Programmed=True.
 func (s *Scenario) ExpectGatewayProgrammed(namespace, name string) {

--- a/test/integration/reconcile_test.go
+++ b/test/integration/reconcile_test.go
@@ -46,6 +46,8 @@ func TestReconciliation(t *testing.T) {
 	)
 	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-evil"})
 
+	s.ExpectRuleSetReady(ns, "ruleset")
+
 	s.CreateEngine(ns, "engine", framework.EngineOpts{
 		RuleSetName: "ruleset",
 		GatewayName: "reconcile-gw",
@@ -86,4 +88,16 @@ func TestReconciliation(t *testing.T) {
 
 	gw.ExpectAllowed("/sinistermonkey")
 	gw.ExpectBlocked("/maniacalmonkey")
+
+	// --- ConfigMap content update: replace with garbage
+
+	s.Step("replace rules with garbage")
+	s.UpdateConfigMap(ns, "block-sinister", "SecDoesNotExist")
+
+	s.ExpectRuleSetDegraded(ns, "ruleset")
+
+	s.Step("cache remained untouched, old rules still apply")
+	gw.ExpectAllowed("/sinistermonkey")
+	gw.ExpectBlocked("/maniacalmonkey")
+
 }


### PR DESCRIPTION
After having tested all reconciliation works for updating a `ConfigMap` wired to a `RuleSet`, we now update the `ConfigMap` with garbage, assert its degraded and that the "previous" correct rules are still applicable.

Closes #24 