### PR TITLE
serialize gateway creation and use existing Istio revision

### DIFF
--- a/hack/ocp_cluster.py
+++ b/hack/ocp_cluster.py
@@ -142,43 +142,6 @@ spec:
     )
 
 
-def create_istio_resources(args, version):
-    """Create the Istio CR for the control plane and wait for readiness."""
-    print(f"--- Creating Istio Control Plane ({version}) ---")
-    run(
-        f"oc create namespace {args.coraza_ns} "
-        f"--dry-run=client -o yaml | oc apply -f -"
-    )
-
-    istio_cr = f"""
-apiVersion: sailoperator.io/v1
-kind: Istio
-metadata: {{namespace: {args.coraza_ns}, name: coraza}}
-spec:
-  namespace: {args.coraza_ns}
-  version: {version}
-  values:
-    pilot:
-      env:
-        PILOT_GATEWAY_API_CONTROLLER_NAME: "istio.io/gateway-controller"
-        PILOT_ENABLE_GATEWAY_API: "true"
-        PILOT_ENABLE_GATEWAY_API_STATUS: "true"
-        PILOT_ENABLE_ALPHA_GATEWAY_API: "false"
-        PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: "true"
-        PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER: "false"
-        PILOT_GATEWAY_API_DEFAULT_GATEWAYCLASS_NAME: "istio"
-        PILOT_MULTI_NETWORK_DISCOVER_GATEWAY_API: "false"
-        ENABLE_GATEWAY_API_MANUAL_DEPLOYMENT: "false"
-        PILOT_ENABLE_GATEWAY_API_CA_CERT_ONLY: "true"
-        PILOT_ENABLE_GATEWAY_API_COPY_LABELS_ANNOTATIONS: "false"
-"""
-    run("oc apply -f -", input_str=istio_cr)
-    run(
-        f"oc wait --for=condition=Ready istio/coraza "
-        f"-n {args.coraza_ns} --timeout={args.timeout}s"
-    )
-
-
 # ---------------------------------------------------------------------------
 # Operator Deployment
 # ---------------------------------------------------------------------------
@@ -255,37 +218,6 @@ def deploy_coraza_operator(args):
         f"oc wait --for=condition=Available "
         f"deployment/{HELM_RELEASE_NAME} "
         f"-n {args.coraza_ns} --timeout={args.timeout}s"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Gateway
-# ---------------------------------------------------------------------------
-
-
-def create_gateway(args, use_lb):
-    """Create the sample Gateway in the test namespace."""
-    print(f"--- Creating Gateway in {args.test_ns} ---")
-    run(
-        f"oc create namespace {args.test_ns} "
-        f"--dry-run=client -o yaml | oc apply -f -"
-    )
-
-    project_root = Path(__file__).parent.parent.absolute()
-    gw_path = project_root / "config" / "samples" / "gateway.yaml"
-
-    if use_lb:
-        run(f"oc apply -f {gw_path} -n {args.test_ns}")
-    else:
-        run(
-            f"oc annotate -f {gw_path} "
-            f"networking.istio.io/service-type=ClusterIP "
-            f"--local -o yaml | oc apply -f - -n {args.test_ns}"
-        )
-
-    run(
-        f"oc wait --for=condition=Programmed gateway/coraza-gateway "
-        f"-n {args.test_ns} --timeout={args.timeout}s"
     )
 
 
@@ -397,13 +329,17 @@ def main():
     args.working_dir = Path(args.working_dir)
 
     if args.action == "setup":
+        # Set GATEWAY_CLASS for OpenShift environment so integration tests
+        # use the correct GatewayClass (openshift-default instead of istio)
+        os.environ["GATEWAY_CLASS"] = "openshift-default"
+
         istio_version, ossm_version = get_versions(args)
         setup_internal_registry(args)
         deploy_gateway_class(args, istio_version, ossm_version)
-        create_istio_resources(args, istio_version)
         deploy_coraza_operator(args)
-        create_gateway(args, use_lb=args.deploy_metallb)
         print("\nCoraza Operator and Istio are ready on OCP!")
+        print("\nTo run integration tests, use:")
+        print("  GATEWAY_CLASS=openshift-default go test -tags=integration ./test/integration/...")
 
     elif args.action == "cleanup":
         cleanup(args)

--- a/test/framework/resources.go
+++ b/test/framework/resources.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -39,6 +40,11 @@ import (
 // CRD builders (Engine, RuleSet) use typed API objects from api/v1alpha1
 // and convert to unstructured for the dynamic client. External resources
 // (Gateway, HTTPRoute) are built as unstructured directly.
+
+// gatewayMu serializes Gateway creation to reduce Istio CA certificate
+// signing contention when many parallel tests create Gateways simultaneously.
+// This prevents conflicts on istio-ca-root-cert ConfigMap updates.
+var gatewayMu sync.Mutex
 
 // -----------------------------------------------------------------------------
 // GVRs
@@ -350,15 +356,29 @@ func (s *Scenario) CreateConfigMap(namespace, name, rules string) {
 	})
 }
 
-// CreateGateway creates a Gateway resource using the default "istio" class and registers cleanup.
+// CreateGateway creates a Gateway resource and registers cleanup.
+// The GatewayClass is determined by the GATEWAY_CLASS environment variable,
+// defaulting to "istio" for Kind/standard Istio clusters.
+// Set GATEWAY_CLASS=openshift-default for OpenShift environments.
 func (s *Scenario) CreateGateway(namespace, name string) {
 	s.T.Helper()
-	s.CreateGatewayWithClass(namespace, name, "istio")
+	gatewayClass := os.Getenv("GATEWAY_CLASS")
+	if gatewayClass == "" {
+		gatewayClass = "istio"
+	}
+	s.CreateGatewayWithClass(namespace, name, gatewayClass)
 }
 
 // CreateGatewayWithClass creates a Gateway resource using the provided GatewayClass and registers cleanup.
 func (s *Scenario) CreateGatewayWithClass(namespace, name, gatewayClassName string) {
 	s.T.Helper()
+
+	// Serialize Gateway creation to avoid overwhelming Istio CA controller.
+	// When many Gateways are created simultaneously, the CA controller races
+	// to update istio-ca-root-cert ConfigMaps, causing conflicts and delays.
+	gatewayMu.Lock()
+	defer gatewayMu.Unlock()
+
 	ctx := s.T.Context()
 
 	// Create ServiceAccount before Gateway to prevent auth race condition.


### PR DESCRIPTION
  - Add gatewayMu mutex to serialize Gateway creation across parallel tests,
    preventing Istio CA controller conflicts on istio-ca-root-cert ConfigMap
    updates that caused 200+ retry errors and test timeouts

  - Remove Istio control plane creation from ocp_cluster.py since OpenShift
    now provides Istio via the openshift-gateway revision

  - Change default GatewayClass from "istio" to "openshift-default" to match
    the available GatewayClass in OpenShift environments