### PR TITLE
fix codeql scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
           - language: actions
             build-mode: none
           - language: go
-            build-mode: autobuild
+            build-mode: manual
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -63,11 +63,11 @@ jobs:
         with:
           persist-credentials: false
 
-      # Add any setup steps before running the `github/codeql-action/init` action.
-      # This includes steps like installing compilers or runtimes (`actions/setup-node`
-      # or others). This is typically only required for manual builds.
-      # - name: Setup runtime (example)
-      #   uses: actions/setup-example@v1
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -88,16 +88,13 @@ jobs:
       # to build your code.
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      - name: Run manual build steps
+      - name: Build Go code
         if: matrix.build-mode == 'manual'
         shell: bash
         run: |
-          echo 'If you are using a "manual" build mode for one or more of the' \
-            'languages you are analyzing, replace this with the commands to build' \
-            'your code, for example:'
-          echo '  make bootstrap'
-          echo '  make release'
-          exit 1
+          go build ./cmd/manager
+          go build ./cmd/kubectl-coraza
+          (cd tools/github_project_manager && go build ./...)
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1


### PR DESCRIPTION
This pull request updates the CodeQL workflow configuration to improve Go language analysis. The main changes involve switching Go builds from automatic to manual, explicitly setting up the Go environment, and defining the manual build steps for all relevant Go binaries and test directories.

**Go language build configuration:**

* Changed the Go build mode from `autobuild` to `manual` in the CodeQL workflow to allow for custom build steps.
* Added a dedicated step to set up the Go environment using `actions/setup-go` with the version specified in `go.mod`.
* Replaced the placeholder manual build step with explicit `go build` commands for all main binaries and relevant directories, ensuring all code is built before analysis.
Fixes #234 
