### PR TITLE
Implement authentication on cache server

### DIFF
--- a/charts/coraza-kubernetes-operator/templates/clusterrole.yaml
+++ b/charts/coraza-kubernetes-operator/templates/clusterrole.yaml
@@ -23,6 +23,23 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
   - events.k8s.io
   resources:
   - events

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
@@ -100,10 +101,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	rulesetCache := setupCacheServer(mgr, cfg)
+	kubeClient, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		setupLog.Error(err, "unable to create kubernetes clientset")
+		os.Exit(1)
+	}
+
+	rulesetCache := setupCacheServer(mgr, cfg, kubeClient)
 	setupIstioPrerequisites(mgr, cfg, podNamespace)
 
-	if err := controller.SetupControllers(mgr, rulesetCache, cfg.envoyClusterName, cfg.istioRevision, cfg.defaultWasmImage, podNamespace); err != nil {
+	if err := controller.SetupControllers(mgr, rulesetCache, cfg.envoyClusterName, cfg.istioRevision, cfg.defaultWasmImage, podNamespace, kubeClient); err != nil {
 		setupLog.Error(err, "unable to setup controllers")
 		os.Exit(1)
 	}
@@ -258,14 +265,15 @@ func buildCacheOptions(operatorNamespace string) ctrlcache.Options {
 	}
 }
 
-func setupCacheServer(mgr ctrl.Manager, cfg config) *cache.RuleSetCache {
+func setupCacheServer(mgr ctrl.Manager, cfg config, kubeClient *kubernetes.Clientset) *cache.RuleSetCache {
 	rulesetCache := cache.NewRuleSetCache()
 	gcConfig := &cache.GarbageCollectionConfig{
 		GCInterval: cfg.cacheGCInterval,
 		MaxAge:     cfg.cacheMaxAge,
 		MaxSize:    cfg.cacheMaxSize,
 	}
-	cacheServer := cache.NewServer(rulesetCache, fmt.Sprintf(":%d", cfg.cacheServerPort), ctrl.Log, gcConfig)
+	tokenReview := kubeClient.AuthenticationV1().TokenReviews()
+	cacheServer := cache.NewServer(rulesetCache, fmt.Sprintf(":%d", cfg.cacheServerPort), ctrl.Log, gcConfig, tokenReview)
 	if err := mgr.Add(cacheServer); err != nil {
 		setupLog.Error(err, "unable to add cache server to manager")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,23 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
   - events.k8s.io
   resources:
   - events

--- a/internal/controller/engine_controller.go
+++ b/internal/controller/engine_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -31,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -65,12 +67,20 @@ type EngineReconciler struct {
 	Recorder events.EventRecorder
 
 	client.Client
+	kubeClient                kubernetes.Interface
 	ruleSetCacheServerCluster string
 	istioRevision             string
 	// defaultWasmImage is the OCI URL used for Istio WasmPlugin spec.url when the
 	// Engine omits spec.driver.istio.wasm.image.
 	defaultWasmImage  string
 	operatorNamespace string
+
+	// tokenStore is a thread-safe store for cache client tokens, keyed by
+	// "namespace/engineName/rulesetName". Uses sync.Map for simple concurrent access.
+	// Each Engine+RuleSet pair has its own token (no sharing), so no per-key mutex is needed.
+	// Including the rulesetName in the key ensures that changing an Engine's
+	// spec.ruleSet.name invalidates the cached token (which encodes the audience).
+	tokenStore sync.Map
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/engine_controller_driver_istio.go
+++ b/internal/controller/engine_controller_driver_istio.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -81,7 +82,32 @@ func (r *EngineReconciler) provisionIstioEngineWithWasm(ctx context.Context, log
 		return ctrl.Result{}, err
 	}
 
-	wasmPlugin, err := r.applyWasmPlugin(ctx, log, req, &engine)
+	logDebug(log, req, "Engine", "Ensuring cache client ServiceAccount")
+	saName, err := r.ensureCacheClientServiceAccount(ctx, log, req, &engine)
+	if err != nil {
+		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "ServiceAccountFailed", fmt.Sprintf("Failed to ensure cache client ServiceAccount: %v", err)); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		return ctrl.Result{}, err
+	}
+
+	logDebug(log, req, "Engine", "Ensuring cache client token")
+	cacheToken, renewAt, err := r.ensureCacheToken(ctx, log, req, saName, engine.Spec.RuleSet.Name)
+	if err != nil {
+		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "TokenFailed", fmt.Sprintf("Failed to ensure cache client token: %v", err)); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		return ctrl.Result{}, err
+	}
+	if cacheToken == "" {
+		err := fmt.Errorf("cache client token is empty for RuleSet %s", engine.Spec.RuleSet.Name)
+		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "TokenFailed", err.Error()); patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		return ctrl.Result{}, err
+	}
+
+	wasmPlugin, err := r.applyWasmPlugin(ctx, log, req, &engine, cacheToken)
 	if err != nil {
 		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "ProvisioningFailed", fmt.Sprintf("Failed to create or update WasmPlugin: %v", err)); patchErr != nil {
 			return ctrl.Result{}, patchErr
@@ -111,12 +137,17 @@ func (r *EngineReconciler) provisionIstioEngineWithWasm(ctx context.Context, log
 	logConditionTransitions(log, req, "Engine", before, engine.Status.Conditions)
 	r.Recorder.Eventf(&engine, nil, "Normal", "WasmPluginCreated", "Provision", "Created WasmPlugin %s/%s", wasmPlugin.GetNamespace(), wasmPlugin.GetName())
 
-	return ctrl.Result{}, nil
+	// Schedule re-reconciliation at the token's renewal deadline. This is a
+	// single requeue that fires exactly when the token needs refreshing,
+	// avoiding repeated intermediate reconciliations.
+	requeueAfter := max(time.Until(renewAt), time.Second)
+	logDebug(log, req, "Engine", "Scheduling token renewal", "requeueAfter", requeueAfter)
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 // applyWasmPlugin builds the WasmPlugin resource, sets the controller reference,
 // and applies it via server-side apply.
-func (r *EngineReconciler) applyWasmPlugin(ctx context.Context, log logr.Logger, req ctrl.Request, engine *wafv1alpha1.Engine) (*unstructured.Unstructured, error) {
+func (r *EngineReconciler) applyWasmPlugin(ctx context.Context, log logr.Logger, req ctrl.Request, engine *wafv1alpha1.Engine, cacheToken string) (*unstructured.Unstructured, error) {
 	logDebug(log, req, "Engine", "Building WasmPlugin resource")
 	wasmURL, fromSpec := r.wasmPluginOCIURLSource(engine)
 	if fromSpec {
@@ -124,7 +155,7 @@ func (r *EngineReconciler) applyWasmPlugin(ctx context.Context, log logr.Logger,
 	} else {
 		logDebug(log, req, "Engine", "WasmPlugin OCI URL from operator default", "url", wasmURL)
 	}
-	wasmPlugin := r.buildWasmPlugin(engine, wasmURL)
+	wasmPlugin := r.buildWasmPlugin(engine, wasmURL, cacheToken)
 
 	logDebug(log, req, "Engine", "Setting controller reference on WasmPlugin")
 	if err := controllerutil.SetControllerReference(engine, wasmPlugin, r.Scheme); err != nil {
@@ -157,7 +188,7 @@ func (r *EngineReconciler) wasmPluginOCIURLSource(engine *wafv1alpha1.Engine) (u
 	return r.defaultWasmImage, false
 }
 
-func (r *EngineReconciler) buildWasmPlugin(engine *wafv1alpha1.Engine, wasmURL string) *unstructured.Unstructured {
+func (r *EngineReconciler) buildWasmPlugin(engine *wafv1alpha1.Engine, wasmURL string, cacheToken string) *unstructured.Unstructured {
 	rulesetKey := fmt.Sprintf("%s/%s", engine.Namespace, engine.Spec.RuleSet.Name)
 
 	failurePolicy := wafv1alpha1.FailurePolicyFail
@@ -169,6 +200,7 @@ func (r *EngineReconciler) buildWasmPlugin(engine *wafv1alpha1.Engine, wasmURL s
 		"cache_server_instance": rulesetKey,
 		"cache_server_cluster":  r.ruleSetCacheServerCluster,
 		"failure_policy":        string(failurePolicy),
+		"cache_token":           cacheToken,
 	}
 
 	if engine.Spec.Driver.Istio.Wasm.RuleSetCacheServer != nil {

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +36,7 @@ import (
 
 	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
 	"github.com/networking-incubator/coraza-kubernetes-operator/internal/defaults"
+	rcache "github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
 	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
 )
 
@@ -74,16 +77,61 @@ func TestEngineReconciler_BuildWasmPlugin_IstioRevisionLabel(t *testing.T) {
 		ruleSetCacheServerCluster: "test-cluster",
 		istioRevision:             "canary",
 	}
-	w := withRev.buildWasmPlugin(engine, testWasmOCI)
+	w := withRev.buildWasmPlugin(engine, testWasmOCI, "test-token")
 	assert.Equal(t, "canary", w.GetLabels()["istio.io/rev"])
 
 	noRev := &EngineReconciler{
 		ruleSetCacheServerCluster: "test-cluster",
 		operatorNamespace:         testNamespace,
 	}
-	w2 := noRev.buildWasmPlugin(engine, testWasmOCI)
+	w2 := noRev.buildWasmPlugin(engine, testWasmOCI, "test-token")
 	_, has := w2.GetLabels()["istio.io/rev"]
 	assert.False(t, has, "istio.io/rev should not be set when revision is empty")
+}
+
+func TestEngineReconciler_BuildWasmPlugin_CacheToken(t *testing.T) {
+	engine := utils.NewTestEngine(utils.EngineOptions{
+		Name:      "token-test-engine",
+		Namespace: testNamespace,
+	})
+
+	reconciler := &EngineReconciler{
+		ruleSetCacheServerCluster: "test-cluster",
+	}
+
+	t.Run("cache_token is set in pluginConfig", func(t *testing.T) {
+		w := reconciler.buildWasmPlugin(engine, "oci://test.example/wasm:latest", "my-jwt-token")
+
+		spec, found, err := getNestedMap(w.Object, "spec")
+		require.NoError(t, err)
+		require.True(t, found)
+
+		pluginConfig, found, err := getNestedMap(spec, "pluginConfig")
+		require.NoError(t, err)
+		require.True(t, found)
+
+		token, found, err := getNestedString(pluginConfig, "cache_token")
+		require.NoError(t, err)
+		require.True(t, found, "cache_token should be present in pluginConfig")
+		assert.Equal(t, "my-jwt-token", token)
+	})
+
+	t.Run("empty token is still set", func(t *testing.T) {
+		w := reconciler.buildWasmPlugin(engine, "oci://test.example/wasm:latest", "")
+
+		spec, found, err := getNestedMap(w.Object, "spec")
+		require.NoError(t, err)
+		require.True(t, found)
+
+		pluginConfig, found, err := getNestedMap(spec, "pluginConfig")
+		require.NoError(t, err)
+		require.True(t, found)
+
+		token, found, err := getNestedString(pluginConfig, "cache_token")
+		require.NoError(t, err)
+		require.True(t, found, "cache_token key should exist even when empty")
+		assert.Empty(t, token)
+	})
 }
 
 func TestEngineReconciler_ReconcileMissingRuleSet(t *testing.T) {
@@ -169,6 +217,7 @@ func TestEngineReconciler_ReconcileIstioDriver(t *testing.T) {
 		Client:                    k8sClient,
 		Scheme:                    scheme,
 		Recorder:                  recorder,
+		kubeClient:                testKubeClient,
 		ruleSetCacheServerCluster: "test-cluster",
 		defaultWasmImage:          defaults.DefaultCorazaWasmOCIReference,
 		operatorNamespace:         testNamespace,
@@ -185,10 +234,10 @@ func TestEngineReconciler_ReconcileIstioDriver(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotZero(t, result.RequeueAfter)
 
-	// Second reconcile proceeds with provisioning.
+	// Second reconcile proceeds with provisioning and schedules token renewal.
 	result, err = reconciler.Reconcile(ctx, engineReq)
 	require.NoError(t, err)
-	assert.Zero(t, result.RequeueAfter)
+	assert.NotZero(t, result.RequeueAfter, "should schedule token renewal requeue")
 
 	t.Log("Verifying engine status")
 	var updated wafv1alpha1.Engine
@@ -317,6 +366,7 @@ func TestEngineReconciler_FailurePolicyInWasmPluginConfig(t *testing.T) {
 				Client:                    k8sClient,
 				Scheme:                    scheme,
 				Recorder:                  utils.NewTestRecorder(),
+				kubeClient:                testKubeClient,
 				ruleSetCacheServerCluster: "test-cluster",
 				defaultWasmImage:          defaults.DefaultCorazaWasmOCIReference,
 				operatorNamespace:         testNamespace,
@@ -333,14 +383,14 @@ func TestEngineReconciler_FailurePolicyInWasmPluginConfig(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotZero(t, result.RequeueAfter)
 
-			// Second reconcile provisions the WasmPlugin.
+			// Second reconcile provisions the WasmPlugin and schedules token renewal.
 			result, err = reconciler.Reconcile(ctx, req)
 			require.NoError(t, err)
-			assert.Zero(t, result.RequeueAfter)
+			assert.NotZero(t, result.RequeueAfter, "should schedule token renewal requeue")
 
 			t.Log("Fetching created WasmPlugin")
 			wasmURL, _ := reconciler.wasmPluginOCIURLSource(engine)
-			wasmPlugin := reconciler.buildWasmPlugin(engine, wasmURL)
+			wasmPlugin := reconciler.buildWasmPlugin(engine, wasmURL, "test-token")
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      wasmPlugin.GetName(),
 				Namespace: wasmPlugin.GetNamespace(),
@@ -360,6 +410,11 @@ func TestEngineReconciler_FailurePolicyInWasmPluginConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, found, "failure_policy not found in pluginConfig")
 			assert.Equal(t, tt.expectedFailurePolicy, failurePolicy)
+
+			cacheToken, found, err := getNestedString(pluginConfig, "cache_token")
+			require.NoError(t, err)
+			require.True(t, found, "cache_token not found in pluginConfig")
+			assert.NotEmpty(t, cacheToken, "cache_token should be a non-empty JWT token")
 		})
 	}
 }
@@ -406,7 +461,7 @@ func TestEngineReconciler_ImagePullSecretInWasmPlugin(t *testing.T) {
 			ImagePullSecret: "my-registry-secret",
 		})
 
-		wasmPlugin := reconciler.buildWasmPlugin(engine, "")
+		wasmPlugin := reconciler.buildWasmPlugin(engine, "", "")
 
 		spec, found, err := getNestedMap(wasmPlugin.Object, "spec")
 		require.NoError(t, err)
@@ -424,7 +479,7 @@ func TestEngineReconciler_ImagePullSecretInWasmPlugin(t *testing.T) {
 			Namespace: testNamespace,
 		})
 
-		wasmPlugin := reconciler.buildWasmPlugin(engine, "")
+		wasmPlugin := reconciler.buildWasmPlugin(engine, "", "")
 
 		spec, found, err := getNestedMap(wasmPlugin.Object, "spec")
 		require.NoError(t, err)
@@ -456,6 +511,7 @@ func TestEngineReconciler_ImagePullSecretEnvtest(t *testing.T) {
 		Recorder:                  utils.NewTestRecorder(),
 		ruleSetCacheServerCluster: "test-cluster",
 		operatorNamespace:         testNamespace,
+		kubeClient:                testKubeClient,
 	}
 
 	t.Run("imagePullSecret persisted in WasmPlugin via server-side apply", func(t *testing.T) {
@@ -484,10 +540,10 @@ func TestEngineReconciler_ImagePullSecretEnvtest(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotZero(t, result.RequeueAfter)
 
-		// Second reconcile provisions the WasmPlugin.
+		// Second reconcile provisions the WasmPlugin and schedules token renewal.
 		result, err = reconciler.Reconcile(ctx, req)
 		require.NoError(t, err)
-		assert.Zero(t, result.RequeueAfter)
+		assert.NotZero(t, result.RequeueAfter, "should schedule token renewal requeue")
 
 		t.Log("Fetching WasmPlugin from API server")
 		wasmPlugin := &unstructured.Unstructured{}
@@ -537,10 +593,10 @@ func TestEngineReconciler_ImagePullSecretEnvtest(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotZero(t, result.RequeueAfter)
 
-		// Second reconcile provisions the WasmPlugin.
+		// Second reconcile provisions the WasmPlugin and schedules token renewal.
 		result, err = reconciler.Reconcile(ctx, req)
 		require.NoError(t, err)
-		assert.Zero(t, result.RequeueAfter)
+		assert.NotZero(t, result.RequeueAfter, "should schedule token renewal requeue")
 
 		t.Log("Fetching WasmPlugin from API server")
 		wasmPlugin := &unstructured.Unstructured{}
@@ -909,7 +965,7 @@ func TestEngineReconciler_BuildWasmPlugin_WasmImageResolution(t *testing.T) {
 		engine.Spec.Driver.Istio.Wasm.Image = ""
 		r := &EngineReconciler{defaultWasmImage: operatorDefault}
 		wasmURL, _ := r.wasmPluginOCIURLSource(engine)
-		wp := r.buildWasmPlugin(engine, wasmURL)
+		wp := r.buildWasmPlugin(engine, wasmURL, "")
 		spec, found, err := getNestedMap(wp.Object, "spec")
 		require.NoError(t, err)
 		require.True(t, found)
@@ -933,7 +989,7 @@ func TestEngineReconciler_BuildWasmPlugin_WasmImageResolution(t *testing.T) {
 		engine.Spec.Driver.Istio.Wasm.Image = custom
 		r := &EngineReconciler{defaultWasmImage: operatorDefault}
 		wasmURL, _ := r.wasmPluginOCIURLSource(engine)
-		wp := r.buildWasmPlugin(engine, wasmURL)
+		wp := r.buildWasmPlugin(engine, wasmURL, "")
 		spec, found, err := getNestedMap(wp.Object, "spec")
 		require.NoError(t, err)
 		require.True(t, found)
@@ -941,6 +997,158 @@ func TestEngineReconciler_BuildWasmPlugin_WasmImageResolution(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, found)
 		assert.Equal(t, custom, url)
+	})
+}
+
+func TestEngineReconciler_TokenStoreIntegration(t *testing.T) {
+	ctx := context.Background()
+
+	ruleset := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "tokenstore-ruleset",
+		Namespace: testNamespace,
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleset))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(ctx, ruleset); err != nil {
+			t.Logf("Failed to delete ruleset: %v", err)
+		}
+	})
+
+	engine := utils.NewTestEngine(utils.EngineOptions{
+		Name:        "tokenstore-engine",
+		Namespace:   testNamespace,
+		RuleSetName: ruleset.Name,
+	})
+	require.NoError(t, k8sClient.Create(ctx, engine))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(ctx, engine); err != nil {
+			t.Logf("Failed to delete engine: %v", err)
+		}
+	})
+
+	reconciler := &EngineReconciler{
+		Client:                    k8sClient,
+		Scheme:                    scheme,
+		Recorder:                  utils.NewTestRecorder(),
+		kubeClient:                testKubeClient,
+		ruleSetCacheServerCluster: "test-cluster",
+		defaultWasmImage:          defaults.DefaultCorazaWasmOCIReference,
+		operatorNamespace:         testNamespace,
+	}
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      engine.Name,
+			Namespace: engine.Namespace,
+		},
+	}
+
+	// First reconcile: adds finalizer, no token yet.
+	result, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.NotZero(t, result.RequeueAfter)
+
+	tokenKey := fmt.Sprintf("%s/%s/%s", engine.Namespace, engine.Name, ruleset.Name)
+	_, found := reconciler.tokenStore.Load(tokenKey)
+	assert.False(t, found, "tokenStore should be empty after finalizer-only reconcile")
+
+	// Second reconcile: provisions SA, token, and WasmPlugin.
+	result, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.NotZero(t, result.RequeueAfter, "should schedule token renewal requeue")
+
+	t.Run("token is stored with correct key", func(t *testing.T) {
+		val, found := reconciler.tokenStore.Load(tokenKey)
+		require.True(t, found, "tokenStore should have entry for %s", tokenKey)
+
+		entry := val.(*TokenEntry)
+		assert.NotEmpty(t, entry.Token, "stored token should not be empty")
+		assert.False(t, entry.IssuedAt.IsZero(), "IssuedAt should be set")
+		assert.True(t, entry.ExpiresAt.After(time.Now()), "token should not be expired")
+		assert.False(t, entry.NeedsRenewal(), "freshly issued token should not need renewal")
+	})
+
+	t.Run("ServiceAccount created with correct labels", func(t *testing.T) {
+		var saList corev1.ServiceAccountList
+		err := k8sClient.List(ctx, &saList,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels(cacheClientSALabels(engine.Name)),
+		)
+		require.NoError(t, err)
+		require.Len(t, saList.Items, 1, "exactly one SA should exist for the engine")
+
+		sa := saList.Items[0]
+		assert.True(t, len(sa.Name) > len(rcache.CacheEngineSAPrefix),
+			"SA name should be server-generated via GenerateName")
+		assert.Equal(t, "cache-client", sa.Labels["app.kubernetes.io/component"])
+		assert.Equal(t, engine.Name, sa.Labels["app.kubernetes.io/instance"])
+
+		require.Len(t, sa.OwnerReferences, 1, "SA should have an owner reference")
+		assert.Equal(t, engine.Name, sa.OwnerReferences[0].Name)
+		assert.Equal(t, "Engine", sa.OwnerReferences[0].Kind)
+	})
+
+	t.Run("token in WasmPlugin matches tokenStore", func(t *testing.T) {
+		val, _ := reconciler.tokenStore.Load(tokenKey)
+		storedToken := val.(*TokenEntry).Token
+
+		wasmPlugin := &unstructured.Unstructured{}
+		wasmPlugin.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "extensions.istio.io",
+			Version: "v1alpha1",
+			Kind:    "WasmPlugin",
+		})
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      fmt.Sprintf("%s%s", WasmPluginNamePrefix, engine.Name),
+			Namespace: engine.Namespace,
+		}, wasmPlugin)
+		require.NoError(t, err)
+
+		spec, found, err := getNestedMap(wasmPlugin.Object, "spec")
+		require.NoError(t, err)
+		require.True(t, found)
+		pluginConfig, found, err := getNestedMap(spec, "pluginConfig")
+		require.NoError(t, err)
+		require.True(t, found)
+		cacheToken, found, err := getNestedString(pluginConfig, "cache_token")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, storedToken, cacheToken, "WasmPlugin cache_token should match tokenStore entry")
+	})
+
+	t.Run("second reconcile reuses cached token", func(t *testing.T) {
+		val, _ := reconciler.tokenStore.Load(tokenKey)
+		firstToken := val.(*TokenEntry).Token
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.NotZero(t, result.RequeueAfter)
+
+		val, _ = reconciler.tokenStore.Load(tokenKey)
+		secondToken := val.(*TokenEntry).Token
+		assert.Equal(t, firstToken, secondToken, "token should be reused from cache on subsequent reconcile")
+	})
+
+	t.Run("expired token is renewed on reconcile", func(t *testing.T) {
+		val, _ := reconciler.tokenStore.Load(tokenKey)
+		oldToken := val.(*TokenEntry).Token
+
+		// Simulate an expired token by overwriting the entry.
+		reconciler.tokenStore.Store(tokenKey, &TokenEntry{
+			Token:     "expired-token",
+			IssuedAt:  time.Now().Add(-2 * time.Hour),
+			ExpiresAt: time.Now().Add(-1 * time.Hour),
+		})
+
+		result, err := reconciler.Reconcile(ctx, req)
+		require.NoError(t, err)
+		assert.NotZero(t, result.RequeueAfter)
+
+		val, found := reconciler.tokenStore.Load(tokenKey)
+		require.True(t, found)
+		newEntry := val.(*TokenEntry)
+		assert.NotEqual(t, "expired-token", newEntry.Token, "expired token should be replaced")
+		assert.NotEqual(t, oldToken, newEntry.Token, "a fresh token should be generated")
+		assert.True(t, newEntry.ExpiresAt.After(time.Now()), "new token should not be expired")
 	})
 }
 
@@ -980,7 +1188,9 @@ func TestEngineReconciler_NetworkPolicyCreated(t *testing.T) {
 		Client:                    k8sClient,
 		Scheme:                    scheme,
 		Recorder:                  utils.NewTestRecorder(),
+		kubeClient:                testKubeClient,
 		ruleSetCacheServerCluster: "test-cluster",
+		defaultWasmImage:          defaults.DefaultCorazaWasmOCIReference,
 		operatorNamespace:         testNamespace,
 	}
 	engineReq := ctrl.Request{
@@ -1003,10 +1213,10 @@ func TestEngineReconciler_NetworkPolicyCreated(t *testing.T) {
 	assert.Contains(t, updatedEngine.Finalizers, "waf.k8s.coraza.io/network-policy-cleanup",
 		"Engine should have the NetworkPolicy cleanup finalizer")
 
-	// Second reconcile proceeds with provisioning.
+	// Second reconcile proceeds with provisioning and schedules token renewal.
 	result, err = reconciler.Reconcile(ctx, engineReq)
 	require.NoError(t, err)
-	assert.Zero(t, result.RequeueAfter)
+	assert.NotZero(t, result.RequeueAfter, "should schedule token renewal requeue")
 
 	t.Log("Verifying NetworkPolicy was created")
 	var npList networkingv1.NetworkPolicyList

--- a/internal/controller/engine_controller_token.go
+++ b/internal/controller/engine_controller_token.go
@@ -1,0 +1,208 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
+	rcache "github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
+)
+
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+
+const (
+	// tokenDuration is the requested lifetime for cache client tokens.
+	// Kept short (1 hour) to limit the exposure window since tokens are
+	// stored in plaintext in WasmPlugin CRs. The renewal mechanism
+	// requeues at 80% of the actual lifetime (~48 minutes).
+	tokenDuration = 1 * time.Hour
+
+	// tokenRenewalFraction is the fraction of a token's actual lifetime at which
+	// it should be renewed. For example, 0.8 means renew after 80% of the lifetime
+	// has elapsed. This avoids pathological 1-minute requeue loops when the
+	// apiserver returns a shorter lifetime than requested (e.g., max token lifetime
+	// configured to <=24h).
+	tokenRenewalFraction = 0.8
+)
+
+// tokenExpirationSeconds is tokenDuration in seconds for the TokenRequest API.
+var tokenExpirationSeconds = int64(tokenDuration.Seconds())
+
+// -----------------------------------------------------------------------------
+// TokenEntry
+// -----------------------------------------------------------------------------
+
+// TokenEntry holds a cache client token and its issuance/expiry times.
+type TokenEntry struct {
+	Token     string
+	IssuedAt  time.Time
+	ExpiresAt time.Time
+}
+
+// RenewalDeadline returns the absolute time at which the token should be renewed.
+func (e *TokenEntry) RenewalDeadline() time.Time {
+	lifetime := e.ExpiresAt.Sub(e.IssuedAt)
+	renewAfter := time.Duration(float64(lifetime) * tokenRenewalFraction)
+	return e.IssuedAt.Add(renewAfter)
+}
+
+// NeedsRenewal returns true if the token has passed the renewal point
+// (i.e., more than tokenRenewalFraction of its lifetime has elapsed).
+func (e *TokenEntry) NeedsRenewal() bool {
+	return !time.Now().Before(e.RenewalDeadline())
+}
+
+// -----------------------------------------------------------------------------
+// Engine Controller - Token Management
+// -----------------------------------------------------------------------------
+
+// cacheClientSALabels returns the labels used to identify a cache client
+// ServiceAccount owned by a specific Engine.
+func cacheClientSALabels(engineName string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by": "coraza-kubernetes-operator",
+		"app.kubernetes.io/component":  "cache-client",
+		"app.kubernetes.io/instance":   engineName,
+	}
+}
+
+// ensureCacheClientServiceAccount creates a ServiceAccount for cache client
+// authentication if it doesn't already exist. The SA uses GenerateName with
+// the "coraza-engine-" prefix and is discovered by label on subsequent calls.
+// An owner reference is set to the Engine so the SA is garbage-collected when
+// the Engine is deleted.
+//
+// Returns the actual ServiceAccount name so callers can use it for token creation.
+func (r *EngineReconciler) ensureCacheClientServiceAccount(ctx context.Context, log logr.Logger, req ctrl.Request, engine *wafv1alpha1.Engine) (string, error) {
+	labels := cacheClientSALabels(engine.Name)
+
+	// Discover existing SA by label.
+	var saList corev1.ServiceAccountList
+	if err := r.List(ctx, &saList,
+		client.InNamespace(req.Namespace),
+		client.MatchingLabels(labels),
+	); err != nil {
+		return "", fmt.Errorf("failed to list ServiceAccounts for engine %s: %w", engine.Name, err)
+	}
+	if len(saList.Items) > 0 {
+		if len(saList.Items) > 1 {
+			log.Info("Multiple ServiceAccounts match cache-client labels, using first",
+				"engine", req.Name,
+				"namespace", req.Namespace,
+				"matchCount", len(saList.Items),
+				"selectedSA", saList.Items[0].Name,
+			)
+		}
+		logDebug(log, req, "Engine", "ServiceAccount already exists")
+		return saList.Items[0].Name, nil
+	}
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: rcache.CacheEngineSAPrefix,
+			Namespace:    req.Namespace,
+			Labels:       labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: wafv1alpha1.GroupVersion.String(),
+					Kind:       "Engine",
+					Name:       engine.Name,
+					UID:        engine.UID,
+					Controller: new(true),
+				},
+			},
+		},
+	}
+
+	if err := r.Create(ctx, sa); err != nil {
+		return "", fmt.Errorf("failed to create ServiceAccount for engine %s: %w", engine.Name, err)
+	}
+
+	logInfo(log, req, "Engine", "Created cache client ServiceAccount", "serviceAccount", fmt.Sprintf("%s/%s", req.Namespace, sa.Name))
+	return sa.Name, nil
+}
+
+// ensureCacheToken returns a valid cache client token for the given Engine and
+// the deadline at which the token should be renewed.
+// If the stored token is missing or near expiry, a new one is generated via
+// the Kubernetes TokenRequest API. The token audience encodes the RuleSet
+// being accessed ("coraza-cache:namespace/rulesetName").
+func (r *EngineReconciler) ensureCacheToken(ctx context.Context, log logr.Logger, req ctrl.Request, saName, rulesetName string) (string, time.Time, error) {
+	key := fmt.Sprintf("%s/%s/%s", req.Namespace, req.Name, rulesetName)
+	audience := rcache.Audience(fmt.Sprintf("%s/%s", req.Namespace, rulesetName))
+
+	// Check if we have a valid cached token.
+	if val, ok := r.tokenStore.Load(key); ok {
+		entry := val.(*TokenEntry)
+		if !entry.NeedsRenewal() {
+			logDebug(log, req, "Engine", "Using cached token", "expiresAt", entry.ExpiresAt)
+			return entry.Token, entry.RenewalDeadline(), nil
+		}
+	}
+
+	logInfo(log, req, "Engine", "Generating new cache client token", "serviceAccount", saName)
+
+	tokenReq := &authv1.TokenRequest{
+		Spec: authv1.TokenRequestSpec{
+			Audiences:         []string{audience},
+			ExpirationSeconds: &tokenExpirationSeconds,
+		},
+	}
+
+	result, err := r.kubeClient.CoreV1().ServiceAccounts(req.Namespace).CreateToken(
+		ctx, saName, tokenReq, metav1.CreateOptions{},
+	)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to create token for SA %s/%s: %w", req.Namespace, saName, err)
+	}
+
+	now := time.Now()
+	expiresAt := result.Status.ExpirationTimestamp.Time
+	entry := &TokenEntry{Token: result.Status.Token, IssuedAt: now, ExpiresAt: expiresAt}
+	r.tokenStore.Store(key, entry)
+
+	// Lazily prune expired entries to prevent unbounded growth when
+	// Engines are deleted and never reconciled again.
+	r.pruneExpiredTokens()
+
+	logInfo(log, req, "Engine", "Generated cache client token", "expiresAt", expiresAt)
+	return result.Status.Token, entry.RenewalDeadline(), nil
+}
+
+// pruneExpiredTokens removes all expired entries from the token store.
+func (r *EngineReconciler) pruneExpiredTokens() {
+	now := time.Now()
+	r.tokenStore.Range(func(key, value any) bool {
+		entry := value.(*TokenEntry)
+		if now.After(entry.ExpiresAt) {
+			r.tokenStore.Delete(key)
+		}
+		return true
+	})
+}

--- a/internal/controller/engine_controller_token_test.go
+++ b/internal/controller/engine_controller_token_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenEntry_RenewalDeadline(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		entry    TokenEntry
+		expected time.Time
+	}{
+		{
+			name: "1h token renews at 48min",
+			entry: TokenEntry{
+				IssuedAt:  now,
+				ExpiresAt: now.Add(1 * time.Hour),
+			},
+			expected: now.Add(48 * time.Minute), // 0.8 * 60min
+		},
+		{
+			name: "30min token renews at 24min",
+			entry: TokenEntry{
+				IssuedAt:  now,
+				ExpiresAt: now.Add(30 * time.Minute),
+			},
+			expected: now.Add(24 * time.Minute), // 0.8 * 30min
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deadline := tt.entry.RenewalDeadline()
+			// Allow 1ms tolerance for floating-point duration arithmetic.
+			assert.WithinDuration(t, tt.expected, deadline, time.Millisecond)
+		})
+	}
+}
+
+func TestTokenEntry_NeedsRenewal(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		entry    TokenEntry
+		expected bool
+	}{
+		{
+			name: "fresh token does not need renewal",
+			entry: TokenEntry{
+				IssuedAt:  now,
+				ExpiresAt: now.Add(1 * time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "token at 50% lifetime does not need renewal",
+			entry: TokenEntry{
+				IssuedAt:  now.Add(-30 * time.Minute),
+				ExpiresAt: now.Add(30 * time.Minute), // 1h total
+			},
+			expected: false,
+		},
+		{
+			name: "token at 80% lifetime needs renewal",
+			entry: TokenEntry{
+				IssuedAt:  now.Add(-48 * time.Minute),
+				ExpiresAt: now.Add(12 * time.Minute), // 1h total, 80% elapsed
+			},
+			expected: true,
+		},
+		{
+			name: "expired token needs renewal",
+			entry: TokenEntry{
+				IssuedAt:  now.Add(-2 * time.Hour),
+				ExpiresAt: now.Add(-1 * time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "short-lived token (1h) at 50min does need renewal",
+			entry: TokenEntry{
+				IssuedAt:  now.Add(-50 * time.Minute),
+				ExpiresAt: now.Add(10 * time.Minute), // 1h total
+			},
+			expected: true, // 50/60 = 83% > 80%
+		},
+		{
+			name: "short-lived token (1h) at 40min does not need renewal",
+			entry: TokenEntry{
+				IssuedAt:  now.Add(-40 * time.Minute),
+				ExpiresAt: now.Add(20 * time.Minute), // 1h total
+			},
+			expected: false, // 40/60 = 67% < 80%
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.entry.NeedsRenewal())
+		})
+	}
+}
+
+func TestPruneExpiredTokens(t *testing.T) {
+	r := &EngineReconciler{}
+	now := time.Now()
+
+	// Add some entries: 2 expired, 1 valid. Keyed by namespace/engineName/rulesetName.
+	r.tokenStore.Store("ns1/engine1/ruleset-a", &TokenEntry{
+		Token:     "expired-1",
+		IssuedAt:  now.Add(-10 * 24 * time.Hour),
+		ExpiresAt: now.Add(-5 * 24 * time.Hour),
+	})
+	r.tokenStore.Store("ns2/engine2/ruleset-b", &TokenEntry{
+		Token:     "expired-2",
+		IssuedAt:  now.Add(-2 * 24 * time.Hour),
+		ExpiresAt: now.Add(-1 * time.Hour),
+	})
+	r.tokenStore.Store("ns3/engine3/ruleset-c", &TokenEntry{
+		Token:     "valid",
+		IssuedAt:  now,
+		ExpiresAt: now.Add(1 * time.Hour),
+	})
+
+	r.pruneExpiredTokens()
+
+	_, ok1 := r.tokenStore.Load("ns1/engine1/ruleset-a")
+	_, ok2 := r.tokenStore.Load("ns2/engine2/ruleset-b")
+	_, ok3 := r.tokenStore.Load("ns3/engine3/ruleset-c")
+
+	assert.False(t, ok1, "expired entry ns1/engine1/ruleset-a should be pruned")
+	assert.False(t, ok2, "expired entry ns2/engine2/ruleset-b should be pruned")
+	assert.True(t, ok3, "valid entry ns3/engine3/ruleset-c should remain")
+}
+
+func TestPruneExpiredTokens_EmptyStore(t *testing.T) {
+	r := &EngineReconciler{}
+	// Should not panic on empty store.
+	r.pruneExpiredTokens()
+
+	count := 0
+	r.tokenStore.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 0, count)
+}
+
+func TestPruneExpiredTokens_AllExpired(t *testing.T) {
+	r := &EngineReconciler{}
+	now := time.Now()
+
+	r.tokenStore.Store("ns/e1/rs1", &TokenEntry{
+		Token:     "t1",
+		IssuedAt:  now.Add(-2 * time.Hour),
+		ExpiresAt: now.Add(-1 * time.Hour),
+	})
+	r.tokenStore.Store("ns/e2/rs2", &TokenEntry{
+		Token:     "t2",
+		IssuedAt:  now.Add(-3 * time.Hour),
+		ExpiresAt: now.Add(-30 * time.Minute),
+	})
+
+	r.pruneExpiredTokens()
+
+	count := 0
+	r.tokenStore.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 0, count, "all expired entries should be pruned")
+}
+
+func TestPruneExpiredTokens_NoneExpired(t *testing.T) {
+	r := &EngineReconciler{}
+	now := time.Now()
+
+	r.tokenStore.Store("ns/e1/rs1", &TokenEntry{
+		Token:     "t1",
+		IssuedAt:  now,
+		ExpiresAt: now.Add(1 * time.Hour),
+	})
+	r.tokenStore.Store("ns/e2/rs2", &TokenEntry{
+		Token:     "t2",
+		IssuedAt:  now,
+		ExpiresAt: now.Add(30 * time.Minute),
+	})
+
+	r.pruneExpiredTokens()
+
+	count := 0
+	r.tokenStore.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 2, count, "no entries should be pruned")
+}
+
+func TestCacheClientSALabels(t *testing.T) {
+	labels := cacheClientSALabels("my-engine")
+	assert.Equal(t, "coraza-kubernetes-operator", labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "cache-client", labels["app.kubernetes.io/component"])
+	assert.Equal(t, "my-engine", labels["app.kubernetes.io/instance"])
+
+	// Different engine names produce different labels.
+	labels2 := cacheClientSALabels("other-engine")
+	assert.NotEqual(t, labels["app.kubernetes.io/instance"], labels2["app.kubernetes.io/instance"])
+}

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"fmt"
 
+	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
@@ -51,7 +52,7 @@ const DefaultRuleSetCacheServerPort = 18080
 // -----------------------------------------------------------------------------
 
 // SetupControllers initializes all controllers
-func SetupControllers(mgr ctrl.Manager, rulesetCache *cache.RuleSetCache, envoyClusterName, istioRevision, defaultWasmImage, operatorNamespace string) error {
+func SetupControllers(mgr ctrl.Manager, rulesetCache *cache.RuleSetCache, envoyClusterName, istioRevision string, defaultWasmImage, operatorNamespace string, kubeClient kubernetes.Interface) error {
 	if err := (&RuleSetReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
@@ -65,6 +66,7 @@ func SetupControllers(mgr ctrl.Manager, rulesetCache *cache.RuleSetCache, envoyC
 		Client:                    mgr.GetClient(),
 		Scheme:                    mgr.GetScheme(),
 		Recorder:                  mgr.GetEventRecorder("engine-controller"),
+		kubeClient:                kubeClient,
 		ruleSetCacheServerCluster: envoyClusterName,
 		istioRevision:             istioRevision,
 		defaultWasmImage:          defaultWasmImage,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -43,10 +44,11 @@ import (
 // -----------------------------------------------------------------------------
 
 var (
-	testEnv   *envtest.Environment
-	cfg       *rest.Config
-	k8sClient client.Client
-	scheme    *runtime.Scheme
+	testEnv        *envtest.Environment
+	cfg            *rest.Config
+	k8sClient      client.Client
+	testKubeClient kubernetes.Interface
+	scheme         *runtime.Scheme
 )
 
 // -----------------------------------------------------------------------------
@@ -116,6 +118,13 @@ func TestMain(m *testing.M) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create client: %v\n", err)
+		_ = testEnv.Stop()
+		os.Exit(1)
+	}
+
+	testKubeClient, err = kubernetes.NewForConfig(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create kubernetes clientset: %v\n", err)
 		_ = testEnv.Stop()
 		os.Exit(1)
 	}

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -20,4 +20,4 @@ package defaults
 // DefaultCorazaWasmOCIReference is the built-in default OCI URL for the Coraza WASM
 // plugin when an Engine omits spec.driver.istio.wasm.image. Override at runtime via
 // --default-wasm-image, CORAZA_DEFAULT_WASM_IMAGE, or per-Engine spec.
-const DefaultCorazaWasmOCIReference = "oci://ghcr.io/networking-incubator/coraza-proxy-wasm:1902646ac7391b65be092cdec9b47d29fa5724c7"
+const DefaultCorazaWasmOCIReference = "oci://ghcr.io/networking-incubator/coraza-proxy-wasm:9ca29e4f4cf3a8c1710a7ed7a8ec399b56cb7296"

--- a/internal/rulesets/cache/auth.go
+++ b/internal/rulesets/cache/auth.go
@@ -1,0 +1,200 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	authclient "k8s.io/client-go/kubernetes/typed/authentication/v1"
+)
+
+const (
+	// CacheEngineSAPrefix is the prefix added to ServiceAccount names created for
+	// cache client authentication. The SA name is "coraza-engine-<engineName>".
+	CacheEngineSAPrefix = "coraza-engine-"
+
+	// cacheAudiencePrefix is the prefix for cache server JWT token audiences.
+	// The full audience is "coraza-cache:<namespace>/<rulesetName>".
+	cacheAudiencePrefix = "coraza-cache:"
+
+	// defaultAuthCacheTTL is the default time-to-live for cached authentication results.
+	// Cached entries are evicted after this duration to force re-validation.
+	defaultAuthCacheTTL = 5 * time.Minute
+
+	// maxAuthCacheSize is the maximum number of entries in the auth cache.
+	// This prevents unbounded memory growth if many unique tokens are presented.
+	// In practice, the number of legitimate tokens is bounded by the number of
+	// Engines × RuleSets, which should be well below this limit.
+	maxAuthCacheSize = 10000
+)
+
+// authCacheEntry holds a cached authentication result with its expiry time.
+type authCacheEntry struct {
+	result    *AuthResult
+	expiresAt time.Time
+}
+
+// TokenAuthenticator validates Kubernetes ServiceAccount JWT tokens
+// using the TokenReview API. It caches successful authentication results
+// to avoid calling the TokenReview API on every request.
+// Only successful authentications are cached — failed attempts are never
+// stored, preventing cache poisoning via invalid tokens.
+type TokenAuthenticator struct {
+	tokenReview authclient.TokenReviewInterface
+	cache       sync.Map // map[string]*authCacheEntry (token -> cached result)
+	cacheSize   int64    // current number of cached entries, guarded by cacheMu
+	// cacheMu guards cacheSize and serializes evict-then-store sequences.
+	// sync.Map handles concurrent access to individual entries, but cacheSize
+	// is a plain int64 that must stay in sync with the map. Without this mutex,
+	// concurrent goroutines could race on cacheSize (causing drift) or both
+	// pass the size-limit check and store simultaneously (overshooting the limit).
+	cacheMu  sync.Mutex
+	cacheTTL time.Duration
+}
+
+// Audience returns the audience string for a given cache key (namespace/rulesetName).
+// This audience is embedded in ServiceAccount tokens so the cache server can verify
+// that a token is scoped to the specific RuleSet being accessed.
+func Audience(cacheKey string) string {
+	return cacheAudiencePrefix + cacheKey
+}
+
+// NewTokenAuthenticator creates a TokenAuthenticator that uses the given
+// TokenReview client to validate tokens.
+func NewTokenAuthenticator(tokenReview authclient.TokenReviewInterface) *TokenAuthenticator {
+	return &TokenAuthenticator{
+		tokenReview: tokenReview,
+		cacheTTL:    defaultAuthCacheTTL,
+	}
+}
+
+// AuthResult contains the result of a token authentication attempt.
+type AuthResult struct {
+	// Namespace is the namespace of the authenticated ServiceAccount.
+	Namespace string
+	// Name is the name of the authenticated ServiceAccount.
+	Name string
+}
+
+// Authenticate validates the given JWT token against the Kubernetes TokenReview API.
+// It checks:
+//  1. The token is valid and authenticated
+//  2. The token has the required audience (e.g., "coraza-cache:namespace/rulesetName")
+//  3. The token belongs to a ServiceAccount (system:serviceaccount:namespace:name)
+//
+// Returns the ServiceAccount namespace and name on success.
+func (a *TokenAuthenticator) Authenticate(ctx context.Context, token, audience string) (*AuthResult, error) {
+	// Cache key incorporates the audience to prevent cross-audience cache hits.
+	// Use ":" as separator — it cannot appear in a JWT token (base64url + dots).
+	cacheKey := token + ":" + audience
+
+	// Check cache first to avoid a TokenReview API call on every request.
+	if val, ok := a.cache.Load(cacheKey); ok {
+		entry := val.(*authCacheEntry)
+		if time.Now().Before(entry.expiresAt) {
+			return entry.result, nil
+		}
+		// Expired — atomically remove and decrement counter.
+		a.cacheMu.Lock()
+		if _, loaded := a.cache.LoadAndDelete(cacheKey); loaded {
+			a.cacheSize--
+		}
+		a.cacheMu.Unlock()
+	}
+
+	review := &authv1.TokenReview{
+		Spec: authv1.TokenReviewSpec{
+			Token:     token,
+			Audiences: []string{audience},
+		},
+	}
+
+	result, err := a.tokenReview.Create(ctx, review, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("token review failed: %w", err)
+	}
+
+	if !result.Status.Authenticated {
+		return nil, fmt.Errorf("token not authenticated")
+	}
+
+	// Parse "system:serviceaccount:namespace:name" from the username
+	namespace, name, err := parseServiceAccountUsername(result.Status.User.Username)
+	if err != nil {
+		return nil, err
+	}
+
+	authResult := &AuthResult{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	// Cache the successful result if we haven't exceeded the size limit.
+	// If over limit, evict expired entries first to make room.
+	expiresAt := time.Now().Add(a.cacheTTL)
+
+	a.cacheMu.Lock()
+	if a.cacheSize >= maxAuthCacheSize {
+		a.evictExpiredLocked()
+	}
+	if a.cacheSize < maxAuthCacheSize {
+		a.cache.Store(cacheKey, &authCacheEntry{
+			result:    authResult,
+			expiresAt: expiresAt,
+		})
+		a.cacheSize++
+	}
+	a.cacheMu.Unlock()
+
+	return authResult, nil
+}
+
+// evictExpiredLocked removes expired entries from the cache.
+// Must be called with cacheMu held.
+func (a *TokenAuthenticator) evictExpiredLocked() {
+	now := time.Now()
+	a.cache.Range(func(key, value any) bool {
+		entry := value.(*authCacheEntry)
+		if now.After(entry.expiresAt) {
+			a.cache.Delete(key)
+			a.cacheSize--
+		}
+		return true
+	})
+}
+
+// parseServiceAccountUsername extracts namespace and name from a
+// "system:serviceaccount:<namespace>:<name>" username string.
+func parseServiceAccountUsername(username string) (namespace, name string, err error) {
+	const prefix = "system:serviceaccount:"
+	if !strings.HasPrefix(username, prefix) {
+		return "", "", fmt.Errorf("not a service account token: %s", username)
+	}
+
+	nsName := strings.SplitN(strings.TrimPrefix(username, prefix), ":", 2)
+	if len(nsName) != 2 {
+		return "", "", fmt.Errorf("invalid service account username format: %s", username)
+	}
+
+	return nsName[0], nsName[1], nil
+}

--- a/internal/rulesets/cache/auth_test.go
+++ b/internal/rulesets/cache/auth_test.go
@@ -1,0 +1,417 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	authclient "k8s.io/client-go/kubernetes/typed/authentication/v1"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
+)
+
+// -----------------------------------------------------------------------------
+// Fake TokenReview client for unit tests
+// -----------------------------------------------------------------------------
+
+// fakeTokenReview implements authclient.TokenReviewInterface for unit testing.
+// It only needs Create since that's the sole method on the interface.
+type fakeTokenReview struct {
+	// tokens maps token strings to their authentication result.
+	tokens map[string]fakeTokenResult
+}
+
+type fakeTokenResult struct {
+	authenticated bool
+	username      string
+	audiences     []string
+}
+
+var _ authclient.TokenReviewInterface = &fakeTokenReview{}
+
+func (f *fakeTokenReview) Create(_ context.Context, review *authv1.TokenReview, _ metav1.CreateOptions) (*authv1.TokenReview, error) {
+	result, ok := f.tokens[review.Spec.Token]
+	if !ok {
+		return &authv1.TokenReview{
+			Status: authv1.TokenReviewStatus{Authenticated: false},
+		}, nil
+	}
+
+	// Check audience match if audiences are specified in the review request.
+	if len(review.Spec.Audiences) > 0 {
+		matched := false
+		for _, reqAud := range review.Spec.Audiences {
+			for _, tokenAud := range result.audiences {
+				if reqAud == tokenAud {
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched {
+			return &authv1.TokenReview{
+				Status: authv1.TokenReviewStatus{Authenticated: false},
+			}, nil
+		}
+	}
+
+	return &authv1.TokenReview{
+		Status: authv1.TokenReviewStatus{
+			Authenticated: result.authenticated,
+			User:          authv1.UserInfo{Username: result.username},
+			Audiences:     result.audiences,
+		},
+	}, nil
+}
+
+// newFakeTokenReview creates a fakeTokenReview with preconfigured tokens.
+func newFakeTokenReview(tokens map[string]fakeTokenResult) *fakeTokenReview {
+	return &fakeTokenReview{tokens: tokens}
+}
+
+// newNoopTokenReview creates a fakeTokenReview that rejects all tokens.
+// Used by existing tests that don't exercise authentication.
+func newNoopTokenReview() *fakeTokenReview {
+	return &fakeTokenReview{tokens: map[string]fakeTokenResult{}}
+}
+
+// -----------------------------------------------------------------------------
+// Tests - Token Authenticator
+// -----------------------------------------------------------------------------
+
+func TestTokenAuthenticator_Authenticate(t *testing.T) {
+	testAudience := Audience("test-ns/my-ruleset")
+
+	fake := newFakeTokenReview(map[string]fakeTokenResult{
+		"valid-token": {
+			authenticated: true,
+			username:      "system:serviceaccount:test-ns:coraza-engine-my-engine",
+			audiences:     []string{testAudience},
+		},
+		"wrong-audience-token": {
+			authenticated: true,
+			username:      "system:serviceaccount:test-ns:coraza-engine-my-engine",
+			audiences:     []string{"wrong-audience"},
+		},
+		"not-sa-token": {
+			authenticated: true,
+			username:      "admin",
+			audiences:     []string{testAudience},
+		},
+	})
+
+	auth := NewTokenAuthenticator(fake)
+	ctx := context.Background()
+
+	t.Run("valid token", func(t *testing.T) {
+		result, err := auth.Authenticate(ctx, "valid-token", testAudience)
+		require.NoError(t, err)
+		assert.Equal(t, "test-ns", result.Namespace)
+		assert.Equal(t, "coraza-engine-my-engine", result.Name)
+	})
+
+	t.Run("unknown token", func(t *testing.T) {
+		_, err := auth.Authenticate(ctx, "unknown-token", testAudience)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not authenticated")
+	})
+
+	t.Run("wrong audience", func(t *testing.T) {
+		_, err := auth.Authenticate(ctx, "wrong-audience-token", testAudience)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not authenticated")
+	})
+
+	t.Run("not a service account", func(t *testing.T) {
+		_, err := auth.Authenticate(ctx, "not-sa-token", testAudience)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a service account")
+	})
+}
+
+func TestParseServiceAccountUsername(t *testing.T) {
+	tests := []struct {
+		username      string
+		wantNamespace string
+		wantName      string
+		wantErr       bool
+	}{
+		{
+			username:      "system:serviceaccount:default:coraza-engine-my-engine",
+			wantNamespace: "default",
+			wantName:      "coraza-engine-my-engine",
+		},
+		{
+			username:      "system:serviceaccount:kube-system:coraza-engine-test",
+			wantNamespace: "kube-system",
+			wantName:      "coraza-engine-test",
+		},
+		{
+			username: "admin",
+			wantErr:  true,
+		},
+		{
+			username: "system:serviceaccount:",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.username, func(t *testing.T) {
+			ns, name, err := parseServiceAccountUsername(tt.username)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantNamespace, ns)
+			assert.Equal(t, tt.wantName, name)
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Tests - Auth Cache Behavior
+// -----------------------------------------------------------------------------
+
+// countingTokenReview wraps fakeTokenReview and counts API calls.
+type countingTokenReview struct {
+	inner    *fakeTokenReview
+	apiCalls int
+}
+
+func (c *countingTokenReview) Create(ctx context.Context, review *authv1.TokenReview, opts metav1.CreateOptions) (*authv1.TokenReview, error) {
+	c.apiCalls++
+	return c.inner.Create(ctx, review, opts)
+}
+
+func TestTokenAuthenticator_CachesSuccessfulResults(t *testing.T) {
+	testAudience := Audience("test-ns/my-ruleset")
+	inner := newFakeTokenReview(map[string]fakeTokenResult{
+		"valid-token": {
+			authenticated: true,
+			username:      "system:serviceaccount:test-ns:coraza-engine-my-engine",
+			audiences:     []string{testAudience},
+		},
+	})
+	counting := &countingTokenReview{inner: inner}
+	auth := NewTokenAuthenticator(counting)
+	ctx := context.Background()
+
+	// First call should hit the API.
+	result1, err := auth.Authenticate(ctx, "valid-token", testAudience)
+	require.NoError(t, err)
+	assert.Equal(t, "test-ns", result1.Namespace)
+	assert.Equal(t, 1, counting.apiCalls)
+
+	// Second call should use cache, not hit API.
+	result2, err := auth.Authenticate(ctx, "valid-token", testAudience)
+	require.NoError(t, err)
+	assert.Equal(t, "test-ns", result2.Namespace)
+	assert.Equal(t, 1, counting.apiCalls, "second call should use cache")
+}
+
+func TestTokenAuthenticator_DoesNotCacheFailures(t *testing.T) {
+	inner := newFakeTokenReview(map[string]fakeTokenResult{})
+	counting := &countingTokenReview{inner: inner}
+	auth := NewTokenAuthenticator(counting)
+	ctx := context.Background()
+	testAudience := Audience("test-ns/my-ruleset")
+
+	// First call fails — should hit API.
+	_, err := auth.Authenticate(ctx, "bad-token", testAudience)
+	require.Error(t, err)
+	assert.Equal(t, 1, counting.apiCalls)
+
+	// Second call should also hit API (failures not cached).
+	_, err = auth.Authenticate(ctx, "bad-token", testAudience)
+	require.Error(t, err)
+	assert.Equal(t, 2, counting.apiCalls, "failed auth should not be cached")
+}
+
+func TestTokenAuthenticator_CacheExpiry(t *testing.T) {
+	testAudience := Audience("test-ns/my-ruleset")
+	inner := newFakeTokenReview(map[string]fakeTokenResult{
+		"valid-token": {
+			authenticated: true,
+			username:      "system:serviceaccount:test-ns:coraza-engine-my-engine",
+			audiences:     []string{testAudience},
+		},
+	})
+	counting := &countingTokenReview{inner: inner}
+	auth := NewTokenAuthenticator(counting)
+	// Use a very short TTL so we can test expiry.
+	auth.cacheTTL = 10 * time.Millisecond
+	ctx := context.Background()
+
+	// First call populates cache.
+	_, err := auth.Authenticate(ctx, "valid-token", testAudience)
+	require.NoError(t, err)
+	assert.Equal(t, 1, counting.apiCalls)
+
+	// Wait for cache to expire.
+	time.Sleep(20 * time.Millisecond)
+
+	// Third call should hit API again after expiry.
+	_, err = auth.Authenticate(ctx, "valid-token", testAudience)
+	require.NoError(t, err)
+	assert.Equal(t, 2, counting.apiCalls, "expired cache entry should trigger new API call")
+}
+
+func TestTokenAuthenticator_CacheSizeLimit(t *testing.T) {
+	testAudience := Audience("ns/my-ruleset")
+	// Create many unique valid tokens.
+	tokens := make(map[string]fakeTokenResult)
+	for i := 0; i < maxAuthCacheSize+100; i++ {
+		token := fmt.Sprintf("token-%d", i)
+		tokens[token] = fakeTokenResult{
+			authenticated: true,
+			username:      fmt.Sprintf("system:serviceaccount:ns:coraza-engine-eng-%d", i),
+			audiences:     []string{testAudience},
+		}
+	}
+	inner := newFakeTokenReview(tokens)
+	auth := NewTokenAuthenticator(inner)
+	ctx := context.Background()
+
+	// Authenticate more tokens than the cache can hold.
+	for i := 0; i < maxAuthCacheSize+100; i++ {
+		token := fmt.Sprintf("token-%d", i)
+		_, err := auth.Authenticate(ctx, token, testAudience)
+		require.NoError(t, err)
+	}
+
+	// Cache size should not exceed the limit.
+	auth.cacheMu.Lock()
+	size := auth.cacheSize
+	auth.cacheMu.Unlock()
+	assert.LessOrEqual(t, size, int64(maxAuthCacheSize), "cache size must not exceed limit")
+}
+
+// -----------------------------------------------------------------------------
+// Tests - Server Authentication Integration
+// -----------------------------------------------------------------------------
+
+func TestServer_HandleRules_Authentication(t *testing.T) {
+	c := NewRuleSetCache()
+	c.Put("test-ns/my-ruleset", "SecRule test", nil)
+
+	rulesetAudience := Audience("test-ns/my-ruleset")
+
+	fake := newFakeTokenReview(map[string]fakeTokenResult{
+		"valid-token": {
+			authenticated: true,
+			username:      "system:serviceaccount:test-ns:coraza-engine-my-engine",
+			audiences:     []string{rulesetAudience},
+		},
+		"wrong-ns-token": {
+			authenticated: true,
+			username:      "system:serviceaccount:other-ns:coraza-engine-other-engine",
+			audiences:     []string{rulesetAudience},
+		},
+		"wrong-audience-token": {
+			authenticated: true,
+			username:      "system:serviceaccount:test-ns:coraza-engine-my-engine",
+			audiences:     []string{Audience("test-ns/other-ruleset")},
+		},
+	})
+
+	logger := utils.NewTestLogger(t)
+	server := NewServer(c, testServerAddr, logger, nil, fake)
+
+	t.Run("missing authorization header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/rules/test-ns/my-ruleset", nil)
+		w := httptest.NewRecorder()
+		server.handleRules(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("invalid bearer token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/rules/test-ns/my-ruleset", nil)
+		req.Header.Set("Authorization", "Bearer invalid-token")
+		w := httptest.NewRecorder()
+		server.handleRules(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("valid token for correct ruleset", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/rules/test-ns/my-ruleset", nil)
+		req.Header.Set("Authorization", "Bearer valid-token")
+		w := httptest.NewRecorder()
+		server.handleRules(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response RuleSetEntry
+		err := json.NewDecoder(w.Body).Decode(&response)
+		require.NoError(t, err)
+		assert.Equal(t, "SecRule test", response.Rules)
+	})
+
+	t.Run("token from wrong namespace", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/rules/test-ns/my-ruleset", nil)
+		req.Header.Set("Authorization", "Bearer wrong-ns-token")
+		w := httptest.NewRecorder()
+		server.handleRules(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("token with wrong audience", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/rules/test-ns/my-ruleset", nil)
+		req.Header.Set("Authorization", "Bearer wrong-audience-token")
+		w := httptest.NewRecorder()
+		server.handleRules(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("valid token for latest endpoint", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/rules/test-ns/my-ruleset/latest", nil)
+		req.Header.Set("Authorization", "Bearer valid-token")
+		w := httptest.NewRecorder()
+		server.handleRules(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response LatestResponse
+		err := json.NewDecoder(w.Body).Decode(&response)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.UUID)
+	})
+
+	t.Run("method not allowed still works without auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/rules/test-ns/my-ruleset", nil)
+		w := httptest.NewRecorder()
+		server.handleRules(w, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("empty path still works without auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/rules/", nil)
+		w := httptest.NewRecorder()
+		server.handleRules(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}

--- a/internal/rulesets/cache/server.go
+++ b/internal/rulesets/cache/server.go
@@ -22,12 +22,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
+	authclient "k8s.io/client-go/kubernetes/typed/authentication/v1"
 )
 
 // -----------------------------------------------------------------------------
@@ -83,13 +83,15 @@ type LatestResponse struct {
 // ruleSetCacheServer provides HTTP endpoints for accessing cached rulesets
 type ruleSetCacheServer struct {
 	cache  *RuleSetCache
+	auth   *TokenAuthenticator
 	srv    *http.Server
 	logger logr.Logger
 	gc     GarbageCollectionConfig
 }
 
 // NewServer creates a new RuleSetCacheServer instance.
-func NewServer(cache *RuleSetCache, addr string, logger logr.Logger, gc *GarbageCollectionConfig) *ruleSetCacheServer {
+// The tokenReview client is used to validate ServiceAccount JWT tokens on incoming requests.
+func NewServer(cache *RuleSetCache, addr string, logger logr.Logger, gc *GarbageCollectionConfig, tokenReview authclient.TokenReviewInterface) *ruleSetCacheServer {
 	gcConfig := DefaultGC()
 	if gc != nil {
 		gcConfig = *gc
@@ -97,6 +99,7 @@ func NewServer(cache *RuleSetCache, addr string, logger logr.Logger, gc *Garbage
 
 	s := &ruleSetCacheServer{
 		cache:  cache,
+		auth:   NewTokenAuthenticator(tokenReview),
 		logger: logger,
 		gc:     gcConfig,
 	}
@@ -119,17 +122,10 @@ func NewServer(cache *RuleSetCache, addr string, logger logr.Logger, gc *Garbage
 
 // Start the cache server.
 func (s *ruleSetCacheServer) Start(ctx context.Context) error {
-	ln, err := net.Listen("tcp", s.srv.Addr)
-	if err != nil {
-		return fmt.Errorf("cache server listen: %w", err)
-	}
-
-	go s.rungc(ctx)
-
 	errChan := make(chan error, 1)
 	go func() {
 		s.logger.Info("Starting ruleset cache server", "addr", s.srv.Addr)
-		if err := s.srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		if err := s.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errChan <- err
 		}
 	}()
@@ -176,12 +172,66 @@ func (s *ruleSetCacheServer) handleRules(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if cacheKey, ok := strings.CutSuffix(path, "/latest"); ok {
+	// Determine the cache key (strip /latest suffix if present).
+	cacheKey := path
+	isLatest := false
+	if stripped, ok := strings.CutSuffix(path, "/latest"); ok {
+		cacheKey = stripped
+		isLatest = true
+	}
+
+	// Authenticate: the token audience must match the requested RuleSet, and
+	// the SA namespace must match the cache key namespace.
+	if err := s.authenticateRequest(r, cacheKey); err != nil {
+		s.logger.Info("Authentication failed", "cacheKey", cacheKey, "error", err)
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	if isLatest {
 		s.handleLatest(w, r, cacheKey)
 		return
 	}
 
-	s.handleGetRules(w, r, path)
+	s.handleGetRules(w, r, cacheKey)
+}
+
+// authenticateRequest validates the Bearer token from the request and checks
+// that the ServiceAccount namespace matches the cache key namespace.
+// The audience-scoped TokenReview ensures the token is authorized for the
+// specific RuleSet being accessed (audience = "coraza-cache:namespace/rulesetName").
+func (s *ruleSetCacheServer) authenticateRequest(r *http.Request, cacheKey string) error {
+	token := extractBearerToken(r)
+	if token == "" {
+		return fmt.Errorf("missing bearer token")
+	}
+
+	audience := Audience(cacheKey)
+	result, err := s.auth.Authenticate(r.Context(), token, audience)
+	if err != nil {
+		return err
+	}
+
+	// Extract the namespace from the cache key and verify the SA lives in it.
+	keyNS, _, ok := strings.Cut(cacheKey, "/")
+	if !ok {
+		return fmt.Errorf("invalid cache key format: %s", cacheKey)
+	}
+	if result.Namespace != keyNS {
+		return fmt.Errorf("service account namespace %s does not match cache key namespace %s", result.Namespace, keyNS)
+	}
+
+	return nil
+}
+
+// extractBearerToken extracts the token from the Authorization header.
+func extractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(auth) > len(prefix) && strings.EqualFold(auth[:len(prefix)], prefix) {
+		return auth[len(prefix):]
+	}
+	return ""
 }
 
 func (s *ruleSetCacheServer) handleLatest(w http.ResponseWriter, _ *http.Request, cacheKey string) {

--- a/internal/rulesets/cache/server.go
+++ b/internal/rulesets/cache/server.go
@@ -120,8 +120,10 @@ func NewServer(cache *RuleSetCache, addr string, logger logr.Logger, gc *Garbage
 	return s
 }
 
-// Start the cache server.
+// Start the cache server and the GC loop. Both are stopped when ctx is cancelled.
 func (s *ruleSetCacheServer) Start(ctx context.Context) error {
+	go s.rungc(ctx)
+
 	errChan := make(chan error, 1)
 	go func() {
 		s.logger.Info("Starting ruleset cache server", "addr", s.srv.Addr)

--- a/internal/rulesets/cache/server_test.go
+++ b/internal/rulesets/cache/server_test.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,7 @@ var (
 func TestNewServer(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
-	server := NewServer(cache, testServerAddr, logger, nil)
+	server := NewServer(cache, testServerAddr, logger, nil, newNoopTokenReview())
 	require.NotNil(t, server)
 	assert.Equal(t, testServerAddr, server.srv.Addr)
 	assert.Equal(t, MaxHeaderSize, server.srv.MaxHeaderBytes)
@@ -52,7 +53,7 @@ func TestNewServer(t *testing.T) {
 func TestServer_StartAndStop(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
-	server := NewServer(cache, testServerAddr, logger, nil)
+	server := NewServer(cache, testServerAddr, logger, nil, newNoopTokenReview())
 
 	t.Log("Starting server in background goroutine")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -69,7 +70,7 @@ func TestServer_StartAndStop(t *testing.T) {
 	t.Log("Waiting for server to shut down")
 	select {
 	case err := <-errChan:
-		if err != nil && err != http.ErrServerClosed && err.Error() != "context canceled" {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, context.Canceled) {
 			t.Errorf("Unexpected error from server: %v", err)
 		}
 	case <-time.After(2 * time.Second):
@@ -77,18 +78,37 @@ func TestServer_StartAndStop(t *testing.T) {
 	}
 }
 
+// testTokenReview returns a fakeTokenReview that authenticates "test-token" as
+// system:serviceaccount:default:coraza-engine-test-engine. Used by handler tests.
+func testTokenReview() *fakeTokenReview {
+	return newFakeTokenReview(map[string]fakeTokenResult{
+		"test-token": {
+			authenticated: true,
+			username:      "system:serviceaccount:default:coraza-engine-test-engine",
+			audiences:     []string{Audience("default/test-instance")},
+		},
+	})
+}
+
+// authenticatedRequest creates an HTTP request with a valid test Bearer token.
+func authenticatedRequest(path string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	return req
+}
+
 func TestServer_HandleGetRules_Success(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
-	server := NewServer(cache, testServerAddr, logger, nil)
+	server := NewServer(cache, testServerAddr, logger, nil, testTokenReview())
 
 	t.Log("Adding test ruleset to cache")
 	testRules := "SecRule REQUEST_URI \"@contains /admin\" \"id:1,deny\""
 
-	cache.Put("test-instance", testRules, dataFile)
+	cache.Put("default/test-instance", testRules, dataFile)
 
 	t.Log("Requesting ruleset from server")
-	req := httptest.NewRequest(http.MethodGet, "/rules/test-instance", nil)
+	req := authenticatedRequest("/rules/default/test-instance")
 	w := httptest.NewRecorder()
 	server.handleRules(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -107,9 +127,10 @@ func TestServer_HandleGetRules_Success(t *testing.T) {
 
 	t.Log("do with null datafile")
 	w = httptest.NewRecorder()
-	cache.Put("test-instance", testRules, nil)
+	cache.Put("default/test-instance", testRules, nil)
 
 	t.Log("Requesting ruleset from server")
+	req = authenticatedRequest("/rules/default/test-instance")
 	server.handleRules(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -129,13 +150,13 @@ func TestServer_HandleGetRules_Success(t *testing.T) {
 func TestServer_HandleLatest_Success(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
-	server := NewServer(cache, testServerAddr, logger, nil)
+	server := NewServer(cache, testServerAddr, logger, nil, testTokenReview())
 
 	t.Log("Adding test ruleset to cache")
-	cache.Put("test-instance", "test rules", dataFile)
+	cache.Put("default/test-instance", "test rules", dataFile)
 
 	t.Log("Requesting latest from server")
-	req := httptest.NewRequest(http.MethodGet, "/rules/test-instance/latest", nil)
+	req := authenticatedRequest("/rules/default/test-instance/latest")
 	w := httptest.NewRecorder()
 	server.handleRules(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -156,13 +177,13 @@ func TestServer_HandleLatest_Success(t *testing.T) {
 func TestServer_HandleRules_UUIDConsistency(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
-	server := NewServer(cache, testServerAddr, logger, nil)
+	server := NewServer(cache, testServerAddr, logger, nil, testTokenReview())
 
 	t.Log("Adding test ruleset to cache")
-	cache.Put("test-instance", "test rules", nil)
+	cache.Put("default/test-instance", "test rules", nil)
 
 	t.Log("Requesting latest and rules endpoints")
-	req1 := httptest.NewRequest(http.MethodGet, "/rules/test-instance/latest", nil)
+	req1 := authenticatedRequest("/rules/default/test-instance/latest")
 	w1 := httptest.NewRecorder()
 	server.handleRules(w1, req1)
 
@@ -171,7 +192,7 @@ func TestServer_HandleRules_UUIDConsistency(t *testing.T) {
 	require.NoError(t, json.NewDecoder(w1.Body).Decode(&latestResp))
 
 	t.Log("Requesting rules endpoint")
-	req2 := httptest.NewRequest(http.MethodGet, "/rules/test-instance", nil)
+	req2 := authenticatedRequest("/rules/default/test-instance")
 	w2 := httptest.NewRecorder()
 	server.handleRules(w2, req2)
 
@@ -194,7 +215,7 @@ func TestServer_GCByAge(t *testing.T) {
 		MaxAge:     100 * time.Millisecond,
 		MaxSize:    1024 * 1024 * 1024, // 1GB - disable size-based pruning
 	}
-	server := NewServer(cache, testServerAddr, logger, gc)
+	server := NewServer(cache, testServerAddr, logger, gc, newNoopTokenReview())
 
 	modifiedData := make(map[string][]byte)
 	maps.Copy(modifiedData, testDataFile)
@@ -257,7 +278,7 @@ func TestServer_GCBySize(t *testing.T) {
 		MaxAge:     24 * time.Hour, // disable age-based pruning
 		MaxSize:    50,
 	}
-	server := NewServer(cache, ":0", logger, gc)
+	server := NewServer(cache, ":0", logger, gc, newNoopTokenReview())
 
 	t.Log("Adding multiple versions for some instances to create prunable entries")
 	cache.Put("instance1", "instance1 old - 27 chars...", nil)
@@ -318,7 +339,7 @@ func TestServer_GCEmptyCache(t *testing.T) {
 		MaxAge:     100 * time.Millisecond,
 		MaxSize:    100,
 	}
-	server := NewServer(cache, ":0", logger, gc)
+	server := NewServer(cache, ":0", logger, gc, newNoopTokenReview())
 
 	t.Log("Starting GC on empty cache")
 	ctx := t.Context()
@@ -334,8 +355,8 @@ func TestServer_GCEmptyCache(t *testing.T) {
 func TestServer_HandleGetRules_NotFound(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
-	server := NewServer(cache, testServerAddr, logger, nil)
-	req := httptest.NewRequest(http.MethodGet, "/rules/non-existent", nil)
+	server := NewServer(cache, testServerAddr, logger, nil, testTokenReview())
+	req := authenticatedRequest("/rules/default/test-instance")
 	w := httptest.NewRecorder()
 	server.handleRules(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -344,7 +365,7 @@ func TestServer_HandleGetRules_NotFound(t *testing.T) {
 func TestServer_HandleGetRules_MissingInstance(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
-	server := NewServer(cache, testServerAddr, logger, nil)
+	server := NewServer(cache, testServerAddr, logger, nil, newNoopTokenReview())
 	req := httptest.NewRequest(http.MethodGet, "/rules/", nil)
 	w := httptest.NewRecorder()
 	server.handleRules(w, req)
@@ -354,8 +375,8 @@ func TestServer_HandleGetRules_MissingInstance(t *testing.T) {
 func TestServer_HandleLatest_NotFound(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
-	server := NewServer(cache, testServerAddr, logger, nil)
-	req := httptest.NewRequest(http.MethodGet, "/rules/non-existent/latest", nil)
+	server := NewServer(cache, testServerAddr, logger, nil, testTokenReview())
+	req := authenticatedRequest("/rules/default/test-instance/latest")
 	w := httptest.NewRecorder()
 	server.handleRules(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -364,7 +385,7 @@ func TestServer_HandleLatest_NotFound(t *testing.T) {
 func TestServer_HandleRules_MethodNotAllowed(t *testing.T) {
 	cache := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
-	server := NewServer(cache, testServerAddr, logger, nil)
+	server := NewServer(cache, testServerAddr, logger, nil, newNoopTokenReview())
 	methods := []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch}
 	for _, method := range methods {
 		t.Run(method, func(t *testing.T) {

--- a/test/framework/assertions.go
+++ b/test/framework/assertions.go
@@ -129,15 +129,53 @@ func (s *Scenario) ExpectEngineGateways(namespace, name string, expectedNames []
 
 // ExpectWasmPluginExists polls until a WasmPlugin with the given name exists
 // in the namespace.
-func (s *Scenario) ExpectWasmPluginExists(namespace, name string) {
+func (s *Scenario) ExpectWasmPluginExists(namespace, name string) *unstructured.Unstructured {
 	s.T.Helper()
 	s.T.Logf("Waiting for WasmPlugin %s/%s to exist", namespace, name)
+	var err error
+	output := &unstructured.Unstructured{}
 	require.Eventually(s.T, func() bool {
-		_, err := s.F.DynamicClient.Resource(WasmPluginGVR).Namespace(namespace).Get(
+		output, err = s.F.DynamicClient.Resource(WasmPluginGVR).Namespace(namespace).Get(
 			s.T.Context(), name, metav1.GetOptions{},
 		)
 		return err == nil
 	}, DefaultTimeout, DefaultInterval, "WasmPlugin %s/%s should exist", namespace, name)
+	return output
+}
+
+// ExpectServiceAccountExists polls until a ServiceAccount with the given name exists
+// in the namespace
+func (s *Scenario) ExpectServiceAccountExists(namespace, name string) {
+	s.T.Helper()
+	s.T.Logf("Waiting for ServiceAccount %s/%s to exist", namespace, name)
+	require.Eventually(s.T, func() bool {
+		_, err := s.F.KubeClient.CoreV1().ServiceAccounts(namespace).Get(
+			s.T.Context(), name, metav1.GetOptions{},
+		)
+		return err == nil
+	}, DefaultTimeout, DefaultInterval, "ServiceAccount %s/%s should exist", namespace, name)
+}
+
+// ExpectCacheClientSAExists polls until a cache client ServiceAccount exists
+// for the given engine (matched by app.kubernetes.io/instance label).
+// Returns the discovered ServiceAccount name.
+func (s *Scenario) ExpectCacheClientSAExists(namespace, engineName string) string {
+	s.T.Helper()
+	s.T.Logf("Waiting for cache client ServiceAccount for engine %s/%s", namespace, engineName)
+	var saName string
+	require.Eventually(s.T, func() bool {
+		list, err := s.F.KubeClient.CoreV1().ServiceAccounts(namespace).List(
+			s.T.Context(), metav1.ListOptions{
+				LabelSelector: "app.kubernetes.io/component=cache-client,app.kubernetes.io/instance=" + engineName,
+			},
+		)
+		if err != nil || len(list.Items) == 0 {
+			return false
+		}
+		saName = list.Items[0].Name
+		return true
+	}, DefaultTimeout, DefaultInterval, "cache client SA for engine %s/%s should exist", namespace, engineName)
+	return saName
 }
 
 // ExpectResourceGone polls until the specified resource no longer exists.

--- a/test/framework/networking.go
+++ b/test/framework/networking.go
@@ -277,7 +277,195 @@ func (g *GatewayProxy) ExpectHeaderStatus(path string, headers map[string]string
 }
 
 // -----------------------------------------------------------------------------
-// Shared Port-Forward Loop
+// Cache Server
+// -----------------------------------------------------------------------------
+
+// cacheServerPort is the port the cache server listens on inside the operator pod.
+const cacheServerPort = 18080
+
+// CacheServerProxy manages a port-forward to the operator's cache server and
+// provides HTTP helpers for testing cache authentication.
+type CacheServerProxy struct {
+	s         *Scenario
+	localPort string
+	baseURL   string
+	httpc     *http.Client
+	cancel    context.CancelFunc
+}
+
+// ProxyToCacheServer sets up a SPDY port-forward to the operator's cache
+// server pod (found by label control-plane=coraza-controller-manager in
+// operatorNamespace) and returns a CacheServerProxy for making HTTP requests.
+// The port-forward is automatically cleaned up when the scenario ends.
+func (s *Scenario) ProxyToCacheServer(operatorNamespace string) *CacheServerProxy {
+	s.T.Helper()
+	port := AllocatePort()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	proxy := &CacheServerProxy{
+		s:         s,
+		localPort: port,
+		baseURL:   fmt.Sprintf("http://localhost:%s", port),
+		httpc:     &http.Client{Timeout: 10 * time.Second},
+		cancel:    cancel,
+	}
+
+	go proxy.maintain(ctx, operatorNamespace)
+
+	require.Eventually(s.T, func() bool {
+		resp, err := proxy.httpc.Get(proxy.baseURL + "/")
+		if err != nil {
+			return false
+		}
+		defer func() {
+			_, _ = io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+		}()
+		return true
+	}, DefaultTimeout, time.Second,
+		"port-forward to cache server (localhost:%s) not ready", port,
+	)
+
+	s.OnCleanup(func() {
+		cancel()
+	})
+
+	s.T.Logf("Port-forwarding cache server -> localhost:%s", port)
+	return proxy
+}
+
+// URL returns the full URL for a given path through the proxy.
+func (c *CacheServerProxy) URL(path string) string {
+	return c.baseURL + path
+}
+
+// GetWithBearer makes a GET request with an optional Bearer token.
+func (c *CacheServerProxy) GetWithBearer(path, token string) *HTTPResult {
+	req, err := http.NewRequest(http.MethodGet, c.URL(path), nil)
+	if err != nil {
+		return &HTTPResult{Err: err}
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return c.do(req)
+}
+
+func (c *CacheServerProxy) do(req *http.Request) *HTTPResult {
+	resp, err := c.httpc.Do(req)
+	if err != nil {
+		return &HTTPResult{Err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return &HTTPResult{
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header,
+		Body:       body,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Cache Server - Port Forward Management
+// -----------------------------------------------------------------------------
+
+func (c *CacheServerProxy) logf(format string, args ...any) {
+	if c.s.T.Context().Err() != nil {
+		return
+	}
+	c.s.T.Logf(format, args...)
+}
+
+func (c *CacheServerProxy) maintain(ctx context.Context, operatorNamespace string) {
+	backoff := time.Second
+	const maxBackoff = 10 * time.Second
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		start := time.Now()
+		err := c.runPortForward(ctx, operatorNamespace)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			c.logf("cache server port-forward restarting (backoff %s): %v", backoff, err)
+		}
+
+		if time.Since(start) > maxBackoff {
+			backoff = time.Second
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		backoff = min(backoff*2, maxBackoff)
+	}
+}
+
+func (c *CacheServerProxy) runPortForward(ctx context.Context, operatorNamespace string) error {
+	const labelSelector = "control-plane=coraza-controller-manager"
+
+	pods, err := c.s.F.KubeClient.CoreV1().Pods(operatorNamespace).List(
+		ctx,
+		metav1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return fmt.Errorf("list pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no pods matching %s in %s", labelSelector, operatorNamespace)
+	}
+
+	podName := pods.Items[0].Name
+
+	transport, upgrader, err := spdy.RoundTripperFor(c.s.F.RestConfig)
+	if err != nil {
+		return fmt.Errorf("create SPDY transport: %w", err)
+	}
+
+	pfURL := c.s.F.KubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(operatorNamespace).
+		Name(podName).
+		SubResource("portforward").
+		URL()
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", pfURL)
+
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			close(stopCh)
+		case <-done:
+		}
+	}()
+
+	pf, err := portforward.New(dialer,
+		[]string{fmt.Sprintf("%s:%d", c.localPort, cacheServerPort)},
+		stopCh, nil, io.Discard, io.Discard,
+	)
+	if err != nil {
+		close(done)
+		return fmt.Errorf("create port-forwarder: %w", err)
+	}
+
+	err = pf.ForwardPorts()
+	close(done)
+	return err
+}
+
+// -----------------------------------------------------------------------------
+// Gateway - Port Forward Management
 // -----------------------------------------------------------------------------
 
 // portForwardLoop implements the maintain/reconnect loop and port-forward

--- a/test/framework/resources.go
+++ b/test/framework/resources.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -352,6 +353,26 @@ func (s *Scenario) CreateConfigMap(namespace, name, rules string) {
 			s.T.Logf("cleanup: failed to delete ConfigMap %s/%s: %v", namespace, name, err)
 		}
 	})
+}
+
+// CreateCacheServerToken creates a ServiceAccount token via TokenRequest for the cache server client and returns the token string.
+func (s *Scenario) CreateCacheServerToken(namespace, name, audience string) string {
+	s.T.Helper()
+	ctx := s.T.Context()
+
+	tokenReq := &authv1.TokenRequest{
+		Spec: authv1.TokenRequestSpec{
+			Audiences: []string{audience},
+		},
+	}
+	result, err := s.F.KubeClient.CoreV1().ServiceAccounts(namespace).CreateToken(
+		ctx, name, tokenReq, metav1.CreateOptions{},
+	)
+	require.NoError(s.T, err, "create token for SA %s/%s", namespace, name)
+
+	s.T.Logf("Created token for ServiceAccount: %s/%s", namespace, name)
+	return result.Status.Token
+
 }
 
 // CreateGateway creates a Gateway resource and registers cleanup.

--- a/test/integration/cache_auth_test.go
+++ b/test/integration/cache_auth_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
+	"github.com/networking-incubator/coraza-kubernetes-operator/test/framework"
+)
+
+// TestCacheServerAuthentication validates that the cache server properly
+// authenticates requests using Kubernetes ServiceAccount JWT tokens.
+func TestCacheServerAuthentication(t *testing.T) {
+	t.Parallel()
+	s := fw.NewScenario(t)
+
+	ns := s.GenerateNamespace("cache-auth")
+
+	s.Step("create gateway")
+	s.CreateGateway(ns, "auth-gateway")
+	s.ExpectGatewayProgrammed(ns, "auth-gateway")
+
+	s.Step("deploy rules and create ruleset")
+	s.CreateConfigMap(ns, "test-rules", `SecRuleEngine On`)
+	s.CreateRuleSet(ns, "auth-test", []string{"test-rules"})
+	s.ExpectRuleSetReady(ns, "auth-test")
+
+	s.Step("create engine")
+	s.CreateEngine(ns, "auth-test", framework.EngineOpts{
+		RuleSetName: "auth-test",
+		GatewayName: "auth-gateway",
+	})
+
+	s.Step("verify cache client ServiceAccount was created")
+	saName := s.ExpectCacheClientSAExists(ns, "auth-test")
+
+	s.Step("port-forward to operator cache server")
+	cs := s.ProxyToCacheServer(operatorNamespace)
+
+	s.Step("verify that wasmplugin was created with a valid token")
+	wasmplugin := s.ExpectWasmPluginExists(ns, "coraza-engine-auth-test")
+	validToken, found, err := unstructured.NestedString(wasmplugin.Object, "spec", "pluginConfig", "cache_token")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotEmpty(t, validToken)
+
+	s.Step("create valid SA token with correct audience")
+	cacheKey := fmt.Sprintf("%s/auth-test", ns)
+
+	s.Step("test: valid token returns cached rules")
+	result := cs.GetWithBearer("/rules/"+cacheKey, validToken)
+	require.NoError(t, result.Err)
+	require.Equal(t, http.StatusOK, result.StatusCode,
+		"valid token should return 200, got %d: %s", result.StatusCode, string(result.Body))
+
+	var entry cache.RuleSetEntry
+	require.NoError(t, json.Unmarshal(result.Body, &entry))
+	assert.NotEmpty(t, entry.UUID)
+	assert.Contains(t, entry.Rules, "SecRuleEngine On")
+
+	s.Step("test: valid token works for /latest endpoint")
+	result = cs.GetWithBearer("/rules/"+cacheKey+"/latest", validToken)
+	require.NoError(t, result.Err)
+	require.Equal(t, http.StatusOK, result.StatusCode)
+	var latest cache.LatestResponse
+	require.NoError(t, json.Unmarshal(result.Body, &latest))
+	assert.Equal(t, entry.UUID, latest.UUID)
+
+	s.Step("test: missing token returns 403")
+	result = cs.GetWithBearer("/rules/"+cacheKey, "")
+	require.NoError(t, result.Err)
+	assert.Equal(t, http.StatusForbidden, result.StatusCode)
+
+	s.Step("test: invalid/garbage token returns 403")
+	result = cs.GetWithBearer("/rules/"+cacheKey, "garbage-token-value")
+	require.NoError(t, result.Err)
+	assert.Equal(t, http.StatusForbidden, result.StatusCode)
+
+	s.Step("test: valid token for wrong ruleset returns 403")
+	s.CreateConfigMap(ns, "other-rules", `SecRuleEngine Off`)
+	s.CreateRuleSet(ns, "other-test", []string{"other-rules"})
+	s.ExpectRuleSetReady(ns, "other-test")
+
+	s.CreateEngine(ns, "other-test", framework.EngineOpts{
+		RuleSetName: "other-test",
+		GatewayName: "auth-gateway",
+	})
+
+	otherSAName := s.ExpectCacheClientSAExists(ns, "other-test")
+
+	otherCacheKey := fmt.Sprintf("%s/other-test", ns)
+	wrongToken := s.CreateCacheServerToken(ns, otherSAName, cache.Audience(otherCacheKey))
+	result = cs.GetWithBearer("/rules/"+cacheKey, wrongToken)
+	require.NoError(t, result.Err)
+	assert.Equal(t, http.StatusForbidden, result.StatusCode,
+		"token for different ruleset should return 403")
+
+	s.Step("test: token with wrong audience returns 403")
+	wrongAudienceToken := s.CreateCacheServerToken(ns, saName, "wrong-audience")
+	result = cs.GetWithBearer("/rules/"+cacheKey, wrongAudienceToken)
+	require.NoError(t, result.Err)
+	assert.Equal(t, http.StatusForbidden, result.StatusCode,
+		"token with wrong audience should return 403")
+}


### PR DESCRIPTION
## What

Adds authentication and network-level access control to the RuleSet cache server, ensuring only authorized WASM plugins can retrieve WAF rules.

## Why

The cache server (`/rules/{instance}/...`) was previously unauthenticated — any pod with network access could fetch WAF rule data. In multi-tenant or security-sensitive environments, this is an unacceptable exposure: an attacker who compromises any workload in the mesh could exfiltrate the full rule configuration, revealing detection logic and bypass opportunities.

This PR closes that gap with two layers of defense:
1. **Authentication** — Kubernetes ServiceAccount tokens scoped per-Engine/RuleSet audience, validated via the TokenReview API with a bounded result cache.
2. **Network restriction** — A per-Engine NetworkPolicy in the operator namespace that limits cache server ingress to only the namespaces running the matched WASM workloads.

## Changes

- **Cache server token authentication** (`internal/rulesets/cache/auth.go`): `TokenAuthenticator` validates bearer tokens via the K8s TokenReview API, enforces audience scoping (`coraza-cache:<ns>/<ruleset>`), and caches successful results (bounded size + TTL) to avoid per-request API calls.
- **Token lifecycle management** (`internal/controller/engine_controller_token.go`): The EngineReconciler creates a dedicated ServiceAccount per Engine, requests short-lived tokens with the correct audience, and injects the token into the WasmPlugin's `pluginConfig`. Token renewal is driven by `RequeueAfter` based on remaining token lifetime.
- **NetworkPolicy management** (`internal/controller/engine_controller_network_policy.go`): Creates a NetworkPolicy in the operator namespace scoping cache server ingress to namespaces selected by the Engine's workloadSelector. Uses a finalizer on the Engine to guarantee cross-namespace cleanup since ownerReferences don't work across namespaces.
- **EngineReconciler flow changes** (`engine_controller.go`, `engine_controller_driver_istio.go`): Reconciliation now provisions NetworkPolicy → ServiceAccount → token → WasmPlugin in order, with degraded status patches on each failure. Added nil-WorkloadSelector guard to prevent accidental cluster-wide WasmPlugin application.
- **Logging improvements** (`internal/controller/utils.go`, `utils_logging_test.go`): Replaced `setStatus*`/`logError` with `applyStatus*`/`logAPIError`/`logConditionTransitions` — condition transitions are now logged only when they actually change, reducing noise in steady-state operation.
- **Manager hardening** (`cmd/manager/main.go`): Metrics endpoint is now always served over HTTPS with authn/authz filters; removed `--metrics-secure` and `--enable-http2` flags; enforced TLS 1.3 minimum; scoped NetworkPolicy informer cache to operator namespace.
- **Proxy WASM bump**: Updated WASM plugin to pass the `cache_token` in requests to the cache server.
- **Helm chart updates**: New RBAC rules for ServiceAccounts, Secrets, NetworkPolicies, and TokenReviews; new NetworkPolicy template for cache server; updated deployment with `POD_NAMESPACE` from downward API.
- **Test coverage**: Unit tests for `TokenAuthenticator`, `NetworkPolicy` lifecycle, condition-transition logging; integration tests for cache auth and secure metrics endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>