### PR TITLE
feat(FailurePolicy): Wasm image with FailurePolicy

### DIFF
--- a/test/framework/resources.go
+++ b/test/framework/resources.go
@@ -110,7 +110,7 @@ type EngineOpts struct {
 // Defaults
 // -----------------------------------------------------------------------------
 
-const fallbackWasmImage = "oci://ghcr.io/networking-incubator/coraza-proxy-wasm:08fb3dd7229b6bf9211bf15e4d4f4f54b7dbda49"
+const fallbackWasmImage = "oci://ghcr.io/networking-incubator/coraza-proxy-wasm:1902646ac7391b65be092cdec9b47d29fa5724c7"
 
 func defaultWasmImage() string {
 	if img := os.Getenv("CORAZA_WASM_IMAGE"); img != "" {


### PR DESCRIPTION
Updated the fallback Wasm image to be used, to be the one with the FailurePolicy being honoured. This can still be overwritten by the user, just as before

Closes #26 
