### PR TITLE
fix(olm): render bundle with openshift.enabled and remove required CRDs

### DIFF
--- a/bundle/base/csv-template.yaml
+++ b/bundle/base/csv-template.yaml
@@ -24,17 +24,6 @@ spec:
         kind: RuleSet
         name: rulesets.waf.k8s.coraza.io
         version: v1alpha1
-    required:
-      - description: Gateway represents an instance of a service-traffic handling infrastructure.
-        displayName: Gateway
-        kind: Gateway
-        name: gateways.gateway.networking.k8s.io
-        version: v1
-      - description: WasmPlugin provides a mechanism to extend the functionality provided by the Istio proxy.
-        displayName: WasmPlugin
-        kind: WasmPlugin
-        name: wasmplugins.extensions.istio.io
-        version: v1alpha1
   description: |
     The Coraza Kubernetes Operator provides Web Application Firewall (WAF)
     support for Kubernetes Gateways. It manages Coraza WAF

--- a/hack/generate_bundle.py
+++ b/hack/generate_bundle.py
@@ -25,15 +25,16 @@ EXCLUDED_KINDS = {"Namespace", "PodDisruptionBudget", "ServiceMonitor",
 
 
 def helm_template(chart_dir: str, release_name: str, namespace: str,
-                  version: str) -> list:
+                  version: str, kube_version: str) -> list:
     """Render the Helm chart and return parsed YAML documents."""
     cmd = [
         "helm", "template",
         release_name,
         chart_dir,
         "--namespace", namespace,
-        "--kube-version", "1.33.0",
+        "--kube-version", kube_version,
         "--version", version,
+        "--set", "openshift.enabled=true",
     ]
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     docs = list(yaml.safe_load_all(result.stdout))
@@ -242,8 +243,13 @@ def main():
         print(f"ERROR: CSV template not found at {template_path}", file=sys.stderr)
         sys.exit(1)
 
+    with open(template_path) as f:
+        csv_template = yaml.safe_load(f)
+    kube_version = csv_template.get("spec", {}).get("minKubeVersion", "1.33.0")
+
     print("Rendering Helm chart...", file=sys.stderr)
-    docs = helm_template(chart_dir, args.release_name, args.namespace, version)
+    docs = helm_template(chart_dir, args.release_name, args.namespace, version,
+                         kube_version)
     print(f"  got {len(docs)} documents", file=sys.stderr)
 
     deployment = find_by_kind(docs, "Deployment")


### PR DESCRIPTION
Set openshift.enabled=true when running helm template for bundle generation so the embedded deployment spec omits hardcoded runAsUser/fsGroup values that violate OCP's restricted-v2 SCC.

Read minKubeVersion from the CSV template instead of hardcoding --kube-version in the helm template call.

Remove the required CRD entries (Gateway, WasmPlugin) from the CSV template. In OLM, `required` CRDs declare a dependency on another operator that owns those CRDs. Gateway API and Istio WasmPlugin CRDs are provided by the platform or controller (e.g. istioctl, Sail controller) rather than by an OLM-managed operator. The Sail operator itself owns Sail-specific CRDs (Istio, IstioRevision), not the upstream Gateway or Istio extension CRDs. Listing them as required would block installation since no operator can satisfy the dependency.

**Which issue this resolves**

Related to: #21
