### PR TITLE
README update for minimum supported OCP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ engines enforce.
 
 [ModSecurity Seclang]:https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)
 
+### Supported Platforms
+
+The operator is designed to run on:
+- **Kubernetes**: v1.33+
+- **OpenShift Container Platform (OCP)**: v4.20+
+
 ### Supported Integrations
 
 The operator integrates with other tools to attach WAF instances to

--- a/charts/coraza-kubernetes-operator/README.md
+++ b/charts/coraza-kubernetes-operator/README.md
@@ -2,7 +2,7 @@
 
 Deploys the [Coraza Kubernetes Operator](https://github.com/networking-incubator/coraza-kubernetes-operator) — declarative Web Application Firewall (WAF) support for Kubernetes Gateways.
 
-> **Requires Kubernetes &#x2265;1.33.0.** The chart and operator use `resizePolicy` and the `Chart.yaml` enforces this minimum.
+> **Requires Kubernetes ≥1.33.0 or OpenShift Container Platform ≥4.20.** The chart and operator use `resizePolicy` and the `Chart.yaml` enforces this minimum.
 
 
 ## Installation


### PR DESCRIPTION
This PR updates the documentation across the main repository and the Helm chart to explicitly state our supported platforms, highlighting compatibility with OpenShift Container Platform (OCP) 4.20+ and establishing the minimum Kubernetes requirement of v1.33+.