### PR TITLE
Implement TLS on cache server endpoint

### DIFF
--- a/charts/coraza-kubernetes-operator/templates/deployment.yaml
+++ b/charts/coraza-kubernetes-operator/templates/deployment.yaml
@@ -49,8 +49,10 @@ spec:
             - --metrics-bind-address=:8082
             - --metrics-secure=false
             {{- end }}
-            - --envoy-cluster-name={{ printf "outbound|80||%s" (include "coraza-operator.serviceFQDN" .) }}
+            - --envoy-cluster-name={{ printf "outbound|443||%s" (include "coraza-operator.serviceFQDN" .) }}
             - --cache-gc-interval=3s
+            - --ca-validity={{ .Values.tls.caValidity }}
+            - --server-cert-validity={{ .Values.tls.serverCertValidity }}
             {{- if .Values.istio.revision }}
             - --istio-revision={{ .Values.istio.revision }}
             {{- end }}

--- a/charts/coraza-kubernetes-operator/templates/role-ca.yaml
+++ b/charts/coraza-kubernetes-operator/templates/role-ca.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "coraza-operator.fullname" . }}-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "coraza-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update

--- a/charts/coraza-kubernetes-operator/templates/rolebinding-ca.yaml
+++ b/charts/coraza-kubernetes-operator/templates/rolebinding-ca.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "coraza-operator.fullname" . }}-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "coraza-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "coraza-operator.fullname" . }}-ca
+subjects:
+- kind: ServiceAccount
+  name: {{ include "coraza-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/coraza-kubernetes-operator/templates/service.yaml
+++ b/charts/coraza-kubernetes-operator/templates/service.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http-ruleset-cache-server
-      port: 80
+    - name: https-ruleset-cache-server
+      port: 443
       protocol: TCP
       targetPort: 18080
     {{- if .Values.metrics.enabled }}

--- a/charts/coraza-kubernetes-operator/values.yaml
+++ b/charts/coraza-kubernetes-operator/values.yaml
@@ -23,6 +23,15 @@ metrics:
   serviceMonitor:
     enabled: false
 
+tls:
+  # Validity period for the CA certificate (Go duration format).
+  # Must be at least 168h (1 week).
+  caValidity: "43800h"  # 5 years
+
+  # Validity period for the cache server certificate (Go duration format).
+  # Must be at least 24h (1 day).
+  serverCertValidity: "720h"  # 30 days
+
 istio:
   # When empty, the operator does not set an Istio revision label on managed resources.
   revision: ""

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -40,6 +40,7 @@ import (
 
 	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
 	"github.com/networking-incubator/coraza-kubernetes-operator/internal/controller"
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/pki"
 	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
 	// +kubebuilder:scaffold:imports
 )
@@ -86,8 +87,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	rulesetCache := setupCacheServer(mgr, cfg)
-	setupIstioPrerequisites(mgr, cfg, os.Getenv("POD_NAMESPACE"))
+	podNamespace := os.Getenv("POD_NAMESPACE")
+	tlsConfig := setupTLSInfrastructure(mgr, cfg, podNamespace)
+	rulesetCache := setupCacheServer(mgr, cfg, tlsConfig)
+	setupIstioPrerequisites(mgr, cfg, podNamespace)
 
 	if err := controller.SetupControllers(mgr, rulesetCache, cfg.envoyClusterName, cfg.istioRevision); err != nil {
 		setupLog.Error(err, "unable to setup controllers")
@@ -128,6 +131,10 @@ type config struct {
 	envoyClusterName  string
 	istioRevision     string
 	operatorName      string
+	caValidity         time.Duration
+	serverCertValidity time.Duration
+	cacheCertPath      string
+	cacheKeyPath       string
 }
 
 func parseFlags() config {
@@ -153,6 +160,10 @@ func parseFlags() config {
 	flag.StringVar(&cfg.envoyClusterName, "envoy-cluster-name", "", "The Envoy cluster name pointing to the RuleSet cache server (required)")
 	flag.StringVar(&cfg.istioRevision, "istio-revision", "", "The Istio revision label value for managed Istio resources")
 	flag.StringVar(&cfg.operatorName, "operator-name", "", "The operator release name used to derive managed resource names (when unset, Istio prerequisites are skipped)")
+	flag.DurationVar(&cfg.caValidity, "ca-validity", pki.DefaultCAValidity, fmt.Sprintf("Validity period for the CA certificate (default %v, minimum %v)", pki.DefaultCAValidity, pki.MinCAValidity))
+	flag.DurationVar(&cfg.serverCertValidity, "server-cert-validity", pki.DefaultServerCertValidity, fmt.Sprintf("Validity period for server certificates (default %v, minimum %v)", pki.DefaultServerCertValidity, pki.MinServerCertValidity))
+	flag.StringVar(&cfg.cacheCertPath, "cache-cert-path", "", "Path to a user-provided TLS certificate for the cache server (disables automatic certificate management)")
+	flag.StringVar(&cfg.cacheKeyPath, "cache-key-path", "", "Path to a user-provided TLS private key for the cache server (disables automatic certificate management)")
 
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
@@ -223,7 +234,56 @@ func setupWebhookServer(cfg config, tlsOpts []func(*tls.Config)) webhook.Server 
 	return webhook.NewServer(opts)
 }
 
-func setupCacheServer(mgr ctrl.Manager, cfg config) *cache.RuleSetCache {
+func setupTLSInfrastructure(mgr ctrl.Manager, cfg config, podNamespace string) *tls.Config {
+	// User-provided certificate mode
+	if cfg.cacheCertPath != "" && cfg.cacheKeyPath != "" {
+		setupLog.Info("WARNING: Using user-provided certificate for cache server TLS. "+
+			"Automatic certificate management (CA controller and cert renewal) is DISABLED. "+
+			"You are responsible for certificate rotation.",
+			"certPath", cfg.cacheCertPath, "keyPath", cfg.cacheKeyPath,
+		)
+		cert, err := tls.LoadX509KeyPair(cfg.cacheCertPath, cfg.cacheKeyPath)
+		if err != nil {
+			setupLog.Error(err, "failed to load user-provided cache server certificate")
+			os.Exit(1)
+		}
+		return &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS13,
+		}
+	}
+
+	// Automatic CA mode — requires POD_NAMESPACE and operator-name
+	if podNamespace == "" {
+		setupLog.Error(errors.New("missing required config"), "POD_NAMESPACE must be set for automatic TLS certificate management. "+
+			"Alternatively, provide --cache-cert-path and --cache-key-path for manual certificate management.")
+		os.Exit(1)
+	}
+	if cfg.operatorName == "" {
+		setupLog.Error(errors.New("missing required flag"), "--operator-name is required for automatic TLS certificate management. "+
+			"Alternatively, provide --cache-cert-path and --cache-key-path for manual certificate management.")
+		os.Exit(1)
+	}
+
+	caCtrl := controller.NewCAController(mgr.GetClient(), podNamespace, cfg.caValidity, ctrl.Log)
+	if err := mgr.Add(caCtrl); err != nil {
+		setupLog.Error(err, "unable to add CA controller to manager")
+		os.Exit(1)
+	}
+
+	serviceFQDN := fmt.Sprintf("%s.%s.svc.cluster.local", cfg.operatorName, podNamespace)
+	dnsNames := []string{serviceFQDN, cfg.operatorName, "localhost"}
+
+	certMgr := controller.NewCertManager(caCtrl, cfg.serverCertValidity, dnsNames, ctrl.Log)
+	if err := mgr.Add(certMgr); err != nil {
+		setupLog.Error(err, "unable to add certificate manager to manager")
+		os.Exit(1)
+	}
+
+	return certMgr.TLSConfig()
+}
+
+func setupCacheServer(mgr ctrl.Manager, cfg config, tlsConfig *tls.Config) *cache.RuleSetCache {
 	rulesetCache := cache.NewRuleSetCache()
 	gcConfig := &cache.GarbageCollectionConfig{
 		GCInterval: cfg.cacheGCInterval,
@@ -231,6 +291,7 @@ func setupCacheServer(mgr ctrl.Manager, cfg config) *cache.RuleSetCache {
 		MaxSize:    cfg.cacheMaxSize,
 	}
 	cacheServer := cache.NewServer(rulesetCache, fmt.Sprintf(":%d", cfg.cacheServerPort), ctrl.Log, gcConfig)
+	cacheServer.SetTLSConfig(tlsConfig)
 	if err := mgr.Add(cacheServer); err != nil {
 		setupLog.Error(err, "unable to add cache server to manager")
 		os.Exit(1)
@@ -269,6 +330,21 @@ func setupHealthChecks(mgr ctrl.Manager) {
 func validateFlags(cfg config) {
 	if cfg.envoyClusterName == "" {
 		setupLog.Error(errors.New("missing required flag"), "envoy-cluster-name is required")
+		os.Exit(1)
+	}
+
+	if cfg.caValidity < pki.MinCAValidity {
+		setupLog.Error(errors.New("invalid flag value"), fmt.Sprintf("ca-validity must be at least %v, got %v", pki.MinCAValidity, cfg.caValidity))
+		os.Exit(1)
+	}
+
+	if cfg.serverCertValidity < pki.MinServerCertValidity {
+		setupLog.Error(errors.New("invalid flag value"), fmt.Sprintf("server-cert-validity must be at least %v, got %v", pki.MinServerCertValidity, cfg.serverCertValidity))
+		os.Exit(1)
+	}
+
+	if (cfg.cacheCertPath == "") != (cfg.cacheKeyPath == "") {
+		setupLog.Error(errors.New("invalid flag combination"), "--cache-cert-path and --cache-key-path must both be set or both be empty")
 		os.Exit(1)
 	}
 }

--- a/internal/controller/ca_controller.go
+++ b/internal/controller/ca_controller.go
@@ -1,0 +1,227 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/pki"
+)
+
+// CAController manages the Certificate Authority for the operator.
+// It ensures the CA secret exists, is valid, and is renewed before expiration.
+// It polls every 30 seconds so deleted or corrupted secrets are restored quickly.
+type CAController struct {
+	client     client.Client
+	namespace  string
+	caValidity time.Duration
+	logger     logr.Logger
+}
+
+// NewCAController creates a new CA controller instance.
+func NewCAController(client client.Client, namespace string, caValidity time.Duration, logger logr.Logger) *CAController {
+	return &CAController{
+		client:     client,
+		namespace:  namespace,
+		caValidity: caValidity,
+		logger:     logger.WithName("ca-controller"),
+	}
+}
+
+// Start initializes the CA and runs a periodic renewal check until ctx is cancelled.
+func (c *CAController) Start(ctx context.Context) error {
+	c.logger.Info("Starting CA controller", "namespace", c.namespace, "caValidity", c.caValidity)
+
+	if err := c.ensureCA(ctx); err != nil {
+		return fmt.Errorf("failed to ensure CA exists: %w", err)
+	}
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Stopping CA controller")
+			return nil
+		case <-ticker.C:
+			c.logger.V(1).Info("Checking if CA needs renewal")
+			if err := c.ensureCA(ctx); err != nil {
+				c.logger.Error(err, "Failed to ensure CA during renewal check")
+			}
+		}
+	}
+}
+
+// NeedLeaderElection implements the LeaderElectionRunnable interface.
+func (c *CAController) NeedLeaderElection() bool {
+	return true
+}
+
+// ensureCA ensures the CA secret exists and is valid, regenerating if needed.
+func (c *CAController) ensureCA(ctx context.Context) error {
+	secret := &corev1.Secret{}
+	err := c.client.Get(ctx, types.NamespacedName{Name: pki.CASecretName, Namespace: c.namespace}, secret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			c.logger.Info("CA secret not found, generating new CA", "secret", pki.CASecretName)
+			return c.generateAndStoreCA(ctx)
+		}
+		return fmt.Errorf("failed to get CA secret: %w", err)
+	}
+
+	certPEM, hasCert := secret.Data[pki.CASecretCertKey]
+	keyPEM, hasKey := secret.Data[pki.CASecretKeyKey]
+	if !hasCert || !hasKey {
+		c.logger.Info("CA secret incomplete, regenerating", "secret", pki.CASecretName, "hasCert", hasCert, "hasKey", hasKey)
+		return c.generateAndStoreCA(ctx)
+	}
+
+	ca, err := pki.ParseCABundle(certPEM, keyPEM)
+	if err != nil {
+		c.logger.Error(err, "Failed to parse existing CA, regenerating", "secret", pki.CASecretName)
+		return c.generateAndStoreCA(ctx)
+	}
+
+	if ca.IsExpired() || ca.NeedsRenewal() {
+		c.logger.Info("CA needs renewal or has expired", "secret", pki.CASecretName, "notAfter", ca.Certificate.NotAfter)
+		return c.generateAndStoreCA(ctx)
+	}
+
+	c.logger.V(1).Info("CA is valid", "secret", pki.CASecretName, "notAfter", ca.Certificate.NotAfter)
+
+	// Always ensure the credential secret (cert-only) exists, even when the
+	// CA itself is healthy. Covers the case where someone deletes only the
+	// credential secret.
+	if err := c.ensureCredentialSecret(ctx, certPEM); err != nil {
+		return fmt.Errorf("failed to ensure CA credential secret: %w", err)
+	}
+
+	return nil
+}
+
+// generateAndStoreCA generates a new CA and creates or updates the secret.
+func (c *CAController) generateAndStoreCA(ctx context.Context) error {
+	ca, err := pki.GenerateCA(c.caValidity)
+	if err != nil {
+		return fmt.Errorf("failed to generate CA: %w", err)
+	}
+
+	data := map[string][]byte{
+		pki.CASecretCertKey: ca.CertPEM,
+		pki.CASecretKeyKey:  ca.KeyPEM,
+	}
+
+	existing := &corev1.Secret{}
+	err = c.client.Get(ctx, types.NamespacedName{Name: pki.CASecretName, Namespace: c.namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pki.CASecretName,
+				Namespace: c.namespace,
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: data,
+		}
+		if err := c.client.Create(ctx, secret); err != nil {
+			return fmt.Errorf("failed to create CA secret: %w", err)
+		}
+		c.logger.Info("CA secret created", "notAfter", ca.Certificate.NotAfter)
+
+		if err := c.ensureCredentialSecret(ctx, ca.CertPEM); err != nil {
+			return fmt.Errorf("failed to create CA credential secret: %w", err)
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to check for existing CA secret: %w", err)
+	}
+
+	existing.Data = data
+	if err := c.client.Update(ctx, existing); err != nil {
+		return fmt.Errorf("failed to update CA secret: %w", err)
+	}
+	c.logger.Info("CA secret updated", "notAfter", ca.Certificate.NotAfter)
+
+	if err := c.ensureCredentialSecret(ctx, ca.CertPEM); err != nil {
+		return fmt.Errorf("failed to update CA credential secret: %w", err)
+	}
+	return nil
+}
+
+// ensureCredentialSecret creates or updates a cert-only secret (no private key)
+// for Istio DestinationRule credentialName. This prevents the CA private key
+// from being exposed to the Istio control plane.
+func (c *CAController) ensureCredentialSecret(ctx context.Context, caCertPEM []byte) error {
+	credData := map[string][]byte{
+		pki.CASecretCertKey: caCertPEM,
+	}
+
+	existing := &corev1.Secret{}
+	err := c.client.Get(ctx, types.NamespacedName{Name: pki.CACredentialSecretName, Namespace: c.namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pki.CACredentialSecretName,
+				Namespace: c.namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: credData,
+		}
+		if err := c.client.Create(ctx, secret); err != nil {
+			return fmt.Errorf("failed to create CA credential secret: %w", err)
+		}
+		c.logger.Info("CA credential secret created (cert-only)", "secret", pki.CACredentialSecretName)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to check for existing CA credential secret: %w", err)
+	}
+
+	existing.Data = credData
+	if err := c.client.Update(ctx, existing); err != nil {
+		return fmt.Errorf("failed to update CA credential secret: %w", err)
+	}
+	c.logger.Info("CA credential secret updated (cert-only)", "secret", pki.CACredentialSecretName)
+	return nil
+}
+
+// GetCA retrieves the current CA bundle from the secret.
+func (c *CAController) GetCA(ctx context.Context) (*pki.CABundle, error) {
+	secret := &corev1.Secret{}
+	if err := c.client.Get(ctx, types.NamespacedName{Name: pki.CASecretName, Namespace: c.namespace}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get CA secret: %w", err)
+	}
+
+	certPEM, ok := secret.Data[pki.CASecretCertKey]
+	if !ok {
+		return nil, fmt.Errorf("CA secret missing certificate data")
+	}
+	keyPEM, ok := secret.Data[pki.CASecretKeyKey]
+	if !ok {
+		return nil, fmt.Errorf("CA secret missing private key data")
+	}
+
+	return pki.ParseCABundle(certPEM, keyPEM)
+}

--- a/internal/controller/ca_controller_test.go
+++ b/internal/controller/ca_controller_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/pki"
+)
+
+func newTestCAController(t *testing.T, objs ...runtime.Object) (*CAController, *runtime.Scheme) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, obj := range objs {
+		builder = builder.WithRuntimeObjects(obj)
+	}
+	client := builder.Build()
+	return NewCAController(client, "test-namespace", pki.DefaultCAValidity, ctrl.Log.WithName("test")), scheme
+}
+
+func getCASecret(t *testing.T, c *CAController) *corev1.Secret {
+	t.Helper()
+	secret := &corev1.Secret{}
+	require.NoError(t, c.client.Get(context.Background(), types.NamespacedName{
+		Name: pki.CASecretName, Namespace: "test-namespace",
+	}, secret))
+	return secret
+}
+
+func TestCAController_EnsureCA_CreateNew(t *testing.T) {
+	c, _ := newTestCAController(t)
+	require.NoError(t, c.ensureCA(context.Background()))
+
+	secret := getCASecret(t, c)
+	assert.Equal(t, corev1.SecretTypeTLS, secret.Type)
+
+	ca, err := pki.ParseCABundle(secret.Data[pki.CASecretCertKey], secret.Data[pki.CASecretKeyKey])
+	require.NoError(t, err)
+	assert.True(t, ca.Certificate.IsCA)
+	assert.False(t, ca.IsExpired())
+	assert.False(t, ca.NeedsRenewal())
+}
+
+func TestCAController_EnsureCA_ValidExisting(t *testing.T) {
+	ca, err := pki.GenerateCA(pki.DefaultCAValidity)
+	require.NoError(t, err)
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: pki.CASecretName, Namespace: "test-namespace"},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			pki.CASecretCertKey: ca.CertPEM,
+			pki.CASecretKeyKey:  ca.KeyPEM,
+		},
+	}
+	c, _ := newTestCAController(t, existing)
+	require.NoError(t, c.ensureCA(context.Background()))
+
+	// Should not have regenerated — serial number should match.
+	secret := getCASecret(t, c)
+	parsed, err := pki.ParseCABundle(secret.Data[pki.CASecretCertKey], secret.Data[pki.CASecretKeyKey])
+	require.NoError(t, err)
+	assert.Equal(t, ca.Certificate.SerialNumber, parsed.Certificate.SerialNumber, "CA should not have been regenerated")
+}
+
+func TestCAController_EnsureCA_RenewExpiring(t *testing.T) {
+	// Generate a CA that expires in 3 days (below the 5-day renewal threshold).
+	expiringCA, err := pki.GenerateExpiringCA(3 * 24 * time.Hour)
+	require.NoError(t, err)
+	require.True(t, expiringCA.NeedsRenewal(), "test prerequisite: CA expiring in 3 days should need renewal (threshold is 5 days)")
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: pki.CASecretName, Namespace: "test-namespace"},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			pki.CASecretCertKey: expiringCA.CertPEM,
+			pki.CASecretKeyKey:  expiringCA.KeyPEM,
+		},
+	}
+	c, _ := newTestCAController(t, existing)
+	require.NoError(t, c.ensureCA(context.Background()))
+
+	secret := getCASecret(t, c)
+	newCA, err := pki.ParseCABundle(secret.Data[pki.CASecretCertKey], secret.Data[pki.CASecretKeyKey])
+	require.NoError(t, err)
+
+	assert.False(t, newCA.NeedsRenewal(), "renewed CA should not need renewal")
+	assert.NotEqual(t, expiringCA.Certificate.SerialNumber, newCA.Certificate.SerialNumber, "CA should have been regenerated")
+	assert.True(t, newCA.Certificate.NotAfter.After(expiringCA.Certificate.NotAfter), "renewed CA should expire later")
+}
+
+func TestCAController_EnsureCA_InvalidSecret(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret *corev1.Secret
+	}{
+		{
+			name: "missing certificate",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: pki.CASecretName, Namespace: "test-namespace"},
+				Type:       corev1.SecretTypeTLS,
+				Data:       map[string][]byte{pki.CASecretKeyKey: []byte("fake-key")},
+			},
+		},
+		{
+			name: "missing private key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: pki.CASecretName, Namespace: "test-namespace"},
+				Type:       corev1.SecretTypeTLS,
+				Data:       map[string][]byte{pki.CASecretCertKey: []byte("fake-cert")},
+			},
+		},
+		{
+			name: "invalid certificate data",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: pki.CASecretName, Namespace: "test-namespace"},
+				Type:       corev1.SecretTypeTLS,
+				Data: map[string][]byte{
+					pki.CASecretCertKey: []byte("invalid"),
+					pki.CASecretKeyKey:  []byte("invalid"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := newTestCAController(t, tt.secret)
+			require.NoError(t, c.ensureCA(context.Background()), "should regenerate invalid CA, not fail")
+
+			secret := getCASecret(t, c)
+			_, err := pki.ParseCABundle(secret.Data[pki.CASecretCertKey], secret.Data[pki.CASecretKeyKey])
+			require.NoError(t, err, "regenerated CA should be valid")
+		})
+	}
+}
+
+func TestCAController_GetCA(t *testing.T) {
+	ca, err := pki.GenerateCA(pki.DefaultCAValidity)
+	require.NoError(t, err)
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: pki.CASecretName, Namespace: "test-namespace"},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			pki.CASecretCertKey: ca.CertPEM,
+			pki.CASecretKeyKey:  ca.KeyPEM,
+		},
+	}
+	c, _ := newTestCAController(t, existing)
+
+	got, err := c.GetCA(context.Background())
+	require.NoError(t, err)
+	assert.True(t, got.Certificate.IsCA)
+	assert.Equal(t, ca.Certificate.SerialNumber, got.Certificate.SerialNumber)
+}
+
+func TestCAController_GetCA_SecretNotFound(t *testing.T) {
+	c, _ := newTestCAController(t)
+	_, err := c.GetCA(context.Background())
+	require.Error(t, err)
+}
+
+func TestCAController_NeedLeaderElection(t *testing.T) {
+	c, _ := newTestCAController(t)
+	assert.True(t, c.NeedLeaderElection())
+}

--- a/internal/controller/cert_manager.go
+++ b/internal/controller/cert_manager.go
@@ -1,0 +1,207 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/pki"
+)
+
+// CertManager manages server certificates issued by the CA controller.
+// It issues certificates on startup and periodically renews them before
+// expiration. It provides a GetCertificate callback for hot-reload in
+// the TLS server without restart.
+//
+// It also detects CA rotation: if the CA serial number changes between
+// renewal checks, the server certificate is re-issued immediately to
+// prevent Envoy from rejecting the old-CA-signed cert.
+//
+// GetCertificate blocks until the first certificate is available,
+// preventing TLS handshake failures during startup.
+type CertManager struct {
+	caController       *CAController
+	serverCertValidity time.Duration
+	dnsNames           []string
+	logger             logr.Logger
+
+	mu           sync.RWMutex
+	tlsCert      *tls.Certificate
+	caPEM        []byte
+	caSerial     string // serial number of the CA that signed the current server cert
+	ready        chan struct{} // closed when first cert is issued
+	readyOnce    sync.Once
+}
+
+// NewCertManager creates a new server certificate manager.
+func NewCertManager(caController *CAController, serverCertValidity time.Duration, dnsNames []string, logger logr.Logger) *CertManager {
+	return &CertManager{
+		caController:       caController,
+		serverCertValidity: serverCertValidity,
+		dnsNames:           dnsNames,
+		logger:             logger.WithName("cert-manager"),
+		ready:              make(chan struct{}),
+	}
+}
+
+// Start issues the initial server certificate and runs a renewal loop.
+func (m *CertManager) Start(ctx context.Context) error {
+	m.logger.Info("Starting certificate manager", "dnsNames", m.dnsNames, "validity", m.serverCertValidity)
+
+	if err := m.issueCertificate(ctx); err != nil {
+		return fmt.Errorf("failed to issue initial server certificate: %w", err)
+	}
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			m.logger.Info("Stopping certificate manager")
+			return nil
+		case <-ticker.C:
+			m.mu.RLock()
+			cert := m.tlsCert
+			currentCASerial := m.caSerial
+			m.mu.RUnlock()
+
+			if cert == nil {
+				m.logger.Info("No server certificate loaded, issuing new one")
+				if err := m.issueCertificate(ctx); err != nil {
+					m.logger.Error(err, "Failed to issue server certificate")
+				}
+				continue
+			}
+
+			leaf := cert.Leaf
+			if leaf == nil {
+				m.logger.Info("Certificate leaf is nil, re-issuing")
+				if err := m.issueCertificate(ctx); err != nil {
+					m.logger.Error(err, "Failed to re-issue server certificate")
+				}
+				continue
+			}
+
+			// Check if the CA has rotated — if so, re-issue immediately to
+			// prevent Envoy from rejecting a cert signed by the old CA.
+			ca, err := m.caController.GetCA(ctx)
+			if err != nil {
+				m.logger.Error(err, "Failed to get CA for rotation check")
+				continue
+			}
+			if ca.Certificate.SerialNumber.String() != currentCASerial {
+				m.logger.Info("CA has rotated, re-issuing server certificate immediately",
+					"oldCASerial", currentCASerial,
+					"newCASerial", ca.Certificate.SerialNumber.String(),
+				)
+				if err := m.issueCertificate(ctx); err != nil {
+					m.logger.Error(err, "Failed to re-issue server certificate after CA rotation")
+				}
+				continue
+			}
+
+			if time.Until(leaf.NotAfter) <= pki.ServerCertRenewalThreshold {
+				m.logger.Info("Server certificate nearing expiration, renewing",
+					"notAfter", leaf.NotAfter,
+					"remaining", time.Until(leaf.NotAfter),
+					"threshold", pki.ServerCertRenewalThreshold,
+				)
+				if err := m.issueCertificate(ctx); err != nil {
+					m.logger.Error(err, "Failed to renew server certificate")
+				}
+			}
+		}
+	}
+}
+
+// NeedLeaderElection implements the LeaderElectionRunnable interface.
+func (m *CertManager) NeedLeaderElection() bool {
+	return true
+}
+
+// issueCertificate gets the CA and issues a new server certificate.
+func (m *CertManager) issueCertificate(ctx context.Context) error {
+	ca, err := m.caController.GetCA(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get CA: %w", err)
+	}
+
+	serverCert, err := ca.IssueCertificate(m.dnsNames, m.serverCertValidity)
+	if err != nil {
+		return fmt.Errorf("failed to issue server certificate: %w", err)
+	}
+
+	tlsCert, err := tls.X509KeyPair(serverCert.CertPEM, serverCert.KeyPEM)
+	if err != nil {
+		return fmt.Errorf("failed to create TLS keypair: %w", err)
+	}
+	tlsCert.Leaf = serverCert.Certificate
+
+	m.mu.Lock()
+	m.tlsCert = &tlsCert
+	m.caPEM = ca.CertPEM
+	m.caSerial = ca.Certificate.SerialNumber.String()
+	m.mu.Unlock()
+
+	m.readyOnce.Do(func() { close(m.ready) })
+
+	m.logger.Info("Server certificate issued",
+		"dnsNames", m.dnsNames,
+		"notAfter", serverCert.Certificate.NotAfter,
+		"serialNumber", serverCert.Certificate.SerialNumber,
+	)
+	return nil
+}
+
+// GetCertificate returns the current server certificate for TLS handshakes.
+// This is used as the tls.Config.GetCertificate callback.
+// On the first call before a certificate is available, it blocks until
+// the certificate manager has issued the initial certificate (or 30s timeout).
+func (m *CertManager) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	select {
+	case <-m.ready:
+	case <-time.After(30 * time.Second):
+		return nil, fmt.Errorf("timed out waiting for server certificate to become available")
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.tlsCert, nil
+}
+
+// TLSConfig returns a TLS configuration that uses GetCertificate for hot-reload.
+func (m *CertManager) TLSConfig() *tls.Config {
+	return &tls.Config{
+		GetCertificate: m.GetCertificate,
+		MinVersion:     tls.VersionTLS13,
+	}
+}
+
+// GetCAPEM returns the current CA certificate PEM data. This is used for
+// injecting the CA into engine namespaces.
+func (m *CertManager) GetCAPEM() []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.caPEM
+}

--- a/internal/controller/cert_manager_test.go
+++ b/internal/controller/cert_manager_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/pki"
+)
+
+func newTestCertManager(t *testing.T) (*CertManager, *CAController) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	// Generate a CA and store it in a secret
+	ca, err := pki.GenerateCA(pki.DefaultCAValidity)
+	require.NoError(t, err)
+
+	namespace := "test-namespace"
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: pki.CASecretName, Namespace: namespace},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			pki.CASecretCertKey: ca.CertPEM,
+			pki.CASecretKeyKey:  ca.KeyPEM,
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	logger := ctrl.Log.WithName("test")
+	caCtrl := NewCAController(client, namespace, pki.DefaultCAValidity, logger)
+
+	certMgr := NewCertManager(caCtrl, pki.DefaultServerCertValidity, []string{"test.example.com", "localhost"}, logger)
+	return certMgr, caCtrl
+}
+
+func TestCertManager_IssueCertificate(t *testing.T) {
+	certMgr, _ := newTestCertManager(t)
+
+	ctx := context.Background()
+	err := certMgr.issueCertificate(ctx)
+	require.NoError(t, err)
+
+	// GetCertificate should return a valid certificate
+	cert, err := certMgr.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	require.NotNil(t, cert.Leaf)
+
+	// Verify DNS names
+	assert.Contains(t, cert.Leaf.DNSNames, "test.example.com")
+	assert.Contains(t, cert.Leaf.DNSNames, "localhost")
+
+	// Verify not a CA
+	assert.False(t, cert.Leaf.IsCA)
+
+	// Verify CA PEM is available
+	caPEM := certMgr.GetCAPEM()
+	assert.NotEmpty(t, caPEM)
+}
+
+func TestCertManager_GetCertificate_BeforeIssue(t *testing.T) {
+	certMgr, _ := newTestCertManager(t)
+
+	// Before issuing, GetCertificate should block and then time out.
+	// Use a short timeout by calling with a goroutine and checking timing.
+	done := make(chan struct{})
+	var cert *tls.Certificate
+	var err error
+	go func() {
+		cert, err = certMgr.GetCertificate(nil)
+		close(done)
+	}()
+
+	// Should not return within 100ms (it's blocking)
+	select {
+	case <-done:
+		t.Fatal("GetCertificate should block when no cert is available")
+	case <-time.After(100 * time.Millisecond):
+		// expected: still blocking
+	}
+
+	// Issue a certificate to unblock it
+	require.NoError(t, certMgr.issueCertificate(context.Background()))
+
+	select {
+	case <-done:
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetCertificate did not unblock after cert was issued")
+	}
+}
+
+func TestCertManager_TLSConfig(t *testing.T) {
+	certMgr, _ := newTestCertManager(t)
+
+	tlsConfig := certMgr.TLSConfig()
+	require.NotNil(t, tlsConfig)
+	assert.NotNil(t, tlsConfig.GetCertificate, "TLSConfig should have GetCertificate set")
+	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion, "MinVersion should be TLS 1.3")
+}
+
+func TestCertManager_NeedLeaderElection(t *testing.T) {
+	certMgr, _ := newTestCertManager(t)
+	assert.True(t, certMgr.NeedLeaderElection())
+}
+
+func TestCertManager_GetCAPEM_BeforeIssue(t *testing.T) {
+	certMgr, _ := newTestCertManager(t)
+	assert.Nil(t, certMgr.GetCAPEM())
+}

--- a/internal/controller/engine_controller_istio_prerequisites.go
+++ b/internal/controller/engine_controller_istio_prerequisites.go
@@ -30,6 +30,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// CASecretNameForCredential is the name of the cert-only secret used for
+// Istio DestinationRule credentialName. This secret contains only the CA
+// certificate (no private key) to avoid exposing the CA key to the Istio
+// control plane.
+const CASecretNameForCredential = "cko-ca-credential"
+
 // -----------------------------------------------------------------------------
 // Istio Prerequisites
 // -----------------------------------------------------------------------------
@@ -129,9 +135,9 @@ func (p *IstioPrerequisites) buildServiceEntry(name, serviceFQDN string, labels 
 		"hosts": []any{serviceFQDN},
 		"ports": []any{
 			map[string]any{
-				"number":   int64(80),
-				"name":     "http-ruleset-cache-server",
-				"protocol": "HTTP",
+				"number":   int64(443),
+				"name":     "https-ruleset-cache-server",
+				"protocol": "HTTPS",
 			},
 		},
 		"location":   "MESH_INTERNAL",
@@ -149,8 +155,10 @@ func (p *IstioPrerequisites) buildDestinationRule(name, serviceFQDN string, labe
 		"host": serviceFQDN,
 		"trafficPolicy": map[string]any{
 			"tls": map[string]any{
-				"mode": "DISABLE",
+				"mode":           "SIMPLE",
+				"credentialName": CASecretNameForCredential,
 			},
 		},
 	})
 }
+

--- a/internal/controller/engine_controller_istio_prerequisites_test.go
+++ b/internal/controller/engine_controller_istio_prerequisites_test.go
@@ -75,9 +75,9 @@ func TestBuildServiceEntry_Shape(t *testing.T) {
 	ports, _ := spec["ports"].([]any)
 	require.Len(t, ports, 1)
 	port, _ := ports[0].(map[string]any)
-	assert.Equal(t, int64(80), port["number"])
-	assert.Equal(t, "http-ruleset-cache-server", port["name"])
-	assert.Equal(t, "HTTP", port["protocol"])
+	assert.Equal(t, int64(443), port["number"])
+	assert.Equal(t, "https-ruleset-cache-server", port["name"])
+	assert.Equal(t, "HTTPS", port["protocol"])
 }
 
 func TestBuildDestinationRule_Shape(t *testing.T) {
@@ -110,7 +110,8 @@ func TestBuildDestinationRule_Shape(t *testing.T) {
 	require.NotNil(t, tp, "trafficPolicy should be present")
 	tls, _ := tp["tls"].(map[string]any)
 	require.NotNil(t, tls, "tls should be present")
-	assert.Equal(t, "DISABLE", tls["mode"])
+	assert.Equal(t, "SIMPLE", tls["mode"])
+	assert.Equal(t, "cko-ca-credential", tls["credentialName"])
 }
 
 func TestNewIstioObject_IstioRevisionLabel(t *testing.T) {

--- a/internal/pki/ca.go
+++ b/internal/pki/ca.go
@@ -1,0 +1,305 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+const (
+	// RSAKeySize is the size of RSA keys in bits
+	RSAKeySize = 4096
+
+	// DefaultCAValidity is the default validity period for CA certificates
+	DefaultCAValidity = 5 * 365 * 24 * time.Hour // 5 years
+
+	// MinCAValidity is the minimum validity period for CA certificates
+	MinCAValidity = 7 * 24 * time.Hour // 1 week
+
+	// DefaultServerCertValidity is the default validity period for server certificates
+	DefaultServerCertValidity = 30 * 24 * time.Hour // 1 month
+
+	// MinServerCertValidity is the minimum validity period for server certificates
+	MinServerCertValidity = 24 * time.Hour // 1 day
+
+	// CASecretName is the name of the secret storing the CA certificate and key
+	CASecretName = "cko-ca"
+
+	// CASecretCertKey is the key in the secret data for the CA certificate
+	CASecretCertKey = "tls.crt"
+
+	// CASecretKeyKey is the key in the secret data for the CA private key
+	CASecretKeyKey = "tls.key"
+
+	// CACredentialSecretName is the name of the secret containing only the
+	// CA certificate (no private key) for Istio DestinationRule credentialName.
+	CACredentialSecretName = "cko-ca-credential"
+
+	// CARenewalThreshold is the time before expiration when CA should be renewed
+	CARenewalThreshold = 5 * 24 * time.Hour // 5 days
+
+	// ServerCertRenewalThreshold is the time before expiration when server cert should be renewed
+	ServerCertRenewalThreshold = 24 * time.Hour // 1 day
+)
+
+// CABundle contains a Certificate Authority certificate and private key
+type CABundle struct {
+	Certificate *x509.Certificate
+	PrivateKey  *rsa.PrivateKey
+	CertPEM     []byte
+	KeyPEM      []byte
+}
+
+// ServerCertBundle contains a server certificate and private key
+type ServerCertBundle struct {
+	Certificate *x509.Certificate
+	PrivateKey  *rsa.PrivateKey
+	CertPEM     []byte
+	KeyPEM      []byte
+}
+
+// GenerateCA creates a new Certificate Authority with the given validity period
+func GenerateCA(validity time.Duration) (*CABundle, error) {
+	if validity < MinCAValidity {
+		return nil, fmt.Errorf("CA validity must be at least %v, got %v", MinCAValidity, validity)
+	}
+
+	// Generate private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CA private key: %w", err)
+	}
+
+	// Generate serial number
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CA serial number: %w", err)
+	}
+
+	// Create CA certificate template
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Coraza Kubernetes Operator"},
+			CommonName:   "Coraza Kubernetes Operator CA",
+		},
+		NotBefore:             now,
+		NotAfter:              now.Add(validity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+	}
+
+	// Self-sign the certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CA certificate: %w", err)
+	}
+
+	// Parse the DER certificate
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CA certificate: %w", err)
+	}
+
+	// Encode to PEM
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	return &CABundle{
+		Certificate: cert,
+		PrivateKey:  privateKey,
+		CertPEM:     certPEM,
+		KeyPEM:      keyPEM,
+	}, nil
+}
+
+// ParseCABundle parses PEM-encoded CA certificate and private key
+func ParseCABundle(certPEM, keyPEM []byte) (*CABundle, error) {
+	// Parse certificate
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return nil, errors.New("failed to decode CA certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CA certificate: %w", err)
+	}
+
+	if !cert.IsCA {
+		return nil, errors.New("certificate is not a CA certificate")
+	}
+
+	// Parse private key
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, errors.New("failed to decode CA private key PEM")
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CA private key: %w", err)
+	}
+
+	return &CABundle{
+		Certificate: cert,
+		PrivateKey:  key,
+		CertPEM:     certPEM,
+		KeyPEM:      keyPEM,
+	}, nil
+}
+
+// NeedsRenewal checks if the CA certificate needs to be renewed
+func (ca *CABundle) NeedsRenewal() bool {
+	return time.Until(ca.Certificate.NotAfter) <= CARenewalThreshold
+}
+
+// IsExpired checks if the CA certificate has expired
+func (ca *CABundle) IsExpired() bool {
+	return time.Now().After(ca.Certificate.NotAfter)
+}
+
+// IssueCertificate issues a server certificate signed by this CA
+func (ca *CABundle) IssueCertificate(dnsNames []string, validity time.Duration) (*ServerCertBundle, error) {
+	if validity < MinServerCertValidity {
+		return nil, fmt.Errorf("server certificate validity must be at least %v, got %v", MinServerCertValidity, validity)
+	}
+
+	if len(dnsNames) == 0 {
+		return nil, errors.New("at least one DNS name must be provided")
+	}
+
+	// Generate private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate server private key: %w", err)
+	}
+
+	// Generate serial number
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate server certificate serial number: %w", err)
+	}
+
+	// Create server certificate template
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Coraza Kubernetes Operator"},
+			CommonName:   dnsNames[0],
+		},
+		DNSNames:              dnsNames,
+		NotBefore:             now,
+		NotAfter:              now.Add(validity),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	// Sign the certificate with the CA
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca.Certificate, &privateKey.PublicKey, ca.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create server certificate: %w", err)
+	}
+
+	// Parse the DER certificate
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse server certificate: %w", err)
+	}
+
+	// Encode to PEM
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	return &ServerCertBundle{
+		Certificate: cert,
+		PrivateKey:  privateKey,
+		CertPEM:     certPEM,
+		KeyPEM:      keyPEM,
+	}, nil
+}
+
+// ParseServerCertBundle parses PEM-encoded server certificate and private key
+func ParseServerCertBundle(certPEM, keyPEM []byte) (*ServerCertBundle, error) {
+	// Parse certificate
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return nil, errors.New("failed to decode server certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse server certificate: %w", err)
+	}
+
+	// Parse private key
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, errors.New("failed to decode server private key PEM")
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse server private key: %w", err)
+	}
+
+	return &ServerCertBundle{
+		Certificate: cert,
+		PrivateKey:  key,
+		CertPEM:     certPEM,
+		KeyPEM:      keyPEM,
+	}, nil
+}
+
+// NeedsRenewal checks if the server certificate needs to be renewed
+func (s *ServerCertBundle) NeedsRenewal() bool {
+	return time.Until(s.Certificate.NotAfter) <= ServerCertRenewalThreshold
+}
+
+// IsExpired checks if the server certificate has expired
+func (s *ServerCertBundle) IsExpired() bool {
+	return time.Now().After(s.Certificate.NotAfter)
+}

--- a/internal/pki/ca_test.go
+++ b/internal/pki/ca_test.go
@@ -1,0 +1,522 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto/x509"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerateCA(t *testing.T) {
+	tests := []struct {
+		name        string
+		validity    time.Duration
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "valid CA with default validity",
+			validity: DefaultCAValidity,
+			wantErr:  false,
+		},
+		{
+			name:     "valid CA with minimum validity",
+			validity: MinCAValidity,
+			wantErr:  false,
+		},
+		{
+			name:        "invalid CA with too short validity",
+			validity:    MinCAValidity - time.Hour,
+			wantErr:     true,
+			errContains: "CA validity must be at least",
+		},
+		{
+			name:     "valid CA with custom validity",
+			validity: 365 * 24 * time.Hour,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ca, err := GenerateCA(tt.validity)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateCA() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if tt.errContains != "" && err != nil {
+					if !strings.Contains(err.Error(), tt.errContains) {
+						t.Errorf("GenerateCA() error = %v, should contain %v", err, tt.errContains)
+					}
+				}
+				return
+			}
+
+			// Verify CA properties
+			if ca == nil {
+				t.Fatal("GenerateCA() returned nil CA bundle")
+			}
+			if ca.Certificate == nil {
+				t.Fatal("CA certificate is nil")
+			}
+			if ca.PrivateKey == nil {
+				t.Fatal("CA private key is nil")
+			}
+			if len(ca.CertPEM) == 0 {
+				t.Fatal("CA certificate PEM is empty")
+			}
+			if len(ca.KeyPEM) == 0 {
+				t.Fatal("CA private key PEM is empty")
+			}
+
+			// Verify certificate is a CA
+			if !ca.Certificate.IsCA {
+				t.Error("Certificate IsCA should be true")
+			}
+
+			// Verify key usage
+			if ca.Certificate.KeyUsage&x509.KeyUsageCertSign == 0 {
+				t.Error("Certificate should have KeyUsageCertSign")
+			}
+			if ca.Certificate.KeyUsage&x509.KeyUsageCRLSign == 0 {
+				t.Error("Certificate should have KeyUsageCRLSign")
+			}
+
+			// Verify validity period
+			actualValidity := ca.Certificate.NotAfter.Sub(ca.Certificate.NotBefore)
+			// Allow for small time differences due to generation time
+			if actualValidity < tt.validity-time.Minute || actualValidity > tt.validity+time.Minute {
+				t.Errorf("CA validity = %v, want %v", actualValidity, tt.validity)
+			}
+
+			// Verify subject
+			if ca.Certificate.Subject.CommonName != "Coraza Kubernetes Operator CA" {
+				t.Errorf("CA CommonName = %v, want 'Coraza Kubernetes Operator CA'", ca.Certificate.Subject.CommonName)
+			}
+		})
+	}
+}
+
+func TestParseCABundle(t *testing.T) {
+	// Generate a valid CA first
+	originalCA, err := GenerateCA(DefaultCAValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate CA for testing: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		certPEM     []byte
+		keyPEM      []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "valid CA bundle",
+			certPEM: originalCA.CertPEM,
+			keyPEM:  originalCA.KeyPEM,
+			wantErr: false,
+		},
+		{
+			name:        "invalid certificate PEM",
+			certPEM:     []byte("invalid"),
+			keyPEM:      originalCA.KeyPEM,
+			wantErr:     true,
+			errContains: "failed to decode CA certificate PEM",
+		},
+		{
+			name:        "invalid private key PEM",
+			certPEM:     originalCA.CertPEM,
+			keyPEM:      []byte("invalid"),
+			wantErr:     true,
+			errContains: "failed to decode CA private key PEM",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ca, err := ParseCABundle(tt.certPEM, tt.keyPEM)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseCABundle() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if tt.errContains != "" && err != nil {
+					if !strings.Contains(err.Error(), tt.errContains) {
+						t.Errorf("ParseCABundle() error = %v, should contain %v", err, tt.errContains)
+					}
+				}
+				return
+			}
+
+			if ca == nil {
+				t.Fatal("ParseCABundle() returned nil")
+			}
+			if ca.Certificate == nil {
+				t.Error("Certificate is nil")
+			}
+			if ca.PrivateKey == nil {
+				t.Error("PrivateKey is nil")
+			}
+		})
+	}
+}
+
+func TestCABundle_NeedsRenewal(t *testing.T) {
+	tests := []struct {
+		name         string
+		timeToExpiry time.Duration
+		wantRenewal  bool
+	}{
+		{
+			name:         "CA expiring soon needs renewal",
+			timeToExpiry: CARenewalThreshold - time.Hour,
+			wantRenewal:  true,
+		},
+		{
+			name:         "CA not expiring soon does not need renewal",
+			timeToExpiry: CARenewalThreshold + 24*time.Hour,
+			wantRenewal:  false,
+		},
+		{
+			name:         "CA at exact threshold needs renewal",
+			timeToExpiry: CARenewalThreshold,
+			wantRenewal:  true, // At boundary, renew to be safe
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ca, err := GenerateCA(DefaultCAValidity)
+			if err != nil {
+				t.Fatalf("Failed to generate CA: %v", err)
+			}
+
+			// Manually adjust NotAfter to simulate expiring certificate
+			ca.Certificate.NotAfter = time.Now().Add(tt.timeToExpiry)
+
+			if got := ca.NeedsRenewal(); got != tt.wantRenewal {
+				t.Errorf("CABundle.NeedsRenewal() = %v, want %v", got, tt.wantRenewal)
+			}
+		})
+	}
+}
+
+func TestCABundle_IsExpired(t *testing.T) {
+	// Create an expired CA (backdated)
+	ca, err := GenerateCA(MinCAValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate CA: %v", err)
+	}
+
+	// Manually set NotAfter to the past
+	ca.Certificate.NotAfter = time.Now().Add(-time.Hour)
+
+	if !ca.IsExpired() {
+		t.Error("CABundle.IsExpired() should return true for expired certificate")
+	}
+
+	// Create a non-expired CA
+	ca2, err := GenerateCA(DefaultCAValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate CA: %v", err)
+	}
+
+	if ca2.IsExpired() {
+		t.Error("CABundle.IsExpired() should return false for valid certificate")
+	}
+}
+
+func TestCABundle_IssueCertificate(t *testing.T) {
+	ca, err := GenerateCA(DefaultCAValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate CA: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		dnsNames    []string
+		validity    time.Duration
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "valid server certificate",
+			dnsNames: []string{"test.example.com"},
+			validity: DefaultServerCertValidity,
+			wantErr:  false,
+		},
+		{
+			name:     "valid server certificate with multiple SANs",
+			dnsNames: []string{"test.example.com", "test.internal", "localhost"},
+			validity: DefaultServerCertValidity,
+			wantErr:  false,
+		},
+		{
+			name:        "invalid - no DNS names",
+			dnsNames:    []string{},
+			validity:    DefaultServerCertValidity,
+			wantErr:     true,
+			errContains: "at least one DNS name must be provided",
+		},
+		{
+			name:        "invalid - validity too short",
+			dnsNames:    []string{"test.example.com"},
+			validity:    MinServerCertValidity - time.Hour,
+			wantErr:     true,
+			errContains: "server certificate validity must be at least",
+		},
+		{
+			name:     "valid - minimum validity",
+			dnsNames: []string{"test.example.com"},
+			validity: MinServerCertValidity,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert, err := ca.IssueCertificate(tt.dnsNames, tt.validity)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IssueCertificate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if tt.errContains != "" && err != nil {
+					if !strings.Contains(err.Error(), tt.errContains) {
+						t.Errorf("IssueCertificate() error = %v, should contain %v", err, tt.errContains)
+					}
+				}
+				return
+			}
+
+			// Verify certificate properties
+			if cert == nil {
+				t.Fatal("IssueCertificate() returned nil")
+			}
+			if cert.Certificate == nil {
+				t.Fatal("Certificate is nil")
+			}
+			if cert.PrivateKey == nil {
+				t.Fatal("PrivateKey is nil")
+			}
+			if len(cert.CertPEM) == 0 {
+				t.Fatal("Certificate PEM is empty")
+			}
+			if len(cert.KeyPEM) == 0 {
+				t.Fatal("Private key PEM is empty")
+			}
+
+			// Verify certificate is NOT a CA
+			if cert.Certificate.IsCA {
+				t.Error("Server certificate should not be a CA")
+			}
+
+			// Verify DNS names
+			if len(cert.Certificate.DNSNames) != len(tt.dnsNames) {
+				t.Errorf("DNS names count = %v, want %v", len(cert.Certificate.DNSNames), len(tt.dnsNames))
+			}
+			for i, name := range tt.dnsNames {
+				if cert.Certificate.DNSNames[i] != name {
+					t.Errorf("DNS name[%d] = %v, want %v", i, cert.Certificate.DNSNames[i], name)
+				}
+			}
+
+			// Verify key usage
+			if cert.Certificate.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
+				t.Error("Certificate should have KeyUsageDigitalSignature")
+			}
+			// KeyUsageKeyEncipherment is intentionally omitted — TLS 1.3
+			// uses only ECDHE key exchange, so KeyEncipherment is not needed.
+
+			// Verify extended key usage
+			hasServerAuth := false
+			for _, eku := range cert.Certificate.ExtKeyUsage {
+				if eku == x509.ExtKeyUsageServerAuth {
+					hasServerAuth = true
+					break
+				}
+			}
+			if !hasServerAuth {
+				t.Error("Certificate should have ExtKeyUsageServerAuth")
+			}
+
+			// Verify validity period
+			actualValidity := cert.Certificate.NotAfter.Sub(cert.Certificate.NotBefore)
+			// Allow for small time differences
+			if actualValidity < tt.validity-time.Minute || actualValidity > tt.validity+time.Minute {
+				t.Errorf("Certificate validity = %v, want %v", actualValidity, tt.validity)
+			}
+
+			// Verify certificate is signed by CA
+			roots := x509.NewCertPool()
+			roots.AddCert(ca.Certificate)
+			opts := x509.VerifyOptions{
+				Roots:     roots,
+				DNSName:   tt.dnsNames[0],
+				KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			}
+			if _, err := cert.Certificate.Verify(opts); err != nil {
+				t.Errorf("Certificate verification failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseServerCertBundle(t *testing.T) {
+	// Generate a valid CA and server cert
+	ca, err := GenerateCA(DefaultCAValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate CA: %v", err)
+	}
+
+	originalCert, err := ca.IssueCertificate([]string{"test.example.com"}, DefaultServerCertValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate server certificate: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		certPEM     []byte
+		keyPEM      []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "valid server certificate bundle",
+			certPEM: originalCert.CertPEM,
+			keyPEM:  originalCert.KeyPEM,
+			wantErr: false,
+		},
+		{
+			name:        "invalid certificate PEM",
+			certPEM:     []byte("invalid"),
+			keyPEM:      originalCert.KeyPEM,
+			wantErr:     true,
+			errContains: "failed to decode server certificate PEM",
+		},
+		{
+			name:        "invalid private key PEM",
+			certPEM:     originalCert.CertPEM,
+			keyPEM:      []byte("invalid"),
+			wantErr:     true,
+			errContains: "failed to decode server private key PEM",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert, err := ParseServerCertBundle(tt.certPEM, tt.keyPEM)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseServerCertBundle() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if tt.errContains != "" && err != nil {
+					if !strings.Contains(err.Error(), tt.errContains) {
+						t.Errorf("ParseServerCertBundle() error = %v, should contain %v", err, tt.errContains)
+					}
+				}
+				return
+			}
+
+			if cert == nil {
+				t.Fatal("ParseServerCertBundle() returned nil")
+			}
+			if cert.Certificate == nil {
+				t.Error("Certificate is nil")
+			}
+			if cert.PrivateKey == nil {
+				t.Error("PrivateKey is nil")
+			}
+		})
+	}
+}
+
+func TestServerCertBundle_NeedsRenewal(t *testing.T) {
+	ca, err := GenerateCA(DefaultCAValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate CA: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		timeToExpiry time.Duration
+		wantRenewal  bool
+	}{
+		{
+			name:         "certificate expiring soon needs renewal",
+			timeToExpiry: ServerCertRenewalThreshold - time.Hour,
+			wantRenewal:  true,
+		},
+		{
+			name:         "certificate not expiring soon does not need renewal",
+			timeToExpiry: ServerCertRenewalThreshold + 24*time.Hour,
+			wantRenewal:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert, err := ca.IssueCertificate([]string{"test.example.com"}, DefaultServerCertValidity)
+			if err != nil {
+				t.Fatalf("Failed to generate server certificate: %v", err)
+			}
+
+			// Manually adjust NotAfter to simulate expiring certificate
+			cert.Certificate.NotAfter = time.Now().Add(tt.timeToExpiry)
+
+			if got := cert.NeedsRenewal(); got != tt.wantRenewal {
+				t.Errorf("ServerCertBundle.NeedsRenewal() = %v, want %v", got, tt.wantRenewal)
+			}
+		})
+	}
+}
+
+func TestServerCertBundle_IsExpired(t *testing.T) {
+	ca, err := GenerateCA(DefaultCAValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate CA: %v", err)
+	}
+
+	// Create an expired certificate
+	cert, err := ca.IssueCertificate([]string{"test.example.com"}, MinServerCertValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate server certificate: %v", err)
+	}
+
+	// Manually set NotAfter to the past
+	cert.Certificate.NotAfter = time.Now().Add(-time.Hour)
+
+	if !cert.IsExpired() {
+		t.Error("ServerCertBundle.IsExpired() should return true for expired certificate")
+	}
+
+	// Create a non-expired certificate
+	cert2, err := ca.IssueCertificate([]string{"test.example.com"}, DefaultServerCertValidity)
+	if err != nil {
+		t.Fatalf("Failed to generate server certificate: %v", err)
+	}
+
+	if cert2.IsExpired() {
+		t.Error("ServerCertBundle.IsExpired() should return false for valid certificate")
+	}
+}
+

--- a/internal/pki/ca_testing.go
+++ b/internal/pki/ca_testing.go
@@ -1,0 +1,80 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// GenerateExpiringCA creates a CA certificate that expires after the given
+// remaining duration from now. This bypasses the MinCAValidity check and is
+// intended for testing renewal logic. The certificate is backdated so that
+// NotBefore is in the past.
+func GenerateExpiringCA(remaining time.Duration) (*CABundle, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CA private key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CA serial number: %w", err)
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Coraza Kubernetes Operator"},
+			CommonName:   "Coraza Kubernetes Operator CA",
+		},
+		NotBefore:             now.Add(-365 * 24 * time.Hour), // backdated 1 year
+		NotAfter:              now.Add(remaining),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CA certificate: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CA certificate: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+
+	return &CABundle{
+		Certificate: cert,
+		PrivateKey:  privateKey,
+		CertPEM:     certPEM,
+		KeyPEM:      keyPEM,
+	}, nil
+}

--- a/internal/rulesets/cache/server.go
+++ b/internal/rulesets/cache/server.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -70,10 +71,11 @@ type LatestResponse struct {
 
 // ruleSetCacheServer provides HTTP endpoints for accessing cached rulesets
 type ruleSetCacheServer struct {
-	cache  *RuleSetCache
-	srv    *http.Server
-	logger logr.Logger
-	gc     GarbageCollectionConfig
+	cache     *RuleSetCache
+	srv       *http.Server
+	logger    logr.Logger
+	gc        GarbageCollectionConfig
+	tlsConfig *tls.Config
 }
 
 // NewServer creates a new RuleSetCacheServer instance.
@@ -102,14 +104,21 @@ func NewServer(cache *RuleSetCache, addr string, logger logr.Logger, gc *Garbage
 	return s
 }
 
+// SetTLSConfig configures the server to use TLS with the given configuration.
+// Must be called before Start.
+func (s *ruleSetCacheServer) SetTLSConfig(tlsConfig *tls.Config) {
+	s.tlsConfig = tlsConfig
+	s.srv.TLSConfig = tlsConfig
+}
+
 // Start the cache server.
 func (s *ruleSetCacheServer) Start(ctx context.Context) error {
 	go s.rungc(ctx)
 
 	errChan := make(chan error, 1)
 	go func() {
-		s.logger.Info("Starting ruleset cache server", "addr", s.srv.Addr)
-		if err := s.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		s.logger.Info("Starting ruleset cache server with TLS", "addr", s.srv.Addr)
+		if err := s.srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 			errChan <- err
 		}
 	}()

--- a/internal/rulesets/cache/server_test.go
+++ b/internal/rulesets/cache/server_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"maps"
 	"net/http"
@@ -28,8 +29,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/pki"
 	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
 )
+
+// testTLSConfig returns a TLS config for testing with a self-signed cert.
+func testTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+	ca, err := pki.GenerateCA(pki.DefaultCAValidity)
+	require.NoError(t, err)
+	cert, err := ca.IssueCertificate([]string{"localhost"}, pki.DefaultServerCertValidity)
+	require.NoError(t, err)
+	tlsCert, err := tls.X509KeyPair(cert.CertPEM, cert.KeyPEM)
+	require.NoError(t, err)
+	return &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+		MinVersion:   tls.VersionTLS13,
+	}
+}
 
 const testServerAddr = ":38080"
 
@@ -53,6 +70,7 @@ func TestServer_StartAndStop(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
 	server := NewServer(cache, testServerAddr, logger, nil)
+	server.SetTLSConfig(testTLSConfig(t))
 
 	t.Log("Starting server in background goroutine")
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/rulesets/cache/server_tls_test.go
+++ b/internal/rulesets/cache/server_tls_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/pki"
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
+)
+
+func TestServer_TLS_StartAndServe(t *testing.T) {
+	ca, err := pki.GenerateCA(pki.DefaultCAValidity)
+	require.NoError(t, err)
+
+	serverCert, err := ca.IssueCertificate([]string{"localhost"}, pki.DefaultServerCertValidity)
+	require.NoError(t, err)
+
+	tlsCert, err := tls.X509KeyPair(serverCert.CertPEM, serverCert.KeyPEM)
+	require.NoError(t, err)
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	cache := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	server := NewServer(cache, ":0", logger, nil)
+	server.SetTLSConfig(tlsConfig)
+
+	// Use a fixed port for this test
+	port := 48443
+	server.srv.Addr = fmt.Sprintf(":%d", port)
+
+	cache.Put("tls-test", "SecRule REQUEST_URI \"@contains /admin\" \"id:1,deny\"", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- server.Start(ctx)
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	// Create a client that trusts the CA
+	certPool := x509.NewCertPool()
+	certPool.AddCert(ca.Certificate)
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    certPool,
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+
+	t.Run("HTTPS request succeeds with trusted CA", func(t *testing.T) {
+		resp, err := httpClient.Get(fmt.Sprintf("https://localhost:%d/rules/tls-test", port))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		var entry RuleSetEntry
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&entry))
+		assert.NotEmpty(t, entry.UUID)
+		assert.Contains(t, entry.Rules, "@contains /admin")
+	})
+
+	t.Run("HTTPS latest endpoint works", func(t *testing.T) {
+		resp, err := httpClient.Get(fmt.Sprintf("https://localhost:%d/rules/tls-test/latest", port))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var latest LatestResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&latest))
+		assert.NotEmpty(t, latest.UUID)
+	})
+
+	t.Run("HTTP request to HTTPS server fails", func(t *testing.T) {
+		plainClient := &http.Client{Timeout: 2 * time.Second}
+		resp, err := plainClient.Get(fmt.Sprintf("http://localhost:%d/rules/tls-test", port))
+		if err == nil {
+			defer resp.Body.Close()
+			// Go's TLS server returns 400 Bad Request for plain HTTP
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		}
+		// Either an error or a 400 is acceptable — both mean plain HTTP is rejected
+	})
+
+	t.Run("HTTPS request with untrusted CA fails", func(t *testing.T) {
+		untrustedClient := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+				},
+			},
+			Timeout: 2 * time.Second,
+		}
+		_, err := untrustedClient.Get(fmt.Sprintf("https://localhost:%d/rules/tls-test", port))
+		assert.Error(t, err)
+	})
+
+	t.Run("not found returns 404 over TLS", func(t *testing.T) {
+		resp, err := httpClient.Get(fmt.Sprintf("https://localhost:%d/rules/nonexistent", port))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	cancel()
+	select {
+	case err := <-errChan:
+		if err != nil && err != http.ErrServerClosed {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Server did not shut down in time")
+	}
+}
+
+func TestServer_TLS_CertificateHotReload(t *testing.T) {
+	ca, err := pki.GenerateCA(pki.DefaultCAValidity)
+	require.NoError(t, err)
+
+	// Issue first certificate
+	serverCert1, err := ca.IssueCertificate([]string{"localhost"}, pki.DefaultServerCertValidity)
+	require.NoError(t, err)
+
+	tlsCert1, err := tls.X509KeyPair(serverCert1.CertPEM, serverCert1.KeyPEM)
+	require.NoError(t, err)
+	tlsCert1.Leaf = serverCert1.Certificate
+
+	// Use GetCertificate for hot reload with atomic pointer for thread safety
+	var currentCert atomic.Pointer[tls.Certificate]
+	currentCert.Store(&tlsCert1)
+
+	tlsConfig := &tls.Config{
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return currentCert.Load(), nil
+		},
+		MinVersion: tls.VersionTLS13,
+	}
+
+	cache := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	server := NewServer(cache, ":0", logger, nil)
+	server.SetTLSConfig(tlsConfig)
+
+	port := 48444
+	server.srv.Addr = fmt.Sprintf(":%d", port)
+	cache.Put("reload-test", "test rules", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go server.Start(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	certPool := x509.NewCertPool()
+	certPool.AddCert(ca.Certificate)
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    certPool,
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+
+	// First request should use cert 1
+	resp, err := httpClient.Get(fmt.Sprintf("https://localhost:%d/rules/reload-test", port))
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, string(body), "test rules")
+
+	// Issue a new certificate (simulating hot reload)
+	serverCert2, err := ca.IssueCertificate([]string{"localhost"}, pki.DefaultServerCertValidity)
+	require.NoError(t, err)
+
+	tlsCert2, err := tls.X509KeyPair(serverCert2.CertPEM, serverCert2.KeyPEM)
+	require.NoError(t, err)
+	tlsCert2.Leaf = serverCert2.Certificate
+
+	// Update the current cert (hot reload) — atomic for thread safety
+	currentCert.Store(&tlsCert2)
+
+	// Force new connection by creating a fresh transport
+	httpClient2 := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    certPool,
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+
+	// Second request should use cert 2 (via GetCertificate)
+	resp2, err := httpClient2.Get(fmt.Sprintf("https://localhost:%d/rules/reload-test", port))
+	require.NoError(t, err)
+	resp2.Body.Close()
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	// Verify different serial numbers
+	assert.NotEqual(t, serverCert1.Certificate.SerialNumber, serverCert2.Certificate.SerialNumber,
+		"second certificate should have different serial number")
+
+	cancel()
+}


### PR DESCRIPTION
**Describe the pull request**

This PR implements TLS on cache server, with a self-contained CA authority. It uses also DestinationRule as a way to publish the CA of the cache server to WASMPlugins

**Which issue this resolves**

Resolves #230

**Additional context**

Self review is pending!
