### PR TITLE
feat(makefile): unify image registry/org under IMAGE_REGISTRY variable

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -498,7 +498,8 @@ make helm.sync
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `VERSION` | Version tag for builds | `dev` |
-| `CONTROLLER_MANAGER_CONTAINER_IMAGE` | Full operator image reference | `ghcr.io/networking-incubator/coraza-kubernetes-operator:dev` |
+| `IMAGE_REGISTRY` | Registry and org prefix for all images | `ghcr.io/networking-incubator` |
+| `CONTROLLER_MANAGER_CONTAINER_IMAGE` | Full operator image reference | `$(IMAGE_REGISTRY)/coraza-kubernetes-operator:dev` |
 | `KIND_CLUSTER_NAME` | KIND cluster name for tests | `coraza-kubernetes-operator-integration` |
 | `ISTIO_VERSION` | Istio version for deployment | `1.28.2` |
 | `METALLB_VERSION` | MetalLB version for KIND | `0.15.3` |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -499,7 +499,7 @@ make helm.sync
 |----------|-------------|---------|
 | `VERSION` | Version tag for builds | `dev` |
 | `IMAGE_REGISTRY` | Registry and org prefix for all images | `ghcr.io/networking-incubator` |
-| `CONTROLLER_MANAGER_CONTAINER_IMAGE` | Full operator image reference | `$(IMAGE_REGISTRY)/coraza-kubernetes-operator:dev` |
+| `CONTROLLER_MANAGER_CONTAINER_IMAGE` | Full operator image reference | `$(IMAGE_REGISTRY)/coraza-kubernetes-operator:v0.0.0-dev` |
 | `KIND_CLUSTER_NAME` | KIND cluster name for tests | `coraza-kubernetes-operator-integration` |
 | `ISTIO_VERSION` | Istio version for deployment | `1.28.2` |
 | `METALLB_VERSION` | MetalLB version for KIND | `0.15.3` |

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ METALLB_VERSION ?= 0.15.3
 METALLB_POOL_SIZE ?= 128 # Defines the size of MetalLB pool, when being used
 
 VERSION ?= v0.0.0-dev
-CONTROLLER_MANAGER_CONTAINER_IMAGE_BASE ?= ghcr.io/networking-incubator/coraza-kubernetes-operator
+IMAGE_REGISTRY ?= ghcr.io/networking-incubator
+CONTROLLER_MANAGER_CONTAINER_IMAGE_BASE ?= $(IMAGE_REGISTRY)/coraza-kubernetes-operator
 CONTROLLER_MANAGER_CONTAINER_IMAGE_TAG ?= $(VERSION)
 CONTROLLER_MANAGER_CONTAINER_IMAGE ?= ${CONTROLLER_MANAGER_CONTAINER_IMAGE_BASE}:${CONTROLLER_MANAGER_CONTAINER_IMAGE_TAG}
 
@@ -243,11 +244,11 @@ test.conformance:
 # OLM Bundle
 # -------------------------------------------------------------------------------
 
-BUNDLE_IMG_BASE ?= ghcr.io/networking-incubator/coraza-kubernetes-operator-bundle
+BUNDLE_IMG_BASE ?= $(IMAGE_REGISTRY)/coraza-kubernetes-operator-bundle
 BUNDLE_IMG_TAG ?= $(VERSION)
 BUNDLE_IMG ?= $(BUNDLE_IMG_BASE):$(BUNDLE_IMG_TAG)
 
-CATALOG_IMG_BASE ?= ghcr.io/networking-incubator/coraza-kubernetes-operator-catalog
+CATALOG_IMG_BASE ?= $(IMAGE_REGISTRY)/coraza-kubernetes-operator-catalog
 CATALOG_IMG_TAG ?= $(VERSION)
 CATALOG_IMG ?= $(CATALOG_IMG_BASE):$(CATALOG_IMG_TAG)
 OPM_VERSION ?= v1.64.0


### PR DESCRIPTION
Introduce a single IMAGE_REGISTRY variable that holds the registry/org prefix. The three *_BASE image variables now derive from it, so overriding the registry for all images is a single variable:

    make build.image IMAGE_REGISTRY=quay.io/myorg VERSION=v0.3.0-dev

Individual *_BASE overrides still work for per-image control.

Closes #191