### PR TITLE
chore: update to golang 1.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM golang:1.26@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
+FROM golang:1.26.1@sha256:595c7847cff97c9a9e76f015083c481d26078f961c9c8dca3923132f51fe12f1 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/networking-incubator/coraza-kubernetes-operator
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/corazawaf/coraza/v3 v3.4.0

--- a/test/conformance/go.mod
+++ b/test/conformance/go.mod
@@ -1,6 +1,6 @@
 module github.com/networking-incubator/coraza-kubernetes-operator/test/conformance
 
-go 1.26.0
+go 1.26.1
 
 tool github.com/coreruleset/go-ftw/v2
 

--- a/tools/github_project_manager/go.mod
+++ b/tools/github_project_manager/go.mod
@@ -1,6 +1,6 @@
 module github.com/networking-incubator/coraza-kubernetes-operator/tools/github_project_manager
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Vulnerability #1: GO-2026-4603
    URLs in meta content attribute actions are not escaped in html/template
  More info: https://pkg.go.dev/vuln/GO-2026-4603
  Standard library
    Found in: html/template@go1.26
    Fixed in: html/template@go1.26.1
    Example traces found:
      #1: internal/rulesets/cache/server.go:112:33: cache.Start calls http.Server.ListenAndServe, which eventually calls template.Template.Execute
      #2: internal/rulesets/cache/server.go:112:33: cache.Start calls http.Server.ListenAndServe, which eventually calls template.Template.ExecuteTemplate

Vulnerability #2: GO-2026-4602
    FileInfo can escape from a Root in os
  More info: https://pkg.go.dev/vuln/GO-2026-4602
  Standard library
    Found in: os@go1.26
    Fixed in: os@go1.26.1
    Example traces found:
      #1: internal/controller/ruleset_controller_validation.go:43:28: controller.RuleSetReconciler.validateAggregatedRules calls coraza.NewWAF, which eventually calls os.File.ReadDir
      #2: test/framework/framework.go:96:22: framework.New calls exec.Command, which eventually calls os.ReadDir

Vulnerability #3: GO-2026-4601
    Incorrect parsing of IPv6 host literals in net/url
  More info: https://pkg.go.dev/vuln/GO-2026-4601
  Standard library
    Found in: net/url@go1.26
    Fixed in: net/url@go1.26.1
    Example traces found:
      #1: test/framework/networking.go:208:29: framework.GatewayProxy.PostWithHeaders calls http.NewRequest, which eventually calls url.Parse
      #2: test/framework/framework.go:101:51: framework.New calls clientcmd.RESTConfigFromKubeConfig, which eventually calls url.ParseRequestURI
      #3: test/framework/networking.go:181:25: framework.GatewayProxy.DoRequest calls http.Client.Do, which eventually calls url.URL.Parse

Vulnerability #4: GO-2026-4600
    Panic in name constraint checking for malformed certificates in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-4600
  Standard library
    Found in: crypto/x509@go1.26
    Fixed in: crypto/x509@go1.26.1
    Example traces found:
      #1: internal/rulesets/unsupported.go:97:13: rulesets.FormatUnsupportedMessage calls fmt.Fprintf, which eventually calls x509.Certificate.Verify

Vulnerability #5: GO-2026-4599
    Incorrect enforcement of email constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-4599
  Standard library
    Found in: crypto/x509@go1.26
    Fixed in: crypto/x509@go1.26.1
    Example traces found:
      #1: internal/rulesets/unsupported.go:97:13: rulesets.FormatUnsupportedMessage calls fmt.Fprintf, which eventually calls x509.Certificate.Verify
