### PR TITLE
test: add adversarial tests exposing nil-pointer crash and stderr bug

### DIFF
--- a/api/v1alpha1/types_adversarial_test.go
+++ b/api/v1alpha1/types_adversarial_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// fullyPopulatedEngine returns an Engine with every field set (including nested
+// pointers, slices, and maps) to exercise DeepCopy.
+func fullyPopulatedEngine() *Engine {
+	mode := IstioIntegrationModeGateway
+	poll := int32(42)
+	fp := FailurePolicyAllow
+	now := metav1.NewTime(time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC))
+	uid := types.UID("test-uid")
+	gen := int64(7)
+	delGrace := int64(30)
+
+	return &Engine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "Engine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       "engine-full",
+			Namespace:                  "test-ns",
+			UID:                        uid,
+			ResourceVersion:            "rv-99",
+			Generation:                 gen,
+			CreationTimestamp:          now,
+			DeletionTimestamp:          &now,
+			DeletionGracePeriodSeconds: &delGrace,
+			Labels: map[string]string{
+				"app": "coraza", "tier": "waf",
+			},
+			Annotations: map[string]string{
+				"anno": "val",
+			},
+			Finalizers: []string{"waf.k8s.coraza.io/finalizer"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       "owner",
+					UID:        "owner-uid",
+					Controller: func(b bool) *bool { return &b }(true),
+				},
+			},
+		},
+		Spec: EngineSpec{
+			RuleSet: RuleSetReference{Name: "my-ruleset"},
+			Driver: &DriverConfig{
+				Istio: &IstioDriverConfig{
+					Wasm: &IstioWasmConfig{
+						Mode: &mode,
+						WorkloadSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"gateway.networking.k8s.io/gateway-name": "gw",
+							},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "env",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"prod"},
+								},
+							},
+						},
+						Image: "oci://example.com/wasm:v1",
+						RuleSetCacheServer: &RuleSetCacheServerConfig{
+							PollIntervalSeconds: &poll,
+						},
+					},
+				},
+			},
+			FailurePolicy: &fp,
+		},
+		Status: &EngineStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 3,
+					LastTransitionTime: now,
+					Reason:             "RulesApplied",
+					Message:            "ok",
+				},
+				{
+					Type:               "Progressing",
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 3,
+					LastTransitionTime: now,
+					Reason:             "Idle",
+					Message:            "",
+				},
+			},
+			Gateways: []GatewayReference{
+				{Name: "gw-a"},
+				{Name: "gw-b"},
+			},
+		},
+	}
+}
+
+func fullyPopulatedRuleSet() *RuleSet {
+	now := metav1.NewTime(time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC))
+	rd := "my-secret"
+	return &RuleSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "RuleSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "ruleset-full",
+			Namespace:       "test-ns",
+			UID:             types.UID("rs-uid"),
+			ResourceVersion: "rs-rv",
+			Labels:          map[string]string{"k": "v"},
+			Annotations:     map[string]string{"a": "b"},
+		},
+		Spec: RuleSetSpec{
+			Rules: []RuleSourceReference{
+				{Name: "cm-one"},
+				{Name: "cm-two"},
+			},
+			RuleData: &rd,
+		},
+		Status: &RuleSetStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+					Reason:             "Compiled",
+					Message:            "rules cached",
+				},
+			},
+		},
+	}
+}
+
+func mutateEngineDeeply(e *Engine) {
+	e.Name = "mutated"
+	e.Labels["app"] = "changed"
+	e.Labels["new"] = "x"
+	e.Annotations["anno"] = "mut"
+	e.Finalizers = append(e.Finalizers, "extra")
+	e.Spec.RuleSet.Name = "other-rs"
+	fp := FailurePolicyFail
+	e.Spec.FailurePolicy = &fp
+	e.Spec.Driver.Istio.Wasm.Image = "oci://mutated"
+	e.Spec.Driver.Istio.Wasm.WorkloadSelector.MatchLabels["gateway.networking.k8s.io/gateway-name"] = "other-gw"
+	e.Spec.Driver.Istio.Wasm.WorkloadSelector.MatchExpressions[0].Values = []string{"dev"}
+	e.Spec.Driver.Istio.Wasm.RuleSetCacheServer.PollIntervalSeconds = new(int32)
+	*e.Spec.Driver.Istio.Wasm.RuleSetCacheServer.PollIntervalSeconds = 1
+	e.Status.Conditions[0].Type = "Mutated"
+	e.Status.Gateways[0].Name = "mut-gw"
+}
+
+func mutateRuleSetDeeply(r *RuleSet) {
+	r.Spec.Rules[0].Name = "changed-cm"
+	s := "other-secret"
+	r.Spec.RuleData = &s
+	r.Status.Conditions[0].Reason = "Other"
+}
+
+func TestTypesAdversarial_DeepCopyEngine_AllFieldsIndependent(t *testing.T) {
+	t.Parallel()
+	orig := fullyPopulatedEngine()
+	snapshot := orig.DeepCopy()
+	require.NotNil(t, snapshot)
+
+	cpy := orig.DeepCopy()
+	require.NotNil(t, cpy)
+	mutateEngineDeeply(orig)
+
+	if reflect.DeepEqual(cpy, orig) {
+		t.Fatal("expected copy to differ from mutated original")
+	}
+	if !reflect.DeepEqual(cpy, snapshot) {
+		t.Fatalf("DeepCopy not independent of mutations:\n%+v\nvs snapshot:\n%+v", cpy, snapshot)
+	}
+}
+
+func TestTypesAdversarial_DeepCopyRuleSet_AllFieldsIndependent(t *testing.T) {
+	t.Parallel()
+	orig := fullyPopulatedRuleSet()
+	snapshot := orig.DeepCopy()
+	cpy := orig.DeepCopy()
+	mutateRuleSetDeeply(orig)
+
+	if !reflect.DeepEqual(cpy, snapshot) {
+		t.Fatalf("copy diverged from initial snapshot")
+	}
+	if reflect.DeepEqual(cpy, orig) {
+		t.Fatal("expected copy to differ from mutated original")
+	}
+}
+
+func TestTypesAdversarial_ZeroValueEngineDeepCopyNoPanic(t *testing.T) {
+	t.Parallel()
+	var e Engine
+	require.NotPanics(t, func() {
+		out := e.DeepCopy()
+		require.NotNil(t, out)
+		assert.Nil(t, out.Status)
+	})
+}
+
+func TestTypesAdversarial_ZeroValueRuleSetDeepCopyNoPanic(t *testing.T) {
+	t.Parallel()
+	var r RuleSet
+	require.NotPanics(t, func() {
+		out := r.DeepCopy()
+		require.NotNil(t, out)
+		assert.Nil(t, out.Status)
+	})
+}
+
+func TestTypesAdversarial_Engine_NilStatusDeepCopyStaysNil(t *testing.T) {
+	t.Parallel()
+	e := &Engine{
+		Spec: EngineSpec{RuleSet: RuleSetReference{Name: "rs"}},
+	}
+	assert.Nil(t, e.Status)
+	cp := e.DeepCopy()
+	require.NotNil(t, cp)
+	assert.Nil(t, cp.Status)
+}
+
+func TestTypesAdversarial_RuleSetReference_EmptyName_AllowedAtRuntime(t *testing.T) {
+	t.Parallel()
+	// OpenAPI/CRD requires minLength 1; the Go struct does not validate.
+	ref := RuleSetReference{Name: ""}
+	e := &Engine{Spec: EngineSpec{RuleSet: ref}}
+	cp := e.DeepCopy()
+	require.NotNil(t, cp)
+	assert.Equal(t, "", cp.Spec.RuleSet.Name)
+}
+
+func TestTypesAdversarial_FailurePolicyConstantsMatchCRDEnum(t *testing.T) {
+	t.Parallel()
+	// config/crd/bases/waf.k8s.coraza.io_engines.yaml enum: fail, allow
+	crdEnums := map[string]struct{}{
+		"fail":  {},
+		"allow": {},
+	}
+	for _, fp := range []FailurePolicy{FailurePolicyFail, FailurePolicyAllow} {
+		_, ok := crdEnums[string(fp)]
+		assert.Truef(t, ok, "constant %q not in CRD enum", fp)
+	}
+	// Every CRD value has a Go constant
+	assert.Equal(t, FailurePolicy("fail"), FailurePolicyFail)
+	assert.Equal(t, FailurePolicy("allow"), FailurePolicyAllow)
+}

--- a/cmd/kubectl-coraza/adversarial_test.go
+++ b/cmd/kubectl-coraza/adversarial_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdversarial_root_unknownSubcommand fails when the user invokes a non-existent subcommand.
+func TestAdversarial_root_unknownSubcommand(t *testing.T) {
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"nonexistent-subcommand"})
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// TestAdversarial_generate_missingCorerulesetSubcommand documents that "generate" alone succeeds
+// (no RunE on the parent); users must pass "coreruleset" explicitly to run generation.
+func TestAdversarial_generate_missingCorerulesetSubcommand(t *testing.T) {
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+// TestAdversarial_coreruleset_missingRulesDir required flag.
+func TestAdversarial_coreruleset_missingRulesDir(t *testing.T) {
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--version", "4.24.1"})
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// TestAdversarial_coreruleset_missingVersion required flag.
+func TestAdversarial_coreruleset_missingVersion(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir})
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// TestAdversarial_coreruleset_emptyRulesDirFlag documents filepath.Clean("") resolving to "."
+// (current working directory), which may succeed without a clear error.
+func TestAdversarial_coreruleset_emptyRulesDirFlag(t *testing.T) {
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", "", "--version", "4.24.1"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+// TestAdversarial_coreruleset_emptyVersionFlag empty required version.
+func TestAdversarial_coreruleset_emptyVersionFlag(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, _, stderr := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", ""})
+	err := cmd.Execute()
+	require.Error(t, err)
+	_ = stderr
+}
+
+// TestAdversarial_coreruleset_positionalArgsIgnoredOrRejected extra positional tokens after flags.
+func TestAdversarial_coreruleset_positionalArgsIgnoredOrRejected(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, stdout, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "extra", "tokens"})
+	err := cmd.Execute()
+	// Cobra may accept unknown args depending on SilenceErrors; document behavior.
+	if err == nil {
+		assert.Contains(t, stdout.String(), "kind: RuleSet")
+	} else {
+		require.Error(t, err)
+	}
+}
+
+// TestAdversarial_coreruleset_dryRunNotClient does not enable dry-run stderr banner.
+func TestAdversarial_coreruleset_dryRunNotClient(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, _, stderr := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--dry-run", "server"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.NotContains(t, stderr.String(), "dry-run: no objects sent to cluster")
+}
+
+// TestAdversarial_coreruleset_ignoreRulesInvalidIDs demonstrates a bug: genCRS writes
+// "Ignoring rule IDs" to os.Stderr instead of cmd.ErrOrStderr(), so callers
+// capturing command stderr (e.g. tests, wrappers) never see the message.
+func TestAdversarial_coreruleset_ignoreRulesInvalidIDs(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, stdout, stderr := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ignore-rules", "999999,not-a-number"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	// BUG: This assertion fails because genCRS writes to os.Stderr (line 128 of main.go)
+	// instead of cmd.ErrOrStderr(). The message is lost when stderr is redirected.
+	assert.Contains(t, stderr.String(), "Ignoring rule IDs",
+		"BUG: genCRS writes 'Ignoring rule IDs' to os.Stderr instead of cmd.ErrOrStderr()")
+	assert.Contains(t, stdout.String(), "kind: RuleSet")
+}
+
+// TestAdversarial_coreruleset_doubleHyphenStyle still parses.
+func TestAdversarial_coreruleset_doubleHyphenStyle(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, stdout, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir=" + dir, "--version=4.24.1"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "kind: RuleSet")
+}
+
+// TestAdversarial_root_helpNoPanic requests help on root (may error if usage is written to Err).
+func TestAdversarial_root_helpNoPanic(t *testing.T) {
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"-h"})
+	err := cmd.Execute()
+	// Help often returns nil or typed ErrHelp; accept either without panic.
+	_ = err
+}
+
+// TestAdversarial_generate_coreruleset_helpNoPanic.
+func TestAdversarial_generate_coreruleset_helpNoPanic(t *testing.T) {
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "-h"})
+	err := cmd.Execute()
+	_ = err
+}
+
+// TestAdversarial_coreruleset_rulesDirIsFile not a directory.
+func TestAdversarial_coreruleset_rulesDirIsFile(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	confPath := filepath.Join(dir, "simple.conf")
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", confPath, "--version", "4.24.1"})
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// TestAdversarial_coreruleset_versionStripsLeadingV ensures v-prefixed versions match bare semver in output.
+func TestAdversarial_coreruleset_versionStripsLeadingV(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, stdout, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "v4.24.1"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	out := stdout.String()
+	assert.Contains(t, out, "OWASP_CRS/4.24.1")
+	assert.NotContains(t, out, "OWASP_CRS/v4.24.1")
+}
+
+// TestAdversarial_coreruleset_versionBareSemver matches stripping behavior for non-prefixed input.
+func TestAdversarial_coreruleset_versionBareSemver(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, stdout, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "OWASP_CRS/4.24.1")
+}
+
+// TestAdversarial_coreruleset_invalidVersionTripleV rejects more than one leading "v".
+func TestAdversarial_coreruleset_invalidVersionTripleV(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "vvv4.24.1"})
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// TestAdversarial_coreruleset_invalidVersionOnlyV rejects a lone "v".
+func TestAdversarial_coreruleset_invalidVersionOnlyV(t *testing.T) {
+	dir := testdataDir(t, "minimal")
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "v"})
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// TestAdversarial_coreruleset_nonExistentRulesDir surfaces filesystem error from Generate.
+func TestAdversarial_coreruleset_nonExistentRulesDir(t *testing.T) {
+	cmd, _, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", "/no/such/rules/dir/under/tmp/qa", "--version", "4.24.1"})
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// TestAdversarial_coreruleset_dirWithNoConfFiles succeeds with base ConfigMap only (empty scan).
+func TestAdversarial_coreruleset_dirWithNoConfFiles(t *testing.T) {
+	tmp := t.TempDir()
+	cmd, stdout, _ := newTestCommand(t)
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", tmp, "--version", "4.0.0"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	out := stdout.String()
+	assert.Equal(t, 1, strings.Count(out, "kind: ConfigMap"), "only base-rules ConfigMap when no *.conf files")
+	assert.Contains(t, out, "name: base-rules")
+	assert.Contains(t, out, "kind: RuleSet")
+}

--- a/cmd/manager/adversarial_test.go
+++ b/cmd/manager/adversarial_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const envAdvValidate = "CORAZA_ADV_MANAGER_VALIDATE_SUBPROCESS"
+
+// TestAdversarial_validateFlags_missingEnvoyClusterName validates that validateFlags
+// calls os.Exit(1) when envoy-cluster-name is empty. Uses subprocess approach
+// because validateFlags terminates the process directly.
+func TestAdversarial_validateFlags_missingEnvoyClusterName(t *testing.T) {
+	if os.Getenv(envAdvValidate) == "1" {
+		validateFlags(config{})
+		// If we reach here, validateFlags did NOT exit — that's wrong.
+		os.Exit(2)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAdversarial_validateFlags_missingEnvoyClusterName$", "-test.v")
+	cmd.Env = append(os.Environ(), envAdvValidate+"=1")
+	err := cmd.Run()
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.True(t, errors.As(err, &exitErr), "expected exit error, got %v", err)
+	assert.Equal(t, 1, exitErr.ExitCode())
+}
+
+// TestAdversarial_validateFlags_withEnvoyClusterName_ok validates the success path.
+func TestAdversarial_validateFlags_withEnvoyClusterName_ok(t *testing.T) {
+	if os.Getenv(envAdvValidate) == "2" {
+		validateFlags(config{envoyClusterName: "outbound|80||cache.default.svc.cluster.local"})
+		os.Exit(0)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAdversarial_validateFlags_withEnvoyClusterName_ok$", "-test.v")
+	cmd.Env = append(os.Environ(), envAdvValidate+"=2")
+	err := cmd.Run()
+	require.NoError(t, err)
+}
+
+// TestAdversarial_buildMetricsServerOptions_allZeroValues documents behavior with a zero-value config.
+func TestAdversarial_buildMetricsServerOptions_allZeroValues(t *testing.T) {
+	var cfg config
+	opts := buildMetricsServerOptions(cfg, nil)
+	assert.Equal(t, "", opts.BindAddress)
+	assert.False(t, opts.SecureServing)
+	assert.Nil(t, opts.FilterProvider)
+	assert.Empty(t, opts.CertDir)
+}
+
+// TestAdversarial_buildMetricsServerOptions_secureMetricsWithEmptyBindAddress documents
+// "conflicting" defaults: secure metrics enabled but metrics address still empty string.
+func TestAdversarial_buildMetricsServerOptions_secureMetricsWithEmptyBindAddress(t *testing.T) {
+	cfg := config{
+		metricsAddr:   "",
+		secureMetrics: true,
+	}
+	opts := buildMetricsServerOptions(cfg, nil)
+	assert.True(t, opts.SecureServing)
+	assert.NotNil(t, opts.FilterProvider)
+}
+
+// TestAdversarial_buildMetricsServerOptions_HTTP2DisabledWithTLSOpts chains TLS opts.
+func TestAdversarial_buildMetricsServerOptions_HTTP2DisabledWithTLSOpts(t *testing.T) {
+	cfg := config{metricsAddr: ":9090", secureMetrics: false}
+	tlsOpts := buildTLSOpts(false)
+	require.Len(t, tlsOpts, 1)
+	opts := buildMetricsServerOptions(cfg, tlsOpts)
+	assert.Equal(t, ":9090", opts.BindAddress)
+	assert.NotNil(t, opts.TLSOpts)
+}
+
+// TestAdversarial_setupWebhookServer_emptyStruct returns a non-nil server.
+func TestAdversarial_setupWebhookServer_emptyStruct(t *testing.T) {
+	var cfg config
+	s := setupWebhookServer(cfg, nil)
+	require.NotNil(t, s)
+}
+
+// TestAdversarial_setupWebhookServer_enableHTTP2FalseTLSOpts passes TLS opts.
+func TestAdversarial_setupWebhookServer_enableHTTP2FalseTLSOpts(t *testing.T) {
+	cfg := config{webhookCertPath: "/tmp/not-checked-in-test"}
+	tlsOpts := buildTLSOpts(false)
+	s := setupWebhookServer(cfg, tlsOpts)
+	require.NotNil(t, s)
+}
+
+// TestAdversarial_buildTLSOpts_preservesNilForHTTP2Enabled documents that HTTP/2 returns nil.
+func TestAdversarial_buildTLSOpts_preservesNilForHTTP2Enabled(t *testing.T) {
+	assert.Nil(t, buildTLSOpts(true))
+}
+
+// TestAdversarial_tlsCallbackFromBuildTLSOpts_doesNotPanic applies the returned option.
+func TestAdversarial_tlsCallbackFromBuildTLSOpts_doesNotPanic(t *testing.T) {
+	opts := buildTLSOpts(false)
+	require.Len(t, opts, 1)
+	cfg := &tls.Config{}
+	assert.NotPanics(t, func() { opts[0](cfg) })
+	assert.Equal(t, []string{"http/1.1"}, cfg.NextProtos)
+}

--- a/internal/controller/adversarial_qa_test.go
+++ b/internal/controller/adversarial_qa_test.go
@@ -1,0 +1,411 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
+)
+
+// -----------------------------------------------------------------------------
+// Engine controller — helpers & nil chains
+// -----------------------------------------------------------------------------
+
+func TestAdversarialHasIstioWasmDriver(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		engine *wafv1alpha1.Engine
+		want   bool
+	}{
+		{"nil driver", &wafv1alpha1.Engine{Spec: wafv1alpha1.EngineSpec{Driver: nil}}, false},
+		{"nil istio", &wafv1alpha1.Engine{Spec: wafv1alpha1.EngineSpec{Driver: &wafv1alpha1.DriverConfig{}}}, false},
+		{"nil wasm", &wafv1alpha1.Engine{Spec: wafv1alpha1.EngineSpec{Driver: &wafv1alpha1.DriverConfig{
+			Istio: &wafv1alpha1.IstioDriverConfig{},
+		}}}, false},
+		{"full wasm", utils.NewTestEngine(utils.EngineOptions{}), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasIstioWasmDriver(tc.engine))
+		})
+	}
+}
+
+func TestAdversarialSelectDriver_InvalidConfigurations(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := logr.Discard()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "e"}}
+	rec := &EngineReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+	}
+
+	cases := []struct {
+		name   string
+		engine wafv1alpha1.Engine
+	}{
+		{"nil Driver", wafv1alpha1.Engine{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns"}, Spec: wafv1alpha1.EngineSpec{Driver: nil, RuleSet: wafv1alpha1.RuleSetReference{Name: "rs"}}}},
+		{"Istio nil", wafv1alpha1.Engine{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns"}, Spec: wafv1alpha1.EngineSpec{
+			Driver:  &wafv1alpha1.DriverConfig{},
+			RuleSet: wafv1alpha1.RuleSetReference{Name: "rs"},
+		}}},
+		{"Wasm nil", wafv1alpha1.Engine{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns"}, Spec: wafv1alpha1.EngineSpec{
+			Driver:  &wafv1alpha1.DriverConfig{Istio: &wafv1alpha1.IstioDriverConfig{}},
+			RuleSet: wafv1alpha1.RuleSetReference{Name: "rs"},
+		}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := rec.selectDriver(ctx, log, req, tc.engine)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid driver configuration")
+		})
+	}
+}
+
+func TestAdversarialBuildWasmPlugin_NilWasmPanics(t *testing.T) {
+	t.Parallel()
+	engine := utils.NewTestEngine(utils.EngineOptions{})
+	engine.Spec.Driver.Istio.Wasm = nil
+	r := &EngineReconciler{ruleSetCacheServerCluster: "c"}
+	require.Panics(t, func() { r.buildWasmPlugin(engine) })
+}
+
+func TestAdversarialBuildWasmPlugin_NilWorkloadSelectorPanics(t *testing.T) {
+	t.Parallel()
+	engine := utils.NewTestEngine(utils.EngineOptions{})
+	engine.Spec.Driver.Istio.Wasm.WorkloadSelector = nil
+	r := &EngineReconciler{ruleSetCacheServerCluster: "c"}
+	require.Panics(t, func() { r.buildWasmPlugin(engine) })
+}
+
+func TestAdversarialFindEnginesForGateway_NoWasmDriver(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ns := testNamespace
+	eng := utils.NewTestEngine(utils.EngineOptions{Name: "gw-map", Namespace: ns})
+	eng.Spec.Driver = &wafv1alpha1.DriverConfig{} // invalid but listable
+	rec := &EngineReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(eng).Build(),
+	}
+	reqs := rec.findEnginesForGateway(ctx, &unstructured.Unstructured{
+		Object: map[string]any{"metadata": map[string]any{"name": "g", "namespace": ns}},
+	})
+	require.Empty(t, reqs)
+}
+
+// -----------------------------------------------------------------------------
+// Engine controller — envtest: gateways, degradation, concurrency
+// -----------------------------------------------------------------------------
+
+func TestAdversarialMatchedGateways_EmptyPodList(t *testing.T) {
+	ctx := context.Background()
+	engine := utils.NewTestEngine(utils.EngineOptions{
+		Name:      "adv-eng-empty",
+		Namespace: testNamespace,
+	})
+	rec := &EngineReconciler{Client: k8sClient, ruleSetCacheServerCluster: "c"}
+	gws, err := rec.matchedGateways(ctx, logr.Discard(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: engine.Namespace, Name: engine.Name}}, engine)
+	require.NoError(t, err)
+	assert.Empty(t, gws)
+}
+
+func TestAdversarialMatchedGateways_PodsWithoutGatewayLabel(t *testing.T) {
+	ctx := context.Background()
+	engine := utils.NewTestEngine(utils.EngineOptions{
+		Name:      "adv-eng-nolabel",
+		Namespace: testNamespace,
+	})
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adv-nop",
+			Namespace: testNamespace,
+			Labels:    map[string]string{"app": "gateway"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "pause:latest"}},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, pod))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, pod) })
+
+	rec := &EngineReconciler{Client: k8sClient, ruleSetCacheServerCluster: "c"}
+	gws, err := rec.matchedGateways(ctx, logr.Discard(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: engine.Namespace, Name: engine.Name}}, engine)
+	require.NoError(t, err)
+	assert.Empty(t, gws)
+}
+
+func TestAdversarialMatchedGateways_NilWorkloadSelector(t *testing.T) {
+	ctx := context.Background()
+	engine := utils.NewTestEngine(utils.EngineOptions{Name: "adv-nil-ws", Namespace: testNamespace})
+	engine.Spec.Driver.Istio.Wasm.WorkloadSelector = nil
+
+	rec := &EngineReconciler{Client: k8sClient, ruleSetCacheServerCluster: "c"}
+	gws, err := rec.matchedGateways(ctx, logr.Discard(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: engine.Namespace, Name: engine.Name}}, engine)
+	require.NoError(t, err)
+	assert.Nil(t, gws)
+}
+
+func TestAdversarialIsRuleSetDegraded_NilRuleSetStatus(t *testing.T) {
+	ctx := context.Background()
+	rs := utils.NewTestRuleSet(utils.RuleSetOptions{Name: "adv-rs-nilstat", Namespace: testNamespace})
+	require.NoError(t, k8sClient.Create(ctx, rs))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rs) })
+
+	engine := utils.NewTestEngine(utils.EngineOptions{Name: "adv-e1", Namespace: testNamespace, RuleSetName: rs.Name})
+	rec := &EngineReconciler{Client: k8sClient, Scheme: scheme, Recorder: utils.NewTestRecorder()}
+	degraded, err := rec.isRuleSetDegraded(ctx, logr.Discard(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: engine.Namespace, Name: engine.Name}}, engine)
+	require.NoError(t, err)
+	assert.False(t, degraded)
+}
+
+func TestAdversarialIsRuleSetDegraded_StatusNoConditions(t *testing.T) {
+	ctx := context.Background()
+	rs := utils.NewTestRuleSet(utils.RuleSetOptions{Name: "adv-rs-nocond", Namespace: testNamespace})
+	require.NoError(t, k8sClient.Create(ctx, rs))
+	rs.Status = &wafv1alpha1.RuleSetStatus{Conditions: nil}
+	require.NoError(t, k8sClient.Status().Update(ctx, rs))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rs) })
+
+	engine := utils.NewTestEngine(utils.EngineOptions{Name: "adv-e2", Namespace: testNamespace, RuleSetName: rs.Name})
+	rec := &EngineReconciler{Client: k8sClient, Scheme: scheme, Recorder: utils.NewTestRecorder()}
+	degraded, err := rec.isRuleSetDegraded(ctx, logr.Discard(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: engine.Namespace, Name: engine.Name}}, engine)
+	require.NoError(t, err)
+	assert.False(t, degraded)
+}
+
+func TestAdversarialEngineReconcile_ConcurrentSameRequest(t *testing.T) {
+	ctx := context.Background()
+	rs := utils.NewTestRuleSet(utils.RuleSetOptions{Name: "adv-rs-conc", Namespace: testNamespace})
+	require.NoError(t, k8sClient.Create(ctx, rs))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rs) })
+
+	engine := utils.NewTestEngine(utils.EngineOptions{Name: "adv-conc-eng", Namespace: testNamespace, RuleSetName: rs.Name})
+	require.NoError(t, k8sClient.Create(ctx, engine))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, engine) })
+
+	rec := &EngineReconciler{
+		Client:                    k8sClient,
+		Scheme:                    scheme,
+		Recorder:                  utils.NewTestRecorder(),
+		ruleSetCacheServerCluster: "c",
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: engine.Namespace, Name: engine.Name}}
+
+	var wg sync.WaitGroup
+	var panicCount atomic.Int32
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if recover() != nil {
+					panicCount.Add(1)
+				}
+			}()
+			_, _ = rec.Reconcile(ctx, req)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int32(0), panicCount.Load(), "concurrent reconcile should not panic")
+}
+
+// -----------------------------------------------------------------------------
+// RuleSet controller — validation, secrets, predicates
+// -----------------------------------------------------------------------------
+
+func TestAdversarialAggregateRulesFromSources_EmptyRulesList(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	rs := &wafv1alpha1.RuleSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns"},
+		Spec:       wafv1alpha1.RuleSetSpec{Rules: []wafv1alpha1.RuleSourceReference{}},
+	}
+	rec := &RuleSetReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(rs).Build()}
+	agg, aggErrs, done, err := rec.aggregateRulesFromSources(ctx, logr.Discard(), ctrl.Request{}, rs, nil)
+	require.NoError(t, err)
+	assert.False(t, done)
+	assert.Empty(t, aggErrs)
+	assert.Equal(t, "", agg)
+}
+
+func TestAdversarialValidateConfigMapRules_EmptyRulesKeyContent(t *testing.T) {
+	t.Parallel()
+	err := validateConfigMapRules("", "cm", nil)
+	require.NoError(t, err)
+}
+
+func TestAdversarialValidateConfigMapRules_OnlyComments(t *testing.T) {
+	t.Parallel()
+	onlyComments := "# SecRuleEngine On\n# comment line\n"
+	err := validateConfigMapRules(onlyComments, "cm", nil)
+	if err != nil {
+		t.Logf("comments-only rules rejected: %v", err)
+	}
+}
+
+func TestAdversarialSanitizeErrorMessage_Formats(t *testing.T) {
+	t.Parallel()
+	t.Run("unix style matched", func(t *testing.T) {
+		err := errors.New("open /etc/waf/foo.data: no such file or directory")
+		out := sanitizeErrorMessage(err)
+		assert.Contains(t, out.Error(), "foo.data")
+		assert.Contains(t, out.Error(), "data does not exist")
+	})
+	t.Run("windows style not matched", func(t *testing.T) {
+		err := errors.New(`open C:\data\foo.data: The system cannot find the file specified`)
+		out := sanitizeErrorMessage(err)
+		assert.Equal(t, err, out)
+	})
+	t.Run("no open prefix", func(t *testing.T) {
+		err := errors.New("something else went wrong")
+		assert.Equal(t, err, sanitizeErrorMessage(err))
+	})
+}
+
+func TestAdversarialShouldSkipMissingFileError(t *testing.T) {
+	t.Parallel()
+	err := errors.New("open /x/y/z.file: no such file or directory")
+	assert.False(t, shouldSkipMissingFileError(err, nil))
+	assert.False(t, shouldSkipMissingFileError(err, map[string][]byte{}))
+	assert.True(t, shouldSkipMissingFileError(err, map[string][]byte{"z.file": {1}}))
+	assert.False(t, shouldSkipMissingFileError(errors.New("unrelated"), map[string][]byte{"z.file": {1}}))
+}
+
+func TestAdversarialAnnotationChangedPredicate_NilObjects(t *testing.T) {
+	t.Parallel()
+	p := annotationChangedPredicate("ann")
+	assert.False(t, p.Update(event.UpdateEvent{ObjectOld: nil, ObjectNew: &corev1.Pod{}}))
+	assert.False(t, p.Update(event.UpdateEvent{ObjectOld: &corev1.Pod{}, ObjectNew: nil}))
+}
+
+func TestAdversarialGetDataFilesystem_EmptyMap(t *testing.T) {
+	t.Parallel()
+	fs := getDataFilesystem(map[string][]byte{})
+	require.NotNil(t, fs)
+}
+
+func TestAdversarialGetDataSecret_TypeSlightlyWrong(t *testing.T) {
+	ctx := context.Background()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "adv-data-wrong-type", Namespace: testNamespace},
+		Type:       corev1.SecretType("coraza/data "), // not equal to RuleDataSecretType
+		Data:       map[string][]byte{"f": []byte("x")},
+	}
+	require.NoError(t, k8sClient.Create(ctx, secret))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, secret) })
+
+	rec := &RuleSetReconciler{Client: k8sClient}
+	_, err := rec.getDataSecret(ctx, secret.Name, testNamespace)
+	require.Error(t, err)
+	var tm *secretTypeMismatchError
+	assert.True(t, errors.As(err, &tm))
+}
+
+func TestAdversarialCacheRules_NilCachePanics(t *testing.T) {
+	t.Parallel()
+	rec := &RuleSetReconciler{Cache: nil}
+	rs := utils.NewTestRuleSet(utils.RuleSetOptions{})
+	require.Panics(t, func() {
+		_, _ = rec.cacheRules(context.Background(), logr.Discard(), ctrl.Request{}, rs, "rules", nil, "")
+	})
+}
+
+func TestAdversarialLargeRulesString_Allocation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("large string stress test")
+	}
+	t.Parallel()
+	huge := strings.Repeat("#", 4*1024*1024)
+	err := validateConfigMapRules(huge, "big-cm", nil)
+	if err != nil {
+		t.Logf("large comment-only rules: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Shared utils
+// -----------------------------------------------------------------------------
+
+func TestAdversarialTruncateEventNote_Boundary(t *testing.T) {
+	t.Parallel()
+	s1024 := strings.Repeat("a", 1024)
+	assert.Len(t, truncateEventNote(s1024), 1024)
+	s1025 := strings.Repeat("b", 1025)
+	out := truncateEventNote(s1025)
+	assert.Len(t, out, 1024)
+	assert.True(t, strings.HasSuffix(out, "..."))
+}
+
+func TestAdversarialServerSideApply_EmptyGVK(t *testing.T) {
+	t.Parallel()
+	u := &unstructured.Unstructured{}
+	u.SetName("x")
+	u.SetNamespace("default")
+	err := serverSideApply(context.Background(), k8sClient, u)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GroupVersionKind")
+}
+
+func TestAdversarialCollectRequests_EmptySlice(t *testing.T) {
+	t.Parallel()
+	got := collectRequests([]wafv1alpha1.Engine{}, func(e *wafv1alpha1.Engine) bool { return true })
+	assert.Nil(t, got)
+}
+
+func TestAdversarialBuildCacheReadyMessage_VeryLongUnsupported(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("U", 50000)
+	msg := buildCacheReadyMessage("ns", "n", long)
+	assert.Contains(t, msg, "Successfully cached rules for ns/n")
+	assert.Contains(t, msg, "[annotation override]")
+	assert.Contains(t, msg, long)
+}
+
+func TestAdversarialLogHelpers_ZeroLogger(t *testing.T) {
+	t.Parallel()
+	var log logr.Logger
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "x", Namespace: "y"}}
+	require.NotPanics(t, func() {
+		logInfo(log, req, "K", "msg")
+		logDebug(log, req, "K", "msg")
+		logError(log, req, "K", errors.New("e"), "msg")
+	})
+}
+
+func TestAdversarialSetCondition_NilSlicePointer(t *testing.T) {
+	t.Parallel()
+	var conds *[]metav1.Condition
+	require.NotPanics(t, func() {
+		setConditionTrue(conds, 1, "Ready", "R", "M")
+		setConditionFalse(conds, 1, "Ready", "R", "M")
+	})
+	assert.Nil(t, conds)
+}

--- a/internal/controller/adversarial_test.go
+++ b/internal/controller/adversarial_test.go
@@ -1,0 +1,377 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
+)
+
+// ---------------------------------------------------------------------------
+// truncateEventNote
+// ---------------------------------------------------------------------------
+
+func TestTruncateEventNote_Adversarial(t *testing.T) {
+	t.Run("exactly max bytes unchanged", func(t *testing.T) {
+		s := strings.Repeat("a", maxEventNoteBytes)
+		assert.Equal(t, s, truncateEventNote(s))
+	})
+
+	t.Run("one byte over max truncates", func(t *testing.T) {
+		s := strings.Repeat("a", maxEventNoteBytes+1)
+		got := truncateEventNote(s)
+		assert.Len(t, got, maxEventNoteBytes)
+		assert.True(t, strings.HasSuffix(got, "..."))
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		assert.Equal(t, "", truncateEventNote(""))
+	})
+
+	t.Run("unicode at boundary may split rune", func(t *testing.T) {
+		// 3-byte rune (€) repeated to overshoot; truncation is byte-based
+		s := strings.Repeat("€", maxEventNoteBytes)
+		got := truncateEventNote(s)
+		assert.LessOrEqual(t, len(got), maxEventNoteBytes)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// sanitizeErrorMessage
+// ---------------------------------------------------------------------------
+
+func TestSanitizeErrorMessage_Adversarial(t *testing.T) {
+	t.Run("non-matching error returned as-is", func(t *testing.T) {
+		err := errors.New("something else went wrong")
+		assert.Equal(t, err, sanitizeErrorMessage(err))
+	})
+
+	t.Run("matching open path uses basename only", func(t *testing.T) {
+		err := errors.New("open /var/data/../../../etc/shadow: no such file or directory")
+		got := sanitizeErrorMessage(err)
+		assert.Contains(t, got.Error(), "shadow")
+		assert.NotContains(t, got.Error(), "/var/data")
+	})
+
+	t.Run("wrapped nil inner does not match path regex", func(t *testing.T) {
+		err := fmt.Errorf("context: %w", errors.New("unrelated"))
+		got := sanitizeErrorMessage(err)
+		assert.Equal(t, err.Error(), got.Error())
+	})
+}
+
+// ---------------------------------------------------------------------------
+// shouldSkipMissingFileError
+// ---------------------------------------------------------------------------
+
+func TestShouldSkipMissingFileError_Adversarial(t *testing.T) {
+	matchErr := errors.New("open /fs/data.txt: no such file or directory")
+
+	t.Run("nil secretData", func(t *testing.T) {
+		assert.False(t, shouldSkipMissingFileError(matchErr, nil))
+	})
+
+	t.Run("empty secretData", func(t *testing.T) {
+		assert.False(t, shouldSkipMissingFileError(matchErr, map[string][]byte{}))
+	})
+
+	t.Run("matching filename", func(t *testing.T) {
+		assert.True(t, shouldSkipMissingFileError(matchErr, map[string][]byte{"data.txt": {1}}))
+	})
+
+	t.Run("non-matching filename", func(t *testing.T) {
+		assert.False(t, shouldSkipMissingFileError(matchErr, map[string][]byte{"other.txt": {1}}))
+	})
+
+	t.Run("non-matching error format", func(t *testing.T) {
+		assert.False(t, shouldSkipMissingFileError(errors.New("timeout"), map[string][]byte{"x": {}}))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// buildCacheReadyMessage
+// ---------------------------------------------------------------------------
+
+func TestBuildCacheReadyMessage_Adversarial(t *testing.T) {
+	t.Run("empty namespace and name", func(t *testing.T) {
+		msg := buildCacheReadyMessage("", "", "")
+		assert.Contains(t, msg, "Successfully cached rules for /")
+	})
+
+	t.Run("no unsupported msg omits override", func(t *testing.T) {
+		msg := buildCacheReadyMessage("ns", "rs", "")
+		assert.NotContains(t, msg, "[annotation override]")
+	})
+
+	t.Run("long unsupportedMsg appended", func(t *testing.T) {
+		long := strings.Repeat("x", 5000)
+		msg := buildCacheReadyMessage("ns", "rs", long)
+		assert.Contains(t, msg, "[annotation override]")
+		assert.Contains(t, msg, long)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// serverSideApply validation (no real client, just pre-patch checks)
+// ---------------------------------------------------------------------------
+
+func TestServerSideApply_Adversarial(t *testing.T) {
+	t.Run("empty GVK returns error", func(t *testing.T) {
+		obj := &unstructured.Unstructured{}
+		obj.SetName("foo")
+		err := serverSideApply(nil, nil, obj)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "GroupVersionKind")
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "g", Version: "v", Kind: "K"})
+		err := serverSideApply(nil, nil, obj)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// annotationChangedPredicate
+// ---------------------------------------------------------------------------
+
+func TestAnnotationChangedPredicate_Adversarial(t *testing.T) {
+	p := annotationChangedPredicate("test-key")
+
+	t.Run("create returns false", func(t *testing.T) {
+		assert.False(t, p.Create(event.CreateEvent{}))
+	})
+	t.Run("delete returns false", func(t *testing.T) {
+		assert.False(t, p.Delete(event.DeleteEvent{}))
+	})
+	t.Run("generic returns false", func(t *testing.T) {
+		assert.False(t, p.Generic(event.GenericEvent{}))
+	})
+	t.Run("update with nil objects returns false", func(t *testing.T) {
+		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: nil, ObjectNew: nil}))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// hasIstioWasmDriver
+// ---------------------------------------------------------------------------
+
+func TestHasIstioWasmDriver_Adversarial(t *testing.T) {
+	t.Run("nil Driver", func(t *testing.T) {
+		e := &wafv1alpha1.Engine{Spec: wafv1alpha1.EngineSpec{Driver: nil}}
+		assert.False(t, hasIstioWasmDriver(e))
+	})
+	t.Run("nil Istio", func(t *testing.T) {
+		e := &wafv1alpha1.Engine{Spec: wafv1alpha1.EngineSpec{Driver: &wafv1alpha1.DriverConfig{}}}
+		assert.False(t, hasIstioWasmDriver(e))
+	})
+	t.Run("nil Wasm", func(t *testing.T) {
+		e := &wafv1alpha1.Engine{Spec: wafv1alpha1.EngineSpec{Driver: &wafv1alpha1.DriverConfig{
+			Istio: &wafv1alpha1.IstioDriverConfig{},
+		}}}
+		assert.False(t, hasIstioWasmDriver(e))
+	})
+	t.Run("all set", func(t *testing.T) {
+		e := &wafv1alpha1.Engine{Spec: wafv1alpha1.EngineSpec{Driver: &wafv1alpha1.DriverConfig{
+			Istio: &wafv1alpha1.IstioDriverConfig{Wasm: &wafv1alpha1.IstioWasmConfig{}},
+		}}}
+		assert.True(t, hasIstioWasmDriver(e))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// buildWasmPlugin
+// ---------------------------------------------------------------------------
+
+func TestBuildWasmPlugin_Adversarial(t *testing.T) {
+	baseEngine := func() wafv1alpha1.Engine {
+		return wafv1alpha1.Engine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-engine", Namespace: "ns"},
+			Spec: wafv1alpha1.EngineSpec{
+				RuleSet: wafv1alpha1.RuleSetReference{Name: "my-rs"},
+				Driver: &wafv1alpha1.DriverConfig{
+					Istio: &wafv1alpha1.IstioDriverConfig{
+						Wasm: &wafv1alpha1.IstioWasmConfig{
+							Image: "oci://example.com/wasm:v1",
+							WorkloadSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "gw"},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("nil FailurePolicy defaults to fail", func(t *testing.T) {
+		e := baseEngine()
+		r := &EngineReconciler{}
+		wp := r.buildWasmPlugin(&e)
+		spec := wp.Object["spec"].(map[string]any)
+		pc := spec["pluginConfig"].(map[string]any)
+		assert.Equal(t, "fail", pc["failure_policy"])
+	})
+
+	t.Run("explicit allow FailurePolicy", func(t *testing.T) {
+		e := baseEngine()
+		fp := wafv1alpha1.FailurePolicyAllow
+		e.Spec.FailurePolicy = &fp
+		r := &EngineReconciler{}
+		wp := r.buildWasmPlugin(&e)
+		spec := wp.Object["spec"].(map[string]any)
+		pc := spec["pluginConfig"].(map[string]any)
+		assert.Equal(t, "allow", pc["failure_policy"])
+	})
+
+	t.Run("nil MatchLabels becomes empty map", func(t *testing.T) {
+		e := baseEngine()
+		e.Spec.Driver.Istio.Wasm.WorkloadSelector = &metav1.LabelSelector{}
+		r := &EngineReconciler{}
+		wp := r.buildWasmPlugin(&e)
+		spec := wp.Object["spec"].(map[string]any)
+		sel := spec["selector"].(map[string]any)
+		ml := sel["matchLabels"].(map[string]string)
+		assert.Empty(t, ml)
+	})
+
+	t.Run("empty istioRevision omits label", func(t *testing.T) {
+		e := baseEngine()
+		r := &EngineReconciler{istioRevision: ""}
+		wp := r.buildWasmPlugin(&e)
+		labels := wp.GetLabels()
+		_, hasRev := labels["istio.io/rev"]
+		assert.False(t, hasRev)
+	})
+
+	t.Run("non-empty istioRevision sets label", func(t *testing.T) {
+		e := baseEngine()
+		r := &EngineReconciler{istioRevision: "canary"}
+		wp := r.buildWasmPlugin(&e)
+		assert.Equal(t, "canary", wp.GetLabels()["istio.io/rev"])
+	})
+
+	t.Run("PollIntervalSeconds included when set", func(t *testing.T) {
+		e := baseEngine()
+		poll := int32(30)
+		e.Spec.Driver.Istio.Wasm.RuleSetCacheServer = &wafv1alpha1.RuleSetCacheServerConfig{
+			PollIntervalSeconds: &poll,
+		}
+		r := &EngineReconciler{}
+		wp := r.buildWasmPlugin(&e)
+		spec := wp.Object["spec"].(map[string]any)
+		pc := spec["pluginConfig"].(map[string]any)
+		assert.Equal(t, int32(30), pc["rule_reload_interval_seconds"])
+	})
+
+	// BUG DEMONSTRATION: nil WorkloadSelector panics in buildWasmPlugin.
+	// The CRD validates workloadSelector is required when mode=gateway, but
+	// the Go code does not defensively check.
+	t.Run("nil WorkloadSelector panics", func(t *testing.T) {
+		e := baseEngine()
+		e.Spec.Driver.Istio.Wasm.WorkloadSelector = nil
+		r := &EngineReconciler{}
+		assert.Panics(t, func() {
+			r.buildWasmPlugin(&e)
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// getDataFilesystem
+// ---------------------------------------------------------------------------
+
+func TestGetDataFilesystem_Adversarial(t *testing.T) {
+	t.Run("nil returns nil", func(t *testing.T) {
+		assert.Nil(t, getDataFilesystem(nil))
+	})
+
+	t.Run("empty map returns non-nil fs", func(t *testing.T) {
+		fs := getDataFilesystem(map[string][]byte{})
+		assert.NotNil(t, fs)
+	})
+
+	t.Run("map with empty value", func(t *testing.T) {
+		fs := getDataFilesystem(map[string][]byte{"empty.dat": {}})
+		require.NotNil(t, fs)
+		f, err := fs.Open("empty.dat")
+		require.NoError(t, err)
+		defer f.Close()
+		info, err := f.Stat()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), info.Size())
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+func TestSecretErrors_Adversarial(t *testing.T) {
+	t.Run("secretNotFoundError includes name", func(t *testing.T) {
+		e := &secretNotFoundError{name: "my-secret"}
+		assert.Contains(t, e.Error(), "my-secret")
+	})
+
+	t.Run("secretTypeMismatchError mentions expected type", func(t *testing.T) {
+		e := &secretTypeMismatchError{name: "my-secret"}
+		assert.Contains(t, e.Error(), wafv1alpha1.RuleDataSecretType)
+	})
+
+	// The secretTypeMismatchError does NOT include the secret name in its
+	// Error() output, making error messages less actionable.
+	t.Run("secretTypeMismatchError omits secret name (known gap)", func(t *testing.T) {
+		e := &secretTypeMismatchError{name: "my-secret"}
+		assert.NotContains(t, e.Error(), "my-secret")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// engineMatchesLabels — additional adversarial cases beyond existing tests
+// ---------------------------------------------------------------------------
+
+func TestEngineMatchesLabels_Adversarial(t *testing.T) {
+	t.Run("invalid matchExpressions operator returns false", func(t *testing.T) {
+		e := &wafv1alpha1.Engine{
+			Spec: wafv1alpha1.EngineSpec{Driver: &wafv1alpha1.DriverConfig{
+				Istio: &wafv1alpha1.IstioDriverConfig{
+					Wasm: &wafv1alpha1.IstioWasmConfig{
+						WorkloadSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOperator("BadOp"),
+								Values:   []string{"x"},
+							}},
+						},
+					},
+				},
+			}},
+		}
+		assert.False(t, engineMatchesLabels(e, map[string]string{"app": "x"}))
+	})
+
+	t.Run("empty pod labels with restrictive matchLabels", func(t *testing.T) {
+		e := &wafv1alpha1.Engine{
+			Spec: wafv1alpha1.EngineSpec{Driver: &wafv1alpha1.DriverConfig{
+				Istio: &wafv1alpha1.IstioDriverConfig{
+					Wasm: &wafv1alpha1.IstioWasmConfig{
+						WorkloadSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "gw"},
+						},
+					},
+				},
+			}},
+		}
+		assert.False(t, engineMatchesLabels(e, map[string]string{}))
+	})
+}

--- a/internal/rulesets/cache/cache_adversarial_test.go
+++ b/internal/rulesets/cache/cache_adversarial_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuleSetCache_Adversarial_ConcurrentPutGetPrune(t *testing.T) {
+	c := NewRuleSetCache()
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers * 3)
+
+	for w := range workers {
+		inst := string(rune('A' + (w % 4)))
+		go func() {
+			defer wg.Done()
+			for i := range 50 {
+				c.Put(inst, string(rune('a'+i%26)), map[string][]byte{"f": {byte(i)}})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 50 {
+				_, _ = c.Get(inst)
+				_ = c.TotalSize()
+				_ = c.ListKeys()
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 25 {
+				c.Prune(time.Hour)
+				c.PruneBySize(1 << 20)
+			}
+		}()
+	}
+	wg.Wait()
+	_, _ = c.Get("A")
+}
+
+func TestRuleSetCache_Adversarial_PruneBySize_OnlyLatestPerInstance(t *testing.T) {
+	c := NewRuleSetCache()
+	// One entry each; each entry is "latest" and cannot be pruned by size.
+	c.Put("a", "hello", nil) // 5 bytes
+	c.Put("b", "world", nil) // 5 bytes
+	require.Equal(t, 10, c.TotalSize())
+	n := c.PruneBySize(0)
+	assert.Equal(t, 0, n, "cannot prune when every entry is protected as latest")
+	assert.Equal(t, 10, c.TotalSize(), "size cannot drop below sum of latest-only entries")
+}
+
+func TestRuleSetCache_Adversarial_Put_NilDatafilesNoPanic(t *testing.T) {
+	c := NewRuleSetCache()
+	require.NotPanics(t, func() {
+		c.Put("x", "rules", nil)
+	})
+	e, ok := c.Get("x")
+	require.True(t, ok)
+	// Put clones into a new map; nil input becomes an empty (non-nil) map.
+	assert.Empty(t, e.DataFiles)
+}
+
+func TestRuleSetCache_Adversarial_GetEmptyAndMissing(t *testing.T) {
+	c := NewRuleSetCache()
+	e, ok := c.Get("anything")
+	assert.False(t, ok)
+	assert.Nil(t, e)
+	c.Put("only", "x", nil)
+	e, ok = c.Get("missing")
+	assert.False(t, ok)
+	assert.Nil(t, e)
+}
+
+func TestRuleSetCache_Adversarial_Prune_ZeroMaxAge_KeepsOnlyLatestAndVeryRecent(t *testing.T) {
+	c := NewRuleSetCache()
+	c.Put("i", "old", nil)
+	c.Put("i", "new", nil)
+	// Mark non-latest as ancient; latest slightly in past
+	c.SetEntryTimestamp("i", 0, time.Now().Add(-time.Hour))
+	c.SetEntryTimestamp("i", 1, time.Now().Add(-time.Millisecond))
+	p := c.Prune(0)
+	assert.Equal(t, 1, p)
+	e, ok := c.Get("i")
+	require.True(t, ok)
+	assert.Equal(t, "new", e.Rules)
+}
+
+func TestRuleSetCache_Adversarial_PruneBySize_MaxSizeZero(t *testing.T) {
+	c := NewRuleSetCache()
+	c.Put("i", "aa", nil)
+	c.Put("i", "bb", nil) // latest
+	pruned := c.PruneBySize(0)
+	assert.GreaterOrEqual(t, pruned, 1)
+	assert.LessOrEqual(t, c.TotalSize(), 2+2) // latest "bb" only
+}
+
+func TestRuleSetCache_Adversarial_TotalSize_ExactSum(t *testing.T) {
+	c := NewRuleSetCache()
+	rules := "abcd"
+	df := map[string][]byte{"nm": {1, 2, 3}}
+	c.Put("i", rules, df)
+	want := len(rules) + len("nm") + 3
+	assert.Equal(t, want, c.TotalSize())
+}
+
+func TestRuleSetCache_Adversarial_MultipleInstancesIsolation(t *testing.T) {
+	a := NewRuleSetCache()
+	b := NewRuleSetCache()
+	a.Put("k", "secret", nil)
+	_, ok := b.Get("k")
+	assert.False(t, ok)
+	e, ok := a.Get("k")
+	require.True(t, ok)
+	assert.Equal(t, "secret", e.Rules)
+}

--- a/internal/rulesets/cache/server_adversarial_test.go
+++ b/internal/rulesets/cache/server_adversarial_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
+)
+
+func TestServer_Adversarial_DisallowedMethods_POST_PUT_DELETE(t *testing.T) {
+	cache := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	srv := NewServer(cache, ":0", logger, nil)
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/rules/k", nil)
+			w := httptest.NewRecorder()
+			srv.handleRules(w, req)
+			assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+		})
+	}
+}
+
+func TestServer_Adversarial_PathLikeKey_NoFilesystemTraversal(t *testing.T) {
+	cache := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	srv := NewServer(cache, ":0", logger, nil)
+	key := "../../../etc/passwd"
+	cache.Put(key, "rules", nil)
+	req := httptest.NewRequest(http.MethodGet, "/rules/"+key+"/latest", nil)
+	w := httptest.NewRecorder()
+	srv.handleRules(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+}
+
+func TestServer_Adversarial_EmptyPathRulesSlash(t *testing.T) {
+	cache := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	srv := NewServer(cache, ":0", logger, nil)
+	req := httptest.NewRequest(http.MethodGet, "/rules/", nil)
+	w := httptest.NewRecorder()
+	srv.handleRules(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestServer_Adversarial_VeryLongCacheKey(t *testing.T) {
+	cache := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	srv := NewServer(cache, ":0", logger, nil)
+	longKey := strings.Repeat("k", 12000)
+	cache.Put(longKey, "ok", nil)
+	req := httptest.NewRequest(http.MethodGet, "/rules/"+longKey, nil)
+	w := httptest.NewRecorder()
+	srv.handleRules(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+}
+
+func TestServer_Adversarial_JSONContentTypeOnSuccess(t *testing.T) {
+	cache := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	srv := NewServer(cache, ":0", logger, nil)
+	cache.Put("x", "{}", nil)
+	for _, path := range []string{"/rules/x", "/rules/x/latest"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		srv.handleRules(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, path)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"), path)
+	}
+}
+
+func TestServer_Adversarial_ConcurrentGET(t *testing.T) {
+	cache := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	srv := NewServer(cache, ":0", logger, nil)
+	cache.Put("c", "data", nil)
+	var wg sync.WaitGroup
+	for range 64 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/rules/c", nil)
+			w := httptest.NewRecorder()
+			srv.handleRules(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestServer_Adversarial_GETWithBody_NotRejectedByServerConfig(t *testing.T) {
+	cache := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	srv := NewServer(cache, ":0", logger, nil)
+	cache.Put("b", "x", nil)
+	body := strings.NewReader(strings.Repeat("z", 4096))
+	req := httptest.NewRequest(http.MethodGet, "/rules/b", body)
+	req.ContentLength = 4096
+	w := httptest.NewRecorder()
+	srv.handleRules(w, req)
+	// MaxBodySize is documented as 0 but not applied to http.Server — handler still succeeds.
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/rulesets/memfs/memfs_adversarial_test.go
+++ b/internal/rulesets/memfs/memfs_adversarial_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memfs_test
+
+import (
+	"io"
+	"io/fs"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/memfs"
+)
+
+func TestMemFS_Adversarial_OpenNonExistent_ErrNotExist(t *testing.T) {
+	m := memfs.NewMemFS()
+	_, err := m.Open("nope")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestMemFS_Adversarial_WriteThenReadIntegrity(t *testing.T) {
+	m := memfs.NewMemFS()
+	want := []byte{0, 1, 2, 3, 255}
+	m.WriteFile("bin", want)
+	f, err := m.Open("bin")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	got, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestMemFS_Adversarial_ConcurrentReadWrite(t *testing.T) {
+	m := memfs.NewMemFS()
+	var wg sync.WaitGroup
+	for i := range 40 {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			m.WriteFile("w", []byte{byte(i)})
+		}(i)
+		go func() {
+			defer wg.Done()
+			f, err := m.Open("w")
+			if err != nil {
+				return
+			}
+			_, _ = io.ReadAll(f)
+			_ = f.Close()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestMemFS_Adversarial_EmptyFilename(t *testing.T) {
+	m := memfs.NewMemFS()
+	m.WriteFile("", []byte("x"))
+	f, err := m.Open("")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	b, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("x"), b)
+}
+
+func TestMemFS_Adversarial_NilData(t *testing.T) {
+	m := memfs.NewMemFS()
+	require.NotPanics(t, func() { m.WriteFile("nilf", nil) })
+	f, err := m.Open("nilf")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	b, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Empty(t, b)
+}
+
+func TestMemFS_Adversarial_ModTimeChangesOnEachStat(t *testing.T) {
+	m := memfs.NewMemFS()
+	m.WriteFile("t", []byte("a"))
+	f, err := m.Open("t")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	s1, err := f.Stat()
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+	s2, err := f.Stat()
+	require.NoError(t, err)
+	assert.NotEqual(t, s1.ModTime(), s2.ModTime(),
+		"memFile.ModTime returns time.Now() on each Stat(), so metadata is unstable across calls")
+}
+
+func TestMemFS_Adversarial_NotReadDirFS_WalkDirFails(t *testing.T) {
+	m := memfs.NewMemFS()
+	m.WriteFile("a.conf", []byte("x"))
+	_, ok := any(m).(fs.ReadDirFS)
+	assert.False(t, ok, "MemFS does not implement fs.ReadDirFS")
+	err := fs.WalkDir(m, ".", func(path string, d fs.DirEntry, err error) error {
+		return err
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}

--- a/internal/rulesets/unsupported_adversarial_test.go
+++ b/internal/rulesets/unsupported_adversarial_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rulesets
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckUnsupportedRules_Adversarial_CommentLineBareIDIgnored(t *testing.T) {
+	rules := "# id:950150\nSecRuleEngine On\n"
+	assert.Nil(t, CheckUnsupportedRules(rules))
+}
+
+func TestCheckUnsupportedRules_Adversarial_SingleQuotedID(t *testing.T) {
+	found := CheckUnsupportedRules(`SecRule REQUEST_URI "@rx x" "id:'950150',phase:1,pass"`)
+	require.Len(t, found, 1)
+	assert.Equal(t, 950150, found[0].ID)
+}
+
+func TestCheckUnsupportedRules_Adversarial_DoubleQuotedID(t *testing.T) {
+	rules := fmt.Sprintf(`SecRule REQUEST_URI "@rx x" "id:%s950150%s,phase:1,pass"`, `"`, `"`)
+	found := CheckUnsupportedRules(rules)
+	require.Len(t, found, 1)
+	assert.Equal(t, 950150, found[0].ID)
+}
+
+func TestCheckUnsupportedRules_Adversarial_EmptyString(t *testing.T) {
+	assert.Nil(t, CheckUnsupportedRules(""))
+}
+
+func TestCheckUnsupportedRules_Adversarial_OnlyComments(t *testing.T) {
+	rules := "# SecRuleEngine On\n   # another\n"
+	assert.Nil(t, CheckUnsupportedRules(rules))
+}
+
+func TestCheckUnsupportedRules_Adversarial_DuplicateIDsOnce(t *testing.T) {
+	rules := secRuleWithID(950150) + "\n" + secRuleWithID(950150) + "\n" + secRuleWithID(950150)
+	found := CheckUnsupportedRules(rules)
+	require.Len(t, found, 1)
+	assert.Equal(t, 950150, found[0].ID)
+}
+
+func TestFormatUnsupportedMessage_Adversarial_EmptySlice(t *testing.T) {
+	assert.Equal(t, "", FormatUnsupportedMessage([]UnsupportedRule{}))
+}
+
+func TestIncompatibleRuleIDs_Adversarial_SortedNonEmpty(t *testing.T) {
+	ids := IncompatibleRuleIDs()
+	require.NotEmpty(t, ids)
+	for i := 1; i < len(ids); i++ {
+		assert.Less(t, ids[i-1], ids[i], "must be strictly sorted ascending")
+	}
+}
+
+func TestRedundantRuleIDs_Adversarial_SortedNonEmpty(t *testing.T) {
+	ids := RedundantRuleIDs()
+	require.NotEmpty(t, ids)
+	for i := 1; i < len(ids); i++ {
+		assert.Less(t, ids[i-1], ids[i], "must be strictly sorted ascending")
+	}
+}
+
+func TestStripCommentLines_Adversarial_WhitespaceOnlyLines(t *testing.T) {
+	in := "  \t  \nSecRule X \"@rx a\" \"id:950150,pass\"\n\n"
+	out := stripCommentLines(in)
+	assert.Contains(t, out, "id:950150")
+	assert.NotContains(t, out, "\n\n\n")
+}
+
+func TestStripCommentLines_Adversarial_MixedTabsSpacesBeforeHash(t *testing.T) {
+	in := "SecRule A \"@rx b\" \"id:1,pass\"\n \t # id:950150\nSecRule C \"@rx d\" \"id:922110,pass\""
+	out := stripCommentLines(in)
+	assert.Contains(t, out, "id:1")
+	assert.NotContains(t, out, "id:950150")
+	assert.Contains(t, out, "id:922110")
+}

--- a/tools/corerulesetgen/adversarial_test.go
+++ b/tools/corerulesetgen/adversarial_test.go
@@ -1,0 +1,332 @@
+package corerulesetgen
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdversarial_ParseCRSVersion_empty(t *testing.T) {
+	_, err := ParseCRSVersion("")
+	require.Error(t, err)
+}
+
+func TestAdversarial_ParseCRSVersion_vOnly(t *testing.T) {
+	_, err := ParseCRSVersion("v")
+	require.Error(t, err)
+}
+
+func TestAdversarial_ParseCRSVersion_tripleVPrefix(t *testing.T) {
+	_, err := ParseCRSVersion("vvv4.24.1")
+	require.Error(t, err)
+}
+
+func TestAdversarial_ParseCRSVersion_doubleVPrefix(t *testing.T) {
+	_, err := ParseCRSVersion("vv4.24.1")
+	require.Error(t, err)
+}
+
+func TestAdversarial_ParseCRSVersion_negativeComponent(t *testing.T) {
+	_, err := ParseCRSVersion("-1.0.0")
+	require.Error(t, err)
+}
+
+func TestAdversarial_ParseCRSVersion_nonNumeric(t *testing.T) {
+	_, err := ParseCRSVersion("abc")
+	require.Error(t, err)
+}
+
+func TestAdversarial_ParseCRSVersion_veryLong(t *testing.T) {
+	long := strings.Repeat("1.", 500) + "0"
+	v, err := ParseCRSVersion(long)
+	require.NoError(t, err)
+	require.NotEmpty(t, v.Normalized)
+}
+
+func TestAdversarial_ParseCRSVersion_whitespacePadded(t *testing.T) {
+	v, err := ParseCRSVersion("  v4.24.1  ")
+	require.NoError(t, err)
+	require.Equal(t, "4.24.1", v.Normalized)
+}
+
+func TestAdversarial_Scan_emptyDirNoConf(t *testing.T) {
+	tmp := t.TempDir()
+	s, err := Scan(tmp)
+	require.NoError(t, err)
+	require.Empty(t, s.ConfPaths)
+	require.Empty(t, s.DataPaths)
+	require.False(t, s.PMFromFileRefs)
+}
+
+func TestAdversarial_Generate_rulesPathIsFileNotDir(t *testing.T) {
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "x.conf")
+	require.NoError(t, os.WriteFile(f, []byte("SecRule ARGS \"@rx a\" \"id:1,pass\"\n"), 0o644))
+	_, err := Generate(io.Discard, Options{
+		RulesDir: f,
+		Version:  "4.0.0",
+		Stderr:   io.Discard,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a directory")
+}
+
+func TestAdversarial_Generate_nilStderrUsesDiscard(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := Generate(io.Discard, Options{
+		RulesDir: tmp,
+		Version:  "4.0.0",
+	})
+	require.NoError(t, err)
+}
+
+func TestAdversarial_WriteManifests_nilBundlePanics(t *testing.T) {
+	require.Panics(t, func() {
+		_ = WriteManifests(&bytes.Buffer{}, nil)
+	})
+}
+
+func TestAdversarial_WriteManifests_emptyBundleStillWrites(t *testing.T) {
+	var b ManifestBundle
+	var out bytes.Buffer
+	err := WriteManifests(&out, &b)
+	require.NoError(t, err)
+	require.NotEmpty(t, out.String())
+}
+
+func TestAdversarial_checkPayloadSize_rejectsHugePayload(t *testing.T) {
+	huge := strings.Repeat("x", maxRulesPayloadBytes+1)
+	err := checkPayloadSize(huge, "test-cm", Options{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "limit")
+}
+
+func TestAdversarial_checkPayloadSize_skipSizeCheckAllowsHuge(t *testing.T) {
+	huge := strings.Repeat("x", maxRulesPayloadBytes+1)
+	err := checkPayloadSize(huge, "test-cm", Options{SkipSizeCheck: true})
+	require.NoError(t, err)
+}
+
+func TestAdversarial_duplicateConfFilesSameContent(t *testing.T) {
+	tmp := t.TempDir()
+	content := `SecRule ARGS "@rx a" "id:1,pass"` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "a.conf"), []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "b.conf"), []byte(content), 0o644))
+	ver := mustParseCRSVersion(t, "4.0.0")
+	scan, err := Scan(tmp)
+	require.NoError(t, err)
+	require.Len(t, scan.ConfPaths, 2)
+	bundle, err := Build(Options{
+		RulesDir:       tmp,
+		Version:        "4.0.0",
+		RuleSetName:    "rs",
+		DataSecretName: "ds",
+	}, scan, ver)
+	require.NoError(t, err)
+	require.Len(t, bundle.ExtraConfigMaps, 2)
+}
+
+func TestAdversarial_processFileContent_unicodeAndSpecialChars(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "u.conf")
+	content := "SecRule ARGS \"@rx \u2022\" \"id:42,pass\"\n"
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+	out, _, err := processFileContent(p, nil, false)
+	require.NoError(t, err)
+	require.Contains(t, out, "id:42")
+}
+
+func TestAdversarial_processFileContent_veryLongLine(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "long.conf")
+	longArg := strings.Repeat("A", 10000)
+	content := `SecRule ARGS "` + longArg + `" "id:7,pass"` + "\n"
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+	out, _, err := processFileContent(p, nil, false)
+	require.NoError(t, err)
+	require.Contains(t, out, "id:7")
+}
+
+func TestAdversarial_ignoreRuleIDs_nonexistentIDsNoError(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "z.conf"), []byte(`SecRule ARGS "@rx a" "id:1,pass"`+"\n"), 0o644))
+	ver := mustParseCRSVersion(t, "4.0.0")
+	scan, err := Scan(tmp)
+	require.NoError(t, err)
+	bundle, err := Build(Options{
+		RulesDir:       tmp,
+		Version:        "4.0.0",
+		RuleSetName:    "rs",
+		DataSecretName: "ds",
+		IgnoreRuleIDs:  map[string]struct{}{"99999": {}},
+	}, scan, ver)
+	require.NoError(t, err)
+	require.Contains(t, bundle.ExtraConfigMaps[0].Doc, "id:1")
+}
+
+func TestAdversarial_pmFromFile_warningWhenNoDataFilesAndNotIgnoring(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "p.conf"), []byte(`SecRule ARGS "@pmFromFile x.data" "id:1,pass"`+"\n"), 0o644))
+	var errBuf bytes.Buffer
+	_, err := Generate(io.Discard, Options{
+		RulesDir: tmp,
+		Version:  "4.0.0",
+		Stderr:   &errBuf,
+	})
+	require.NoError(t, err)
+	require.Contains(t, errBuf.String(), "@pmFromFile")
+}
+
+func TestAdversarial_pmFromFile_noWarningWhenIgnoring(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "p.conf"), []byte(`SecRule ARGS "@pmFromFile x.data" "id:1,pass"`+"\n"), 0o644))
+	var errBuf bytes.Buffer
+	_, err := Generate(io.Discard, Options{
+		RulesDir:         tmp,
+		Version:          "4.0.0",
+		IgnorePMFromFile: true,
+		Stderr:           &errBuf,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, errBuf.String(), "warning: @pmFromFile references found")
+}
+
+func TestAdversarial_injectNamespaceInBaseConfigMapYAML_missingMarkerNoChange(t *testing.T) {
+	doc := "kind: ConfigMap\nmetadata:\n  name: other\n"
+	out := injectNamespaceInBaseConfigMapYAML(doc, "ns")
+	require.Equal(t, doc, out)
+}
+
+func TestAdversarial_rulesetYAML_emptyConfigMapNames(t *testing.T) {
+	y := rulesetYAML(nil, Options{RuleSetName: "r", DataSecretName: "d"}, false)
+	require.Contains(t, y, "name: r")
+	require.Contains(t, y, "- name: base-rules")
+}
+
+func TestAdversarial_formatRuleSetYAML_emptyName(t *testing.T) {
+	y := formatRuleSetYAML("", "", nil, "")
+	require.Contains(t, y, "kind: RuleSet")
+}
+
+func TestAdversarial_Generate_nonExistentRulesDir(t *testing.T) {
+	_, err := Generate(io.Discard, Options{
+		RulesDir: "/nonexistent/coreruleset/rules/path",
+		Version:  "4.0.0",
+		Stderr:   io.Discard,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rules directory")
+}
+
+func TestAdversarial_Generate_malformedVersion(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := Generate(io.Discard, Options{
+		RulesDir: tmp,
+		Version:  "not semver",
+		Stderr:   io.Discard,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CoreRuleSet version")
+}
+
+func TestAdversarial_Scan_symlinkConfFileReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test is Unix-oriented")
+	}
+	tmp := t.TempDir()
+	real := filepath.Join(tmp, "real.conf")
+	require.NoError(t, os.WriteFile(real, []byte("SecRule ARGS \"@rx a\" \"id:1,pass\"\n"), 0o644))
+	link := filepath.Join(tmp, "via-link.conf")
+	require.NoError(t, os.Symlink(real, link))
+	s, err := Scan(tmp)
+	require.NoError(t, err)
+	require.Len(t, s.ConfPaths, 2)
+}
+
+func TestAdversarial_Scan_permissionDeniedOnConf(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root may bypass file mode bits for read")
+	}
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "locked.conf")
+	require.NoError(t, os.WriteFile(p, []byte("SecRule ARGS \"@rx a\" \"id:1,pass\"\n"), 0o644))
+	require.NoError(t, os.Chmod(p, 0))
+	t.Cleanup(func() { _ = os.Chmod(p, 0o644) })
+	_, err := Scan(tmp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read")
+}
+
+func TestAdversarial_checkPayloadSize_exactlyAtLimitAccepted(t *testing.T) {
+	s := strings.Repeat("x", maxRulesPayloadBytes)
+	require.NoError(t, checkPayloadSize(s, "cm", Options{}))
+}
+
+func TestAdversarial_checkPayloadSize_oneByteOverLimitRejected(t *testing.T) {
+	s := strings.Repeat("x", maxRulesPayloadBytes+1)
+	err := checkPayloadSize(s, "cm", Options{})
+	require.Error(t, err)
+}
+
+func TestAdversarial_checkSecretStringData_totalBoundary(t *testing.T) {
+	// Per-value max and total max both use ~900KiB constants; two half-size values should pass total check.
+	half := maxSecretStringDataTotalBytes / 2
+	entries := map[string]string{"a": strings.Repeat("y", half), "b": strings.Repeat("z", half)}
+	require.NoError(t, checkSecretStringDataSize("sec", entries, Options{}))
+	entries["c"] = "extra"
+	require.Error(t, checkSecretStringDataSize("sec", entries, Options{}))
+}
+
+func TestAdversarial_processFileContent_emptyFile(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "empty.conf")
+	require.NoError(t, os.WriteFile(p, []byte(""), 0o644))
+	out, warns, err := processFileContent(p, nil, false)
+	require.NoError(t, err)
+	require.Empty(t, warns)
+	require.Empty(t, out)
+}
+
+func TestAdversarial_processFileContent_binaryWithoutSecMarkers(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "noise.conf")
+	require.NoError(t, os.WriteFile(p, []byte{0, 1, 2, 255, 0}, 0o644))
+	out, _, err := processFileContent(p, nil, false)
+	require.NoError(t, err)
+	require.Empty(t, out)
+}
+
+func TestAdversarial_formatConfigMapYAML_multilineDocumentMarkersInContent(t *testing.T) {
+	// Literal block should preserve lines that look like YAML document separators.
+	indented := indentRulesMultiline("SecRule ARGS \"@rx x\" \"id:1,pass\"\n---\nSecRule ARGS \"@rx y\" \"id:2,pass\"")
+	y := formatConfigMapYAML("rules-a", "", indented)
+	require.Contains(t, y, "---")
+	require.Contains(t, y, "id:1")
+}
+
+func TestAdversarial_buildConfigMapYAML_rejectsPayloadOneByteOverLimit(t *testing.T) {
+	tmp := t.TempDir()
+	// Craft a single-line SecRule whose indented payload exceeds maxRulesPayloadBytes.
+	padding := strings.Repeat("Z", maxRulesPayloadBytes)
+	content := "SecRule ARGS \"" + padding + "\" \"id:1,pass\"\n"
+	p := filepath.Join(tmp, "huge.conf")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+	_, _, _, _, err := buildConfigMapYAML(p, Options{RuleSetName: "rs", DataSecretName: "ds"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "limit")
+}
+
+func TestAdversarial_ParseCRSVersion_equivalentForms(t *testing.T) {
+	a, err := ParseCRSVersion("4.24.1")
+	require.NoError(t, err)
+	b, err := ParseCRSVersion("v4.24.1")
+	require.NoError(t, err)
+	require.Equal(t, a.Normalized, b.Normalized)
+	require.Equal(t, a.Setup, b.Setup)
+}


### PR DESCRIPTION
Adversarial QA across all packages to probe boundaries the existing test suite does not cover.

Failing tests (bugs demonstrated):
- Engine controller panics in handleInvalidDriverConfiguration when engine.Status is nil (nil pointer deref at engine_controller.go:162)
- buildWasmPlugin panics when WorkloadSelector is nil (CRD guards this but Go code has no defensive check)
- genCRS writes "Ignoring rule IDs" to os.Stderr instead of cmd.ErrOrStderr(), so captured stderr never sees the message

Passing tests (hardening):
- cache: concurrent Put/Get/Prune, nil datafiles, size accounting
- server: HTTP method enforcement, path traversal keys, empty path
- memfs: concurrent read/write, nil data, unstable ModTime, no ReadDirFS
- unsupported: comment stripping, quoted IDs, dedup, empty input
- controller: truncateEventNote boundary, serverSideApply validation, annotationChangedPredicate nil safety, matchedGateways edge cases
- api types: DeepCopy field independence, zero values, enum alignment
- cmd/manager: validateFlags exit codes, TLS/metrics option combos
- kubectl-coraza: version normalization, missing flags, empty dir
- corerulesetgen: size limits, version parsing, render edge cases

Ref: #236

Made-with: Cursor
