### PR TITLE
feat(rulesets): add per-instance payload admission for RuleSet cache

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -110,7 +110,15 @@ func main() {
 	rulesetCache := setupCacheServer(mgr, cfg, kubeClient)
 	setupIstioPrerequisites(mgr, cfg, podNamespace)
 
-	if err := controller.SetupControllers(mgr, rulesetCache, cfg.envoyClusterName, cfg.istioRevision, cfg.defaultWasmImage, podNamespace, kubeClient); err != nil {
+	if err := controller.SetupControllers(mgr, kubeClient, rulesetCache,
+		controller.RuleSetOpts{MaxPayloadSize: cfg.cacheMaxSize},
+		controller.EngineOpts{
+			EnvoyClusterName:  cfg.envoyClusterName,
+			IstioRevision:     cfg.istioRevision,
+			DefaultWasmImage:  cfg.defaultWasmImage,
+			OperatorNamespace: podNamespace,
+		},
+	); err != nil {
 		setupLog.Error(err, "unable to setup controllers")
 		os.Exit(1)
 	}
@@ -166,7 +174,7 @@ func parseFlags() config {
 	flag.StringVar(&cfg.metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.DurationVar(&cfg.cacheGCInterval, "cache-gc-interval", cache.CacheGCInterval, "How often to check for and remove stale cache entries in the RuleSet cache")
 	flag.DurationVar(&cfg.cacheMaxAge, "cache-max-age", cache.CacheMaxAge, "Maximum age of a cache entry before it's considered stale in the RuleSet cache")
-	flag.IntVar(&cfg.cacheMaxSize, "cache-max-size", cache.CacheMaxSize, fmt.Sprintf("Maximum total size of all cached rules in the RuleSet cache in bytes (default %dMB)", cache.CacheMaxSize/(1024*1024)))
+	flag.IntVar(&cfg.cacheMaxSize, "cache-max-size", cache.CacheMaxSize, fmt.Sprintf("Maximum total size of all cached rules in the RuleSet cache in bytes; must be > 0 (default %dMB)", cache.CacheMaxSize/(1024*1024)))
 	flag.IntVar(&cfg.cacheServerPort, "cache-server-port", controller.DefaultRuleSetCacheServerPort, fmt.Sprintf("Port number for the RuleSet cache server to listen on (default %d)", controller.DefaultRuleSetCacheServerPort))
 	flag.StringVar(&cfg.envoyClusterName, "envoy-cluster-name", "", "The Envoy cluster name pointing to the RuleSet cache server (required)")
 	flag.StringVar(&cfg.istioRevision, "istio-revision", "", "The Istio revision label value for managed Istio resources")
@@ -309,6 +317,13 @@ func setupHealthChecks(mgr ctrl.Manager) {
 // Validation
 // -----------------------------------------------------------------------------
 
+func validateCacheMaxSize(n int) error {
+	if n <= 0 {
+		return fmt.Errorf("must be greater than 0 (got %d)", n)
+	}
+	return nil
+}
+
 func validateDefaultWasmImage(ref string) error {
 	if ref == "" {
 		return errors.New("must be non-empty")
@@ -325,6 +340,10 @@ func validateDefaultWasmImage(ref string) error {
 func validateFlags(cfg config) {
 	if cfg.envoyClusterName == "" {
 		setupLog.Error(errors.New("missing required flag"), "envoy-cluster-name is required")
+		os.Exit(1)
+	}
+	if err := validateCacheMaxSize(cfg.cacheMaxSize); err != nil {
+		setupLog.Error(err, "invalid cache-max-size")
 		os.Exit(1)
 	}
 	if err := validateDefaultWasmImage(cfg.defaultWasmImage); err != nil {

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -29,6 +29,29 @@ import (
 )
 
 // -----------------------------------------------------------------------------
+// validateCacheMaxSize Tests
+// -----------------------------------------------------------------------------
+
+func TestValidateCacheMaxSize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero", func(t *testing.T) {
+		t.Parallel()
+		assert.Error(t, validateCacheMaxSize(0))
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		t.Parallel()
+		assert.Error(t, validateCacheMaxSize(-1))
+	})
+
+	t.Run("positive", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, validateCacheMaxSize(1))
+	})
+}
+
+// -----------------------------------------------------------------------------
 // validateDefaultWasmImage Tests
 // -----------------------------------------------------------------------------
 

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -51,13 +51,50 @@ const DefaultRuleSetCacheServerPort = 18080
 // Manager - Setup
 // -----------------------------------------------------------------------------
 
-// SetupControllers initializes all controllers
-func SetupControllers(mgr ctrl.Manager, rulesetCache *cache.RuleSetCache, envoyClusterName, istioRevision string, defaultWasmImage, operatorNamespace string, kubeClient kubernetes.Interface) error {
+// RuleSetOpts holds configuration for the RuleSet reconciler.
+type RuleSetOpts struct {
+	// MaxPayloadSize is the per-RuleSet aggregated payload limit in bytes before
+	// the reconciler rejects caching and marks the RuleSet Degraded.
+	// Zero means use cache.CacheMaxSize (the same default as --cache-max-size).
+	// Negative values are invalid. SetupControllers applies this default; constructing
+	// RuleSetReconciler with MaxPayloadSize 0 disables the check (tests only).
+	MaxPayloadSize int
+}
+
+// EngineOpts holds configuration for the Engine reconciler.
+type EngineOpts struct {
+	EnvoyClusterName  string
+	IstioRevision     string
+	DefaultWasmImage  string
+	OperatorNamespace string
+}
+
+// resolveRuleSetMaxPayloadSize maps RuleSetOpts.MaxPayloadSize to the value stored
+// on RuleSetReconciler. Zero opts means the default admission budget (cache.CacheMaxSize).
+func resolveRuleSetMaxPayloadSize(opts RuleSetOpts) (int, error) {
+	n := opts.MaxPayloadSize
+	if n == 0 {
+		return cache.CacheMaxSize, nil
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("invalid RuleSetOpts.MaxPayloadSize %d: must be >= 0 (0 uses default %d bytes)", n, cache.CacheMaxSize)
+	}
+	return n, nil
+}
+
+// SetupControllers initializes all controllers.
+func SetupControllers(mgr ctrl.Manager, kubeClient kubernetes.Interface, rulesetCache *cache.RuleSetCache, ruleSetOpts RuleSetOpts, engineOpts EngineOpts) error {
+	maxPayload, err := resolveRuleSetMaxPayloadSize(ruleSetOpts)
+	if err != nil {
+		return err
+	}
+
 	if err := (&RuleSetReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("ruleset-controller"),
-		Cache:    rulesetCache,
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		Recorder:       mgr.GetEventRecorder("ruleset-controller"),
+		Cache:          rulesetCache,
+		MaxPayloadSize: maxPayload,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller RuleSet: %w", err)
 	}
@@ -67,10 +104,10 @@ func SetupControllers(mgr ctrl.Manager, rulesetCache *cache.RuleSetCache, envoyC
 		Scheme:                    mgr.GetScheme(),
 		Recorder:                  mgr.GetEventRecorder("engine-controller"),
 		kubeClient:                kubeClient,
-		ruleSetCacheServerCluster: envoyClusterName,
-		istioRevision:             istioRevision,
-		defaultWasmImage:          defaultWasmImage,
-		operatorNamespace:         operatorNamespace,
+		ruleSetCacheServerCluster: engineOpts.EnvoyClusterName,
+		istioRevision:             engineOpts.IstioRevision,
+		defaultWasmImage:          engineOpts.DefaultWasmImage,
+		operatorNamespace:         engineOpts.OperatorNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller Engine: %w", err)
 	}

--- a/internal/controller/manager_test.go
+++ b/internal/controller/manager_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
+)
+
+func TestResolveRuleSetMaxPayloadSize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero defaults to CacheMaxSize", func(t *testing.T) {
+		t.Parallel()
+		got, err := resolveRuleSetMaxPayloadSize(RuleSetOpts{})
+		require.NoError(t, err)
+		require.Equal(t, cache.CacheMaxSize, got)
+	})
+
+	t.Run("positive passes through", func(t *testing.T) {
+		t.Parallel()
+		const want = 42
+		got, err := resolveRuleSetMaxPayloadSize(RuleSetOpts{MaxPayloadSize: want})
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("negative is invalid", func(t *testing.T) {
+		t.Parallel()
+		_, err := resolveRuleSetMaxPayloadSize(RuleSetOpts{MaxPayloadSize: -1})
+		require.Error(t, err)
+	})
+}

--- a/internal/controller/ruleset_controller.go
+++ b/internal/controller/ruleset_controller.go
@@ -60,6 +60,10 @@ type RuleSetReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
 	Cache    *cache.RuleSetCache
+	// MaxPayloadSize limits aggregated RuleSet payload size; zero disables the check
+	// (tests). Production wiring uses SetupControllers, which defaults a zero
+	// RuleSetOpts.MaxPayloadSize to cache.CacheMaxSize.
+	MaxPayloadSize int
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/ruleset_controller_cache.go
+++ b/internal/controller/ruleset_controller_cache.go
@@ -14,8 +14,20 @@ import (
 // RuleSetReconciler - Cache Storage
 // -----------------------------------------------------------------------------
 
+// cacheEntryPayloadSize computes the byte size of a cache entry payload using
+// the same accounting as RuleSetCache.TotalSize: len(rules) plus, for each
+// data file, len(filename) + len(content).
+func cacheEntryPayloadSize(rules string, dataFiles map[string][]byte) int {
+	size := len(rules)
+	for name, content := range dataFiles {
+		size += len(name) + len(content)
+	}
+	return size
+}
+
 // cacheRules stores the aggregated rules in the cache and patches the RuleSet
-// status to Ready.
+// status to Ready. If the payload exceeds the per-instance budget
+// (MaxPayloadSize), it rejects the entry and marks the RuleSet Degraded.
 func (r *RuleSetReconciler) cacheRules(
 	ctx context.Context,
 	log logr.Logger,
@@ -26,6 +38,23 @@ func (r *RuleSetReconciler) cacheRules(
 	unsupportedMsg string,
 ) (ctrl.Result, error) {
 	cacheKey := fmt.Sprintf("%s/%s", ruleset.Namespace, ruleset.Name)
+
+	if r.MaxPayloadSize > 0 {
+		payloadSize := cacheEntryPayloadSize(aggregatedRules, secretData)
+		if payloadSize > r.MaxPayloadSize {
+			msg := fmt.Sprintf(
+				"Aggregated rules payload (%d bytes) exceeds maximum allowed size (%d bytes). Reduce the number or size of referenced ConfigMaps/Secrets.",
+				payloadSize, r.MaxPayloadSize,
+			)
+			logError(log, req, "RuleSet", fmt.Errorf("payload %d bytes exceeds limit %d bytes", payloadSize, r.MaxPayloadSize),
+				"Rejecting oversized cache entry", "cacheKey", cacheKey)
+			if err := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "OversizedRules", msg); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+	}
+
 	// NOTE: The data stored in the cache (including any RuleData sourced from a Secret)
 	// is served by the cache HTTP server for consumption by the WASM plugin and must
 	// therefore not contain sensitive or credential material. Treat the cache server

--- a/internal/controller/ruleset_controller_test.go
+++ b/internal/controller/ruleset_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"context"
 	"sort"
 	"testing"
@@ -1015,5 +1016,313 @@ func TestRuleSetReconciler_UnsupportedRules(t *testing.T) {
 		t.Log("Verifying Warning/UnsupportedRules event was still emitted")
 		assert.True(t, recorder.HasEvent("Warning", "UnsupportedRules"),
 			"expected Warning/UnsupportedRules event even with annotation override; got: %v", recorder.Events)
+	})
+}
+
+func TestRuleSetReconciler_OversizedPayload(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("oversized ruleset is rejected with Degraded status", func(t *testing.T) {
+		ruleSetCache := cache.NewRuleSetCache()
+
+		t.Log("Creating ConfigMap with valid rules")
+		cm := utils.NewTestConfigMap("oversize-rules", testNamespace,
+			"SecRule REQUEST_URI \"@contains /admin\" \"id:1,deny\"")
+		require.NoError(t, k8sClient.Create(ctx, cm))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, cm); err != nil {
+				t.Logf("Failed to delete ConfigMap: %v", err)
+			}
+		})
+
+		ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+			Name:      "oversize-ruleset",
+			Namespace: testNamespace,
+			Rules: []wafv1alpha1.RuleSourceReference{
+				{Name: "oversize-rules"},
+			},
+		})
+		require.NoError(t, k8sClient.Create(ctx, ruleSet))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, ruleSet); err != nil {
+				t.Logf("Failed to delete RuleSet: %v", err)
+			}
+		})
+
+		recorder := utils.NewFakeRecorder()
+		reconciler := &RuleSetReconciler{
+			Client:         k8sClient,
+			Scheme:         scheme,
+			Recorder:       recorder,
+			Cache:          ruleSetCache,
+			MaxPayloadSize: 1, // 1 byte: any real payload will exceed this
+		}
+
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      ruleSet.Name,
+				Namespace: ruleSet.Namespace,
+			},
+		})
+
+		require.NoError(t, err, "oversized rejection should not return an error")
+		assert.Equal(t, reconcile.Result{}, result)
+
+		t.Log("Verifying cache was NOT populated")
+		cacheKey := testNamespace + "/oversize-ruleset"
+		_, ok := ruleSetCache.Get(cacheKey)
+		assert.False(t, ok, "cache must not contain an entry for oversized ruleset")
+
+		t.Log("Verifying status conditions")
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+			Name:      ruleSet.Name,
+			Namespace: ruleSet.Namespace,
+		}, ruleSet))
+		ready := apimeta.FindStatusCondition(ruleSet.Status.Conditions, "Ready")
+		require.NotNil(t, ready)
+		assert.Equal(t, metav1.ConditionFalse, ready.Status)
+		assert.Equal(t, "OversizedRules", ready.Reason)
+		assert.Contains(t, ready.Message, "exceeds maximum allowed size")
+
+		degraded := apimeta.FindStatusCondition(ruleSet.Status.Conditions, "Degraded")
+		require.NotNil(t, degraded)
+		assert.Equal(t, metav1.ConditionTrue, degraded.Status)
+		assert.Equal(t, "OversizedRules", degraded.Reason)
+
+		t.Log("Verifying Warning/OversizedRules event")
+		assert.True(t, recorder.HasEvent("Warning", "OversizedRules"),
+			"expected Warning/OversizedRules event; got: %v", recorder.Events)
+	})
+
+	t.Run("payload within budget is accepted normally", func(t *testing.T) {
+		ruleSetCache := cache.NewRuleSetCache()
+
+		cm := utils.NewTestConfigMap("within-budget-rules", testNamespace,
+			"SecRule REQUEST_URI \"@contains /test\" \"id:2,deny\"")
+		require.NoError(t, k8sClient.Create(ctx, cm))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, cm); err != nil {
+				t.Logf("Failed to delete ConfigMap: %v", err)
+			}
+		})
+
+		ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+			Name:      "within-budget-ruleset",
+			Namespace: testNamespace,
+			Rules: []wafv1alpha1.RuleSourceReference{
+				{Name: "within-budget-rules"},
+			},
+		})
+		require.NoError(t, k8sClient.Create(ctx, ruleSet))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, ruleSet); err != nil {
+				t.Logf("Failed to delete RuleSet: %v", err)
+			}
+		})
+
+		recorder := utils.NewFakeRecorder()
+		reconciler := &RuleSetReconciler{
+			Client:         k8sClient,
+			Scheme:         scheme,
+			Recorder:       recorder,
+			Cache:          ruleSetCache,
+			MaxPayloadSize: 100 * 1024 * 1024, // 100 MB — normal budget
+		}
+
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      ruleSet.Name,
+				Namespace: ruleSet.Namespace,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+
+		cacheKey := testNamespace + "/within-budget-ruleset"
+		entry, ok := ruleSetCache.Get(cacheKey)
+		assert.True(t, ok, "cache should contain entry for within-budget ruleset")
+		assert.NotEmpty(t, entry.UUID)
+
+		assert.True(t, recorder.HasEvent("Normal", "RulesCached"),
+			"expected Normal/RulesCached event; got: %v", recorder.Events)
+	})
+
+	t.Run("zero MaxPayloadSize disables admission check", func(t *testing.T) {
+		ruleSetCache := cache.NewRuleSetCache()
+
+		cm := utils.NewTestConfigMap("no-limit-rules", testNamespace,
+			"SecRule REQUEST_URI \"@contains /nolimit\" \"id:3,deny\"")
+		require.NoError(t, k8sClient.Create(ctx, cm))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, cm); err != nil {
+				t.Logf("Failed to delete ConfigMap: %v", err)
+			}
+		})
+
+		ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+			Name:      "no-limit-ruleset",
+			Namespace: testNamespace,
+			Rules: []wafv1alpha1.RuleSourceReference{
+				{Name: "no-limit-rules"},
+			},
+		})
+		require.NoError(t, k8sClient.Create(ctx, ruleSet))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, ruleSet); err != nil {
+				t.Logf("Failed to delete RuleSet: %v", err)
+			}
+		})
+
+		reconciler := &RuleSetReconciler{
+			Client:         k8sClient,
+			Scheme:         scheme,
+			Recorder:       utils.NewTestRecorder(),
+			Cache:          ruleSetCache,
+			MaxPayloadSize: 0, // disabled
+		}
+
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      ruleSet.Name,
+				Namespace: ruleSet.Namespace,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+
+		cacheKey := testNamespace + "/no-limit-ruleset"
+		_, ok := ruleSetCache.Get(cacheKey)
+		assert.True(t, ok, "cache should contain entry when MaxPayloadSize is 0 (disabled)")
+	})
+
+	t.Run("previously cached entry preserved when oversized update is rejected", func(t *testing.T) {
+		ruleSetCache := cache.NewRuleSetCache()
+		cacheKey := testNamespace + "/oversize-update"
+
+		t.Log("Pre-populating cache to simulate previous valid reconciliation")
+		const previousRules = "SecCollectionTimeout 1"
+		ruleSetCache.Put(cacheKey, previousRules, nil)
+		prior, ok := ruleSetCache.Get(cacheKey)
+		require.True(t, ok)
+		priorUUID := prior.UUID
+
+		cm := utils.NewTestConfigMap("oversize-update-rules", testNamespace,
+			"SecRule REQUEST_URI \"@contains /big\" \"id:4,deny\"")
+		require.NoError(t, k8sClient.Create(ctx, cm))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, cm); err != nil {
+				t.Logf("Failed to delete ConfigMap: %v", err)
+			}
+		})
+
+		ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+			Name:      "oversize-update",
+			Namespace: testNamespace,
+			Rules: []wafv1alpha1.RuleSourceReference{
+				{Name: "oversize-update-rules"},
+			},
+		})
+		require.NoError(t, k8sClient.Create(ctx, ruleSet))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, ruleSet); err != nil {
+				t.Logf("Failed to delete RuleSet: %v", err)
+			}
+		})
+
+		reconciler := &RuleSetReconciler{
+			Client:         k8sClient,
+			Scheme:         scheme,
+			Recorder:       utils.NewFakeRecorder(),
+			Cache:          ruleSetCache,
+			MaxPayloadSize: 1, // triggers rejection
+		}
+
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      ruleSet.Name,
+				Namespace: ruleSet.Namespace,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+
+		t.Log("Verifying the previously cached entry is preserved (last-known-good)")
+		entry, ok := ruleSetCache.Get(cacheKey)
+		require.True(t, ok, "prior cache entry must be preserved")
+		assert.Equal(t, priorUUID, entry.UUID, "cache UUID must not have changed")
+		assert.Equal(t, previousRules, entry.Rules)
+	})
+
+	t.Run("RuleData secret bytes count toward payload limit", func(t *testing.T) {
+		ruleSetCache := cache.NewRuleSetCache()
+
+		cm := utils.NewTestConfigMap("oversize-ruledata-cm", testNamespace,
+			`SecRule REQUEST_URI "@pmFromFile rule1.data" "id:55555,phase:1,deny,status:403,msg:'x'"`)
+		require.NoError(t, k8sClient.Create(ctx, cm))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, cm); err != nil {
+				t.Logf("Failed to delete ConfigMap: %v", err)
+			}
+		})
+
+		largeData := bytes.Repeat([]byte("x"), 10000)
+		sec := utils.NewTestRuleData("oversize-ruledata-secret", testNamespace, map[string][]byte{
+			"rule1.data": largeData,
+		})
+		require.NoError(t, k8sClient.Create(ctx, sec))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, sec); err != nil {
+				t.Logf("Failed to delete Secret: %v", err)
+			}
+		})
+
+		ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+			Name:      "oversize-ruledata-ruleset",
+			Namespace: testNamespace,
+			Rules: []wafv1alpha1.RuleSourceReference{
+				{Name: "oversize-ruledata-cm"},
+			},
+			RuleData: "oversize-ruledata-secret",
+		})
+		require.NoError(t, k8sClient.Create(ctx, ruleSet))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, ruleSet); err != nil {
+				t.Logf("Failed to delete RuleSet: %v", err)
+			}
+		})
+
+		reconciler := &RuleSetReconciler{
+			Client:         k8sClient,
+			Scheme:         scheme,
+			Recorder:       utils.NewFakeRecorder(),
+			Cache:          ruleSetCache,
+			MaxPayloadSize: 500, // tiny budget; payload dominated by RuleData file bytes
+		}
+
+		result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      ruleSet.Name,
+				Namespace: ruleSet.Namespace,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+
+		cacheKey := testNamespace + "/oversize-ruledata-ruleset"
+		_, ok := ruleSetCache.Get(cacheKey)
+		assert.False(t, ok, "cache must not accept oversized RuleData payload")
+
+		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
+			Name:      ruleSet.Name,
+			Namespace: ruleSet.Namespace,
+		}, ruleSet))
+		ready := apimeta.FindStatusCondition(ruleSet.Status.Conditions, "Ready")
+		require.NotNil(t, ready)
+		assert.Equal(t, metav1.ConditionFalse, ready.Status)
+		assert.Equal(t, "OversizedRules", ready.Reason)
 	})
 }

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -31,7 +31,76 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
+	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
 )
+
+func TestCacheEntryPayloadSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		rules     string
+		dataFiles map[string][]byte
+		expected  int
+	}{
+		{
+			name:      "empty rules, nil data",
+			rules:     "",
+			dataFiles: nil,
+			expected:  0,
+		},
+		{
+			name:      "rules only",
+			rules:     "SecRule REQUEST_URI",
+			dataFiles: nil,
+			expected:  len("SecRule REQUEST_URI"),
+		},
+		{
+			name:  "rules plus data files",
+			rules: "abc",
+			dataFiles: map[string][]byte{
+				"file.data": []byte("content"),
+			},
+			expected: len("abc") + len("file.data") + len("content"),
+		},
+		{
+			name:  "multiple data files",
+			rules: "",
+			dataFiles: map[string][]byte{
+				"a.data": []byte("x"),
+				"b.data": []byte("yy"),
+			},
+			expected: len("a.data") + 1 + len("b.data") + 2,
+		},
+		{
+			name:      "empty data map",
+			rules:     "r",
+			dataFiles: map[string][]byte{},
+			expected:  1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cacheEntryPayloadSize(tt.rules, tt.dataFiles)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestCacheEntryPayloadSize_matchesRuleSetCacheTotalSize(t *testing.T) {
+	c := cache.NewRuleSetCache()
+	rules := "SecRule"
+	data := map[string][]byte{"rule1.data": []byte("payload")}
+	want := cacheEntryPayloadSize(rules, data)
+	c.Put("test/instance", rules, data)
+	assert.Equal(t, want, c.TotalSize(), "payload accounting must match RuleSetCache.TotalSize for a single stored entry")
+}
+
+func TestOversizedAdmissionUsesStrictGreaterThanBudget(t *testing.T) {
+	budget := 1000
+	rules := strings.Repeat("a", 1000)
+	assert.Equal(t, 1000, cacheEntryPayloadSize(rules, nil))
+	assert.False(t, cacheEntryPayloadSize(rules, nil) > budget, "equal payload must be admitted (check uses > not >=)")
+	assert.True(t, cacheEntryPayloadSize(rules+"x", nil) > budget)
+}
 
 func TestBuildCacheReadyMessage(t *testing.T) {
 	t.Run("without unsupported message", func(t *testing.T) {


### PR DESCRIPTION
**Describe the pull request**

The cache GC intentionally never prunes the latest entry per instance,
so a single oversized RuleSet can permanently exceed CacheMaxSize. This
adds admission control before Put: if the aggregated payload exceeds
MaxPayloadSize (defaults to CacheMaxSize), the entry is rejected and the
RuleSet is marked Degraded with reason OversizedRules. Previously cached
entries are preserved as last-known-good.

**Which issue this resolves**


**Additional context**

Replace the long positional list on SetupControllers with RuleSetOpts and
EngineOpts so each reconciler's settings are grouped and call sites stay
readable.

Keep *cache.RuleSetCache as its own parameter so the shared cache stays
clearly a runtime dependency rather than mixed with config structs.
