### PR TITLE
feat: improve logging signal-to-noise for condition transitions and API errors

### DIFF
--- a/internal/controller/engine_controller.go
+++ b/internal/controller/engine_controller.go
@@ -135,7 +135,7 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, nil
 		}
 
-		logError(log, req, "Engine", err, "Failed to get")
+		logAPIError(log, req, "Engine", err, "Failed to get", nil)
 		return ctrl.Result{}, err
 	}
 
@@ -163,11 +163,13 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	if apimeta.FindStatusCondition(engine.Status.Conditions, "Ready") == nil {
 		patch := client.MergeFrom(engine.DeepCopy())
-		setStatusProgressing(log, req, "Engine", &engine.Status.Conditions, engine.Generation, "Reconciling", "Starting reconciliation")
+		before := snapshotConditions(engine.Status.Conditions)
+		applyStatusProgressing(&engine.Status.Conditions, engine.Generation, "Reconciling", "Starting reconciliation")
 		if err := r.Status().Patch(ctx, &engine, patch); err != nil {
-			logError(log, req, "Engine", err, "Failed to patch initial status")
+			logAPIError(log, req, "Engine", err, "Failed to patch initial status", &engine)
 			return ctrl.Result{}, err
 		}
+		logConditionTransitions(log, req, "Engine", before, engine.Status.Conditions)
 	}
 
 	logDebug(log, req, "Engine", "Checking referenced RuleSet status")
@@ -238,7 +240,7 @@ func (r *EngineReconciler) isRuleSetDegraded(ctx context.Context, log logr.Logge
 			}
 			return true, nil
 		}
-		logError(log, req, "Engine", err, "Failed to get RuleSet")
+		logAPIError(log, req, "Engine", err, "Failed to get RuleSet", nil)
 		return false, fmt.Errorf("failed to get RuleSet %s: %w", engine.Spec.RuleSet.Name, err)
 	}
 	if ruleSet.Status == nil {

--- a/internal/controller/engine_controller_driver_istio.go
+++ b/internal/controller/engine_controller_driver_istio.go
@@ -92,7 +92,7 @@ func (r *EngineReconciler) provisionIstioEngineWithWasm(ctx context.Context, log
 	logDebug(log, req, "Engine", "Finding matched Gateways")
 	gateways, gwErr := r.matchedGateways(ctx, log, req, &engine)
 	if gwErr != nil {
-		logError(log, req, "Engine", gwErr, "Failed to find matched Gateways, not updating Gateway status")
+		logAPIError(log, req, "Engine", gwErr, "Failed to find matched Gateways, not updating Gateway status", &engine)
 	}
 
 	// Status patching is kept inline because it mutates engine.Status.Gateways
@@ -102,11 +102,13 @@ func (r *EngineReconciler) provisionIstioEngineWithWasm(ctx context.Context, log
 	if gwErr == nil {
 		engine.Status.Gateways = gateways
 	}
-	setStatusReady(log, req, "Engine", &engine.Status.Conditions, engine.Generation, "Configured", "WasmPlugin successfully created/updated")
+	before := snapshotConditions(engine.Status.Conditions)
+	applyStatusReady(&engine.Status.Conditions, engine.Generation, "Configured", "WasmPlugin successfully created/updated")
 	if err := r.Status().Patch(ctx, &engine, patch); err != nil {
-		logError(log, req, "Engine", err, "Failed to patch status")
+		logAPIError(log, req, "Engine", err, "Failed to patch status", &engine)
 		return ctrl.Result{}, err
 	}
+	logConditionTransitions(log, req, "Engine", before, engine.Status.Conditions)
 	r.Recorder.Eventf(&engine, nil, "Normal", "WasmPluginCreated", "Provision", "Created WasmPlugin %s/%s", wasmPlugin.GetNamespace(), wasmPlugin.GetName())
 
 	return ctrl.Result{}, nil
@@ -132,7 +134,7 @@ func (r *EngineReconciler) applyWasmPlugin(ctx context.Context, log logr.Logger,
 
 	logDebug(log, req, "Engine", "Applying WasmPlugin", "wasmPluginName", wasmPlugin.GetName())
 	if err := serverSideApply(ctx, r.Client, wasmPlugin); err != nil {
-		logError(log, req, "Engine", err, "Failed to create or update WasmPlugin")
+		logAPIError(log, req, "Engine", err, "Failed to create or update WasmPlugin", wasmPlugin)
 		return nil, err
 	}
 

--- a/internal/controller/engine_controller_network_policy.go
+++ b/internal/controller/engine_controller_network_policy.go
@@ -111,7 +111,7 @@ func (r *EngineReconciler) ensureNetworkPolicyFinalizer(ctx context.Context, log
 	patch := client.MergeFrom(engine.DeepCopy())
 	controllerutil.AddFinalizer(engine, networkPolicyFinalizer)
 	if err := r.Patch(ctx, engine, patch); err != nil {
-		logError(log, req, "Engine", err, "Failed to add NetworkPolicy finalizer")
+		logAPIError(log, req, "Engine", err, "Failed to add NetworkPolicy finalizer", engine)
 		return false, err
 	}
 	logDebug(log, req, "Engine", "Added NetworkPolicy finalizer")
@@ -136,7 +136,7 @@ func (r *EngineReconciler) handleNetworkPolicyDeletion(ctx context.Context, log 
 	patch := client.MergeFrom(engine.DeepCopy())
 	controllerutil.RemoveFinalizer(engine, networkPolicyFinalizer)
 	if err := r.Patch(ctx, engine, patch); err != nil {
-		logError(log, req, "Engine", err, "Failed to remove NetworkPolicy finalizer")
+		logAPIError(log, req, "Engine", err, "Failed to remove NetworkPolicy finalizer", engine)
 		return true, err
 	}
 	logDebug(log, req, "Engine", "Removed NetworkPolicy finalizer")
@@ -169,7 +169,7 @@ func (r *EngineReconciler) applyNetworkPolicy(ctx context.Context, log logr.Logg
 		desired.ResourceVersion = existing.ResourceVersion
 		logDebug(log, req, "Engine", "Updating cache server NetworkPolicy", "networkPolicyName", existing.Name)
 		if err := r.Update(ctx, desired); err != nil {
-			logError(log, req, "Engine", err, "Failed to update NetworkPolicy")
+			logAPIError(log, req, "Engine", err, "Failed to update NetworkPolicy", desired)
 			return err
 		}
 		logInfo(log, req, "Engine", "NetworkPolicy updated", "networkPolicyName", desired.Name, "networkPolicyNamespace", desired.Namespace)
@@ -178,7 +178,7 @@ func (r *EngineReconciler) applyNetworkPolicy(ctx context.Context, log logr.Logg
 
 	logDebug(log, req, "Engine", "Creating cache server NetworkPolicy")
 	if err := r.Create(ctx, desired); err != nil {
-		logError(log, req, "Engine", err, "Failed to create NetworkPolicy")
+		logAPIError(log, req, "Engine", err, "Failed to create NetworkPolicy", desired)
 		return err
 	}
 	logInfo(log, req, "Engine", "NetworkPolicy created", "networkPolicyName", desired.Name, "networkPolicyNamespace", desired.Namespace)
@@ -192,14 +192,15 @@ func (r *EngineReconciler) cleanupNetworkPolicy(ctx context.Context, log logr.Lo
 		client.InNamespace(r.operatorNamespace),
 		engineNetworkPolicyLabels(req.Namespace, req.Name),
 	); err != nil {
-		logError(log, req, "Engine", err, "Failed to list NetworkPolicies for cleanup")
+		logAPIError(log, req, "Engine", err, "Failed to list NetworkPolicies for cleanup", nil,
+			"operatorNamespace", r.operatorNamespace)
 		return err
 	}
 
 	for i := range list.Items {
 		if err := r.Delete(ctx, &list.Items[i]); err != nil {
 			if client.IgnoreNotFound(err) != nil {
-				logError(log, req, "Engine", err, "Failed to cleanup NetworkPolicy")
+				logAPIError(log, req, "Engine", err, "Failed to cleanup NetworkPolicy", &list.Items[i])
 				return err
 			}
 		} else {

--- a/internal/controller/ruleset_controller.go
+++ b/internal/controller/ruleset_controller.go
@@ -113,7 +113,7 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			logDebug(log, req, "RuleSet", "Resource not found")
 			return ctrl.Result{}, nil
 		}
-		logError(log, req, "RuleSet", err, "Failed to GET")
+		logAPIError(log, req, "RuleSet", err, "Failed to GET", nil)
 		return ctrl.Result{}, err
 	}
 
@@ -171,12 +171,13 @@ func (r *RuleSetReconciler) initializeStatus(ctx context.Context, log logr.Logge
 		return nil
 	}
 
-	logDebug(log, req, "RuleSet", "Setting initial progressing status")
 	patch := client.MergeFrom(ruleset.DeepCopy())
-	setStatusProgressing(log, req, "RuleSet", &ruleset.Status.Conditions, ruleset.Generation, "Reconciling", "Starting reconciliation")
+	before := snapshotConditions(ruleset.Status.Conditions)
+	applyStatusProgressing(&ruleset.Status.Conditions, ruleset.Generation, "Reconciling", "Starting reconciliation")
 	if err := r.Status().Patch(ctx, ruleset, patch); err != nil {
-		logError(log, req, "RuleSet", err, "Failed to patch initial status")
+		logAPIError(log, req, "RuleSet", err, "Failed to patch initial status", ruleset)
 		return err
 	}
+	logConditionTransitions(log, req, "RuleSet", before, ruleset.Status.Conditions)
 	return nil
 }

--- a/internal/controller/ruleset_controller_rule_aggregation.go
+++ b/internal/controller/ruleset_controller_rule_aggregation.go
@@ -81,7 +81,7 @@ func (r *RuleSetReconciler) fetchConfigMapRules(
 			}
 			return "", false, true, nil
 		}
-		logError(log, req, "RuleSet", err, "Failed to get ConfigMap", "configMapName", configMapName)
+		logAPIError(log, req, "RuleSet", err, "Failed to get ConfigMap", ruleset, "configMapName", configMapName)
 		msg := fmt.Sprintf("Failed to access ConfigMap %s: %v", configMapName, err)
 		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "ConfigMapAccessError", msg); patchErr != nil {
 			return "", false, true, patchErr

--- a/internal/controller/ruleset_controller_secret_data.go
+++ b/internal/controller/ruleset_controller_secret_data.go
@@ -83,7 +83,7 @@ func (r *RuleSetReconciler) loadRuleDataSecret(
 		}
 		return nil, true, nil
 	default:
-		logError(log, req, "RuleSet", err, "Failed to access RuleData secret", "secretName", ruleDataName)
+		logAPIError(log, req, "RuleSet", err, "Failed to access RuleData secret", ruleset, "secretName", ruleDataName)
 		msg := fmt.Sprintf("Failed to access RuleData secret %s: %v", ruleDataName, err)
 		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "SecretAccessError", msg); patchErr != nil {
 			return nil, true, patchErr

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -61,9 +62,108 @@ func logError(log logr.Logger, req ctrl.Request, kind string, err error, msg str
 	log.Error(err, fmt.Sprintf("%s: %s", kind, msg), args...)
 }
 
+// logAPIError logs an error from a Kubernetes API call, enriching it with
+// resourceVersion (from obj, when non-nil), HTTP status code, API reason,
+// and retryAfterSeconds when the error is or wraps a *apierrors.StatusError.
+//
+// Workqueue retry/attempt count is not available inside Reconcile without a
+// cross-cutting wrapper or metrics integration; that is left for a follow-up.
+func logAPIError(log logr.Logger, req ctrl.Request, kind string, err error, msg string, obj client.Object, extra ...any) {
+	if len(extra)%2 != 0 {
+		logDebug(log, req, kind, "logAPIError called with odd number of extra key-value arguments; dropping trailing orphan")
+		extra = extra[:len(extra)-1]
+	}
+
+	args := append([]any{"namespace", req.Namespace, "name", req.Name}, extra...)
+
+	if obj != nil {
+		if rv := obj.GetResourceVersion(); rv != "" {
+			args = append(args, "resourceVersion", rv)
+		}
+	}
+
+	args = append(args, extractStatusErrorFields(err)...)
+	log.Error(err, fmt.Sprintf("%s: %s", kind, msg), args...)
+}
+
+// extractStatusErrorFields returns structured key/value pairs from a
+// *apierrors.StatusError if err is or wraps one.
+func extractStatusErrorFields(err error) []any {
+	var statusErr *apierrors.StatusError
+	if !errors.As(err, &statusErr) {
+		return nil
+	}
+
+	st := statusErr.Status()
+	fields := []any{
+		"apiStatusCode", st.Code,
+		"apiReason", string(st.Reason),
+	}
+
+	if st.Details != nil && st.Details.RetryAfterSeconds > 0 {
+		fields = append(fields, "retryAfterSeconds", st.Details.RetryAfterSeconds)
+	}
+
+	return fields
+}
+
 // -----------------------------------------------------------------------------
 // Status Condition Helpers
 // -----------------------------------------------------------------------------
+
+// trackedConditionTypes are the operator-owned condition types whose transitions
+// are logged at Info level.
+var trackedConditionTypes = []string{"Ready", "Degraded", "Progressing"}
+
+// conditionSnapshot captures the Status and Reason of each tracked condition
+// type before mutation. A nil entry means the condition was absent.
+type conditionSnapshot map[string]*metav1.Condition
+
+func snapshotConditions(conditions []metav1.Condition) conditionSnapshot {
+	snap := make(conditionSnapshot, len(trackedConditionTypes))
+	for _, ct := range trackedConditionTypes {
+		if c := apimeta.FindStatusCondition(conditions, ct); c != nil {
+			cpy := *c
+			snap[ct] = &cpy
+		}
+	}
+	return snap
+}
+
+// logConditionTransitions compares before and after snapshots and logs at Info
+// for each tracked condition whose Status changed, appeared, or disappeared.
+// Idempotent no-ops (same Status+Reason) are silent.
+func logConditionTransitions(log logr.Logger, req ctrl.Request, kind string, before conditionSnapshot, after []metav1.Condition) {
+	for _, ct := range trackedConditionTypes {
+		prev := before[ct]
+		cur := apimeta.FindStatusCondition(after, ct)
+
+		switch {
+		case prev == nil && cur == nil:
+			continue
+		case prev == nil && cur != nil:
+			logInfo(log, req, kind, "Condition set",
+				"condition", ct,
+				"fromStatus", "",
+				"toStatus", string(cur.Status),
+				"reason", cur.Reason)
+		case prev != nil && cur == nil:
+			logInfo(log, req, kind, "Condition removed",
+				"condition", ct,
+				"fromStatus", string(prev.Status),
+				"toStatus", "")
+		default:
+			if prev.Status == cur.Status && prev.Reason == cur.Reason {
+				continue
+			}
+			logInfo(log, req, kind, "Condition changed",
+				"condition", ct,
+				"fromStatus", string(prev.Status),
+				"toStatus", string(cur.Status),
+				"reason", cur.Reason)
+		}
+	}
+}
 
 // setConditionTrue is a helper function to set metav1.Conditions to True.
 func setConditionTrue(conditions *[]metav1.Condition, generation int64, conditionType, reason, message string) {
@@ -89,17 +189,17 @@ func setConditionFalse(conditions *[]metav1.Condition, generation int64, conditi
 	})
 }
 
-// setStatusConditionDegraded is a helper to mark a resource as degraded.
-func setStatusConditionDegraded(log logr.Logger, req ctrl.Request, kind string, conditions *[]metav1.Condition, generation int64, reason, message string) {
-	logDebug(log, req, kind, fmt.Sprintf("Setting degraded status: %s", reason))
+// applyStatusConditionDegraded mutates conditions to a Degraded state. It does
+// not log; call logConditionTransitions after a successful Status().Patch.
+func applyStatusConditionDegraded(conditions *[]metav1.Condition, generation int64, reason, message string) {
 	setConditionFalse(conditions, generation, "Ready", reason, message)
 	setConditionTrue(conditions, generation, "Degraded", reason, message)
 	apimeta.RemoveStatusCondition(conditions, "Progressing")
 }
 
-// setStatusProgressing is a helper to mark a resource as actively progressing.
-func setStatusProgressing(log logr.Logger, req ctrl.Request, kind string, conditions *[]metav1.Condition, generation int64, reason, message string) {
-	logDebug(log, req, kind, fmt.Sprintf("Setting progressing status: %s", reason))
+// applyStatusProgressing mutates conditions to a Progressing state. It does not
+// log; call logConditionTransitions after a successful Status().Patch.
+func applyStatusProgressing(conditions *[]metav1.Condition, generation int64, reason, message string) {
 	setConditionFalse(conditions, generation, "Ready", reason, message)
 	setConditionTrue(conditions, generation, "Progressing", reason, message)
 }
@@ -119,7 +219,7 @@ func truncateEventNote(msg string) string {
 
 // patchDegraded marks a resource as Degraded, emits a Warning event, and
 // patches the status in a single call. It consolidates the repeated pattern of
-// Eventf → DeepCopy → setStatusConditionDegraded → Status().Patch → error log.
+// Eventf → DeepCopy → apply status → Status().Patch → logConditionTransitions on success.
 func patchDegraded(
 	ctx context.Context,
 	statusWriter client.StatusWriter,
@@ -134,17 +234,19 @@ func patchDegraded(
 ) error {
 	recorder.Eventf(obj, nil, "Warning", reason, "Reconcile", truncateEventNote(message))
 	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
-	setStatusConditionDegraded(log, req, kind, conditions, generation, reason, message)
+	before := snapshotConditions(*conditions)
+	applyStatusConditionDegraded(conditions, generation, reason, message)
 	if err := statusWriter.Patch(ctx, obj, patch); err != nil {
-		logError(log, req, kind, err, "Failed to patch status")
+		logAPIError(log, req, kind, err, "Failed to patch status", obj)
 		return err
 	}
+	logConditionTransitions(log, req, kind, before, *conditions)
 	return nil
 }
 
-// setStatusReady is a helper to mark a resource as ready, fully reconciled.
-func setStatusReady(log logr.Logger, req ctrl.Request, kind string, conditions *[]metav1.Condition, generation int64, reason, message string) {
-	logDebug(log, req, kind, fmt.Sprintf("Setting ready status: %s", reason))
+// applyStatusReady mutates conditions to Ready. It does not log; call
+// logConditionTransitions after a successful Status().Patch.
+func applyStatusReady(conditions *[]metav1.Condition, generation int64, reason, message string) {
 	setConditionTrue(conditions, generation, "Ready", reason, message)
 	apimeta.RemoveStatusCondition(conditions, "Degraded")
 	apimeta.RemoveStatusCondition(conditions, "Progressing")
@@ -166,11 +268,13 @@ func patchReady(
 ) error {
 	recorder.Eventf(obj, nil, "Normal", reason, "Reconcile", truncateEventNote(message))
 	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
-	setStatusReady(log, req, kind, conditions, generation, reason, message)
+	before := snapshotConditions(*conditions)
+	applyStatusReady(conditions, generation, reason, message)
 	if err := statusWriter.Patch(ctx, obj, patch); err != nil {
-		logError(log, req, kind, err, "Failed to patch status")
+		logAPIError(log, req, kind, err, "Failed to patch status", obj)
 		return err
 	}
+	logConditionTransitions(log, req, kind, before, *conditions)
 	return nil
 }
 

--- a/internal/controller/utils_logging_test.go
+++ b/internal/controller/utils_logging_test.go
@@ -1,0 +1,440 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// ---------------------------------------------------------------------------
+// captureSink — records log entries for assertions
+// ---------------------------------------------------------------------------
+
+type captureSink struct {
+	entries []logEntry
+}
+
+type logEntry struct {
+	Level         int
+	Msg           string
+	KeysAndValues []any
+	Err           error
+}
+
+func (s *captureSink) Init(logr.RuntimeInfo)          {}
+func (s *captureSink) Enabled(int) bool               { return true }
+func (s *captureSink) WithValues(...any) logr.LogSink { return s }
+func (s *captureSink) WithName(string) logr.LogSink   { return s }
+
+func (s *captureSink) Info(level int, msg string, keysAndValues ...any) {
+	s.entries = append(s.entries, logEntry{Level: level, Msg: msg, KeysAndValues: keysAndValues})
+}
+
+func (s *captureSink) Error(err error, msg string, keysAndValues ...any) {
+	s.entries = append(s.entries, logEntry{Level: -1, Msg: msg, KeysAndValues: keysAndValues, Err: err})
+}
+
+func newCaptureLogger() (logr.Logger, *captureSink) {
+	sink := &captureSink{}
+	return logr.New(sink), sink
+}
+
+// infoEntries returns log lines emitted at default Info severity (go-logr level 0).
+func (s *captureSink) infoEntries() []logEntry {
+	var out []logEntry
+	for _, e := range s.entries {
+		if e.Level == 0 {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// findInfoEntry returns the first default-Info log (level 0) whose message contains substr.
+func (s *captureSink) findInfoEntry(substr string) *logEntry {
+	for i := range s.entries {
+		if s.entries[i].Level == 0 && strings.Contains(s.entries[i].Msg, substr) {
+			return &s.entries[i]
+		}
+	}
+	return nil
+}
+
+// findInfoEntryByCondition returns the first default-Info log where keys include
+// "condition" == conditionType (avoids brittle substring matching when multiple
+// transitions occur in one reconcile).
+func (s *captureSink) findInfoEntryByCondition(conditionType string) *logEntry {
+	for i := range s.entries {
+		if s.entries[i].Level != 0 {
+			continue
+		}
+		kv := kvMap(s.entries[i].KeysAndValues)
+		if v, ok := kv["condition"].(string); ok && v == conditionType {
+			return &s.entries[i]
+		}
+	}
+	return nil
+}
+
+func kvMap(kvs []any) map[string]any {
+	m := make(map[string]any, len(kvs)/2)
+	for i := 0; i+1 < len(kvs); i += 2 {
+		if k, ok := kvs[i].(string); ok {
+			m[k] = kvs[i+1]
+		}
+	}
+	return m
+}
+
+func testReq() ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "obj"}}
+}
+
+// ---------------------------------------------------------------------------
+// Condition Transition Tests
+// ---------------------------------------------------------------------------
+
+func TestLogConditionTransitions(t *testing.T) {
+	req := testReq()
+
+	t.Run("no prior conditions -> applyStatusProgressing logs new conditions", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		var conditions []metav1.Condition
+
+		before := snapshotConditions(conditions)
+		applyStatusProgressing(&conditions, 1, "Reconciling", "starting")
+		logConditionTransitions(log, req, "Engine", before, conditions)
+
+		infos := sink.infoEntries()
+		require.NotEmpty(t, infos, "expected Info log for new conditions")
+
+		readySet := sink.findInfoEntry("Condition set")
+		require.NotNil(t, readySet, "expected 'Condition set' for Ready=False")
+		assert.Zero(t, readySet.Level, "condition transitions must use log.Info (level 0), not log.V")
+	})
+
+	t.Run("idempotent call does not log transitions", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "RulesCached"},
+		}
+
+		before := snapshotConditions(conditions)
+		applyStatusReady(&conditions, 1, "RulesCached", "cached")
+		logConditionTransitions(log, req, "RuleSet", before, conditions)
+
+		for _, e := range sink.entries {
+			assert.NotContains(t, e.Msg, "Condition changed")
+			assert.NotContains(t, e.Msg, "Condition set")
+		}
+	})
+
+	t.Run("message-only update same status and reason stays silent", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Configured", Message: "old detail"},
+		}
+
+		before := snapshotConditions(conditions)
+		applyStatusReady(&conditions, 1, "Configured", "new detail")
+		logConditionTransitions(log, req, "Engine", before, conditions)
+
+		assert.Empty(t, sink.infoEntries(), "Status+Reason unchanged: no Info noise")
+	})
+
+	t.Run("Progressing -> Ready logs Ready change and Progressing removal", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "Reconciling"},
+			{Type: "Progressing", Status: metav1.ConditionTrue, Reason: "Reconciling"},
+		}
+
+		before := snapshotConditions(conditions)
+		applyStatusReady(&conditions, 1, "Configured", "done")
+		logConditionTransitions(log, req, "Engine", before, conditions)
+
+		changedEntry := sink.findInfoEntryByCondition("Ready")
+		require.NotNil(t, changedEntry)
+		assert.Contains(t, changedEntry.Msg, "Condition changed")
+		assert.Zero(t, changedEntry.Level)
+		kv := kvMap(changedEntry.KeysAndValues)
+		assert.Equal(t, "Ready", kv["condition"])
+		assert.Equal(t, "False", kv["fromStatus"])
+		assert.Equal(t, "True", kv["toStatus"])
+
+		removedEntry := sink.findInfoEntryByCondition("Progressing")
+		require.NotNil(t, removedEntry)
+		assert.Contains(t, removedEntry.Msg, "Condition removed")
+		assert.Zero(t, removedEntry.Level)
+		rkv := kvMap(removedEntry.KeysAndValues)
+		assert.Equal(t, "Progressing", rkv["condition"])
+	})
+
+	t.Run("Ready -> Degraded logs transitions", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Configured"},
+		}
+
+		before := snapshotConditions(conditions)
+		applyStatusConditionDegraded(&conditions, 1, "Error", "something broke")
+		logConditionTransitions(log, req, "Engine", before, conditions)
+
+		infos := sink.infoEntries()
+		require.GreaterOrEqual(t, len(infos), 2, "expect Ready change + Degraded set")
+
+		readyChanged := sink.findInfoEntry("Condition changed")
+		require.NotNil(t, readyChanged)
+		assert.Zero(t, readyChanged.Level)
+		rkv := kvMap(readyChanged.KeysAndValues)
+		assert.Equal(t, "Ready", rkv["condition"])
+		assert.Equal(t, "True", rkv["fromStatus"])
+		assert.Equal(t, "False", rkv["toStatus"])
+	})
+
+	t.Run("same status different reason still logs", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "OldReason"},
+			{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "OldReason"},
+		}
+
+		before := snapshotConditions(conditions)
+		applyStatusConditionDegraded(&conditions, 1, "NewReason", "updated")
+		logConditionTransitions(log, req, "RuleSet", before, conditions)
+
+		entry := sink.findInfoEntry("Condition changed")
+		require.NotNil(t, entry, "reason-only change should log")
+		assert.Zero(t, entry.Level)
+		kv := kvMap(entry.KeysAndValues)
+		assert.Equal(t, "NewReason", kv["reason"])
+	})
+
+	t.Run("applyStatusProgressing adds Progressing when absent", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		conditions := []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "Error"},
+			{Type: "Degraded", Status: metav1.ConditionTrue, Reason: "Error"},
+		}
+
+		before := snapshotConditions(conditions)
+		applyStatusProgressing(&conditions, 2, "Retrying", "retry")
+		logConditionTransitions(log, req, "RuleSet", before, conditions)
+
+		progressingSet := sink.findInfoEntry("Condition set")
+		require.NotNil(t, progressingSet)
+		assert.Zero(t, progressingSet.Level)
+		kv := kvMap(progressingSet.KeysAndValues)
+		assert.Equal(t, "Progressing", kv["condition"])
+
+		readyChanged := sink.findInfoEntry("Condition changed")
+		require.NotNil(t, readyChanged)
+		assert.Zero(t, readyChanged.Level)
+		rkv := kvMap(readyChanged.KeysAndValues)
+		assert.Equal(t, "Ready", rkv["condition"])
+		assert.Equal(t, "Retrying", rkv["reason"])
+	})
+}
+
+// ---------------------------------------------------------------------------
+// extractStatusErrorFields Tests
+// ---------------------------------------------------------------------------
+
+func TestExtractStatusErrorFields(t *testing.T) {
+	t.Run("non-StatusError returns nil", func(t *testing.T) {
+		fields := extractStatusErrorFields(fmt.Errorf("plain error"))
+		assert.Nil(t, fields)
+	})
+
+	t.Run("StatusError returns code and reason", func(t *testing.T) {
+		err := apierrors.NewNotFound(
+			schema.GroupResource{Group: "waf.k8s.coraza.io", Resource: "engines"}, "my-engine")
+
+		fields := extractStatusErrorFields(err)
+		require.NotNil(t, fields)
+		kv := kvMap(fields)
+		assert.Equal(t, int32(http.StatusNotFound), kv["apiStatusCode"])
+		assert.Equal(t, string(metav1.StatusReasonNotFound), kv["apiReason"])
+	})
+
+	t.Run("wrapped StatusError is detected", func(t *testing.T) {
+		inner := apierrors.NewConflict(
+			schema.GroupResource{Resource: "engines"}, "my-engine", fmt.Errorf("conflict"))
+		wrapped := fmt.Errorf("fetching engine: %w", inner)
+
+		fields := extractStatusErrorFields(wrapped)
+		require.NotNil(t, fields)
+		kv := kvMap(fields)
+		assert.Equal(t, int32(http.StatusConflict), kv["apiStatusCode"])
+	})
+
+	t.Run("StatusError with RetryAfterSeconds includes field", func(t *testing.T) {
+		err := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    http.StatusTooManyRequests,
+				Reason:  metav1.StatusReasonTooManyRequests,
+				Details: &metav1.StatusDetails{RetryAfterSeconds: 30},
+			},
+		}
+
+		fields := extractStatusErrorFields(err)
+		kv := kvMap(fields)
+		assert.Equal(t, int32(30), kv["retryAfterSeconds"])
+		assert.Equal(t, int32(http.StatusTooManyRequests), kv["apiStatusCode"])
+	})
+
+	t.Run("StatusError without RetryAfterSeconds omits field", func(t *testing.T) {
+		err := apierrors.NewInternalError(fmt.Errorf("internal"))
+
+		fields := extractStatusErrorFields(err)
+		kv := kvMap(fields)
+		_, hasRetry := kv["retryAfterSeconds"]
+		assert.False(t, hasRetry)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// logAPIError Tests
+// ---------------------------------------------------------------------------
+
+func TestLogAPIError(t *testing.T) {
+	req := testReq()
+
+	t.Run("nil obj omits resourceVersion", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		logAPIError(log, req, "Engine", fmt.Errorf("test"), "Failed to get", nil)
+
+		require.Len(t, sink.entries, 1)
+		kv := kvMap(sink.entries[0].KeysAndValues)
+		_, hasRV := kv["resourceVersion"]
+		assert.False(t, hasRV)
+	})
+
+	t.Run("obj with resourceVersion adds it", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+
+		obj := &unstructured.Unstructured{}
+		obj.SetResourceVersion("12345")
+
+		err := apierrors.NewNotFound(schema.GroupResource{Resource: "engines"}, "eng")
+		logAPIError(log, req, "Engine", err, "Failed to get", obj)
+
+		require.Len(t, sink.entries, 1)
+		kv := kvMap(sink.entries[0].KeysAndValues)
+		assert.Equal(t, "12345", kv["resourceVersion"])
+		assert.Equal(t, int32(http.StatusNotFound), kv["apiStatusCode"])
+	})
+
+	t.Run("non-nil obj with empty resourceVersion omits key", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		obj := &unstructured.Unstructured{}
+		obj.SetName("x")
+
+		err := apierrors.NewTimeoutError("slow", 0)
+		logAPIError(log, req, "Engine", err, "Failed", obj)
+
+		kv := kvMap(sink.entries[0].KeysAndValues)
+		_, hasRV := kv["resourceVersion"]
+		assert.False(t, hasRV)
+	})
+
+	t.Run("extra key-value pairs are included", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		logAPIError(log, req, "RuleSet", fmt.Errorf("err"), "oops", nil, "secretName", "my-secret")
+
+		require.Len(t, sink.entries, 1)
+		kv := kvMap(sink.entries[0].KeysAndValues)
+		assert.Equal(t, "my-secret", kv["secretName"])
+	})
+
+	t.Run("odd extra args with single orphan drops it", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		logAPIError(log, req, "Engine", fmt.Errorf("err"), "Failed", nil, "orphanKey")
+
+		var hasDebugWarning bool
+		for _, e := range sink.entries {
+			if e.Level == debugLevel && strings.Contains(e.Msg, "odd number of extra") {
+				hasDebugWarning = true
+			}
+		}
+		assert.True(t, hasDebugWarning, "expected debug warning about odd extra args")
+
+		errorEntries := 0
+		for _, e := range sink.entries {
+			if e.Level == -1 {
+				errorEntries++
+				kv := kvMap(e.KeysAndValues)
+				_, hasOrphan := kv["orphanKey"]
+				assert.False(t, hasOrphan, "orphan key should not appear in log fields")
+				assert.Equal(t, "ns", kv["namespace"], "namespace must still be logged on error path")
+				assert.Equal(t, "obj", kv["name"], "name must still be logged on error path")
+			}
+		}
+		assert.Equal(t, 1, errorEntries, "error should still be logged")
+	})
+
+	t.Run("odd extra args preserves valid pairs before trailing orphan", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		logAPIError(log, req, "Engine", fmt.Errorf("err"), "Failed", nil,
+			"secretName", "my-secret", "orphanKey")
+
+		var errorEntry *logEntry
+		for i := range sink.entries {
+			if sink.entries[i].Level == -1 {
+				errorEntry = &sink.entries[i]
+			}
+		}
+		require.NotNil(t, errorEntry, "error should still be logged")
+		kv := kvMap(errorEntry.KeysAndValues)
+		assert.Equal(t, "my-secret", kv["secretName"], "valid pair before orphan must be preserved")
+		_, hasOrphan := kv["orphanKey"]
+		assert.False(t, hasOrphan, "trailing orphan must be dropped")
+	})
+
+	t.Run("odd extra args preserves multiple pairs before trailing orphan", func(t *testing.T) {
+		log, sink := newCaptureLogger()
+		logAPIError(log, req, "Engine", fmt.Errorf("err"), "Failed", nil,
+			"k1", "v1", "k2", "v2", "orphan")
+
+		var errorEntry *logEntry
+		for i := range sink.entries {
+			if sink.entries[i].Level == -1 {
+				errorEntry = &sink.entries[i]
+			}
+		}
+		require.NotNil(t, errorEntry)
+		kv := kvMap(errorEntry.KeysAndValues)
+		assert.Equal(t, "v1", kv["k1"])
+		assert.Equal(t, "v2", kv["k2"])
+		_, hasOrphan := kv["orphan"]
+		assert.False(t, hasOrphan)
+	})
+}


### PR DESCRIPTION
**Describe the pull request**

Log condition transitions (Ready, Degraded, Progressing) at Info level only when Status or Reason actually changes, replacing unconditional debug-level messages. Add logAPIError helper that enriches Kubernetes API error logs with resourceVersion, HTTP status code, API reason, and retryAfterSeconds from StatusError. Migrate all API-facing logError call sites to use logAPIError.

**Which issue this resolves**

Closes #262

**Additional context**
