### PR TITLE
fix(ruleset): replace regex error sanitization with fs.PathError detection

### DIFF
--- a/internal/controller/ruleset_controller.go
+++ b/internal/controller/ruleset_controller.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"regexp"
 	"time"
 
 	"github.com/corazawaf/coraza/v3"
@@ -39,10 +38,6 @@ import (
 
 	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
 	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
-)
-
-var (
-	sanitizeFilePath = regexp.MustCompile(`open (.+): no such file or directory`)
 )
 
 // -----------------------------------------------------------------------------

--- a/internal/controller/ruleset_controller_validation_test.go
+++ b/internal/controller/ruleset_controller_validation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,5 +53,12 @@ func TestValidateConfigMapRules(t *testing.T) {
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "data-cm")
+		// Adversarial: user-visible error must not embed memfs/container absolute paths.
+		msg := err.Error()
+		if strings.Contains(msg, "/") {
+			for _, leak := range []string{"/var/", "/etc/", "/tmp/", "/app/", "/root/"} {
+				assert.NotContains(t, msg, leak, "validation error leaked a filesystem path segment")
+			}
+		}
 	})
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 
 	"github.com/go-logr/logr"
@@ -358,35 +359,48 @@ func serverSideApply(ctx context.Context, c client.Client, desired *unstructured
 // Error Messaging Helpers
 // -----------------------------------------------------------------------------
 
-func sanitizeErrorMessage(err error) error {
-	matches := sanitizeFilePath.FindStringSubmatch(err.Error())
-
-	if len(matches) < 2 {
-		return err
+// extractMissingFileBasename extracts the base filename from a missing-file
+// error by walking the error chain for *fs.PathError with fs.ErrNotExist.
+// Returns the basename and true when a structured PathError is found; ("", false)
+// otherwise.
+func extractMissingFileBasename(err error) (string, bool) {
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) && errors.Is(pathErr.Err, fs.ErrNotExist) {
+		return filepath.Base(pathErr.Path), true
 	}
-
-	// matches[1] is the full path. filepath.Base pulls the last element.
-	fileName := filepath.Base(matches[1])
-
-	return fmt.Errorf("open %s: data does not exist", fileName)
-
+	return "", false
 }
 
-// shouldSkipMissingFileError reports whether a missing-file validation error should
-// be skipped because the file is present in secretData.
+// sanitizeErrorMessage replaces filesystem paths in missing-file errors with
+// just the base filename to prevent disclosure of container-internal paths.
+//
+// Detection order:
+//  1. Structured: walk error chain for *fs.PathError + fs.ErrNotExist.
+//  2. Fail-safe: if errors.Is(err, fs.ErrNotExist) but no PathError found,
+//     return a generic redacted message.
+//  3. Non-file errors pass through unchanged.
+func sanitizeErrorMessage(err error) error {
+	if basename, ok := extractMissingFileBasename(err); ok {
+		return fmt.Errorf("open %s: data does not exist", basename)
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return errors.New("validation failed: referenced file does not exist (path redacted)")
+	}
+	return err
+}
+
+// shouldSkipMissingFileError reports whether a missing-file validation error
+// should be skipped because the file is present in secretData. Uses the same
+// structured extraction as sanitizeErrorMessage for consistency.
 func shouldSkipMissingFileError(err error, secretData map[string][]byte) bool {
 	if secretData == nil {
 		return false
 	}
-
-	matches := sanitizeFilePath.FindStringSubmatch(err.Error())
-	if len(matches) < 2 {
+	basename, ok := extractMissingFileBasename(err)
+	if !ok {
 		return false
 	}
-
-	fileName := filepath.Base(matches[1])
-
-	_, exists := secretData[fileName]
+	_, exists := secretData[basename]
 	return exists
 }
 

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -82,4 +88,200 @@ func TestCollectRequests(t *testing.T) {
 			{NamespacedName: types.NamespacedName{Name: "b", Namespace: "ns1"}},
 		}, got)
 	})
+}
+
+func TestExtractMissingFileBasename(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantBase string
+		wantOK   bool
+	}{
+		{
+			name:     "bare PathError with ErrNotExist",
+			err:      &fs.PathError{Op: "open", Path: "/var/lib/data/rules.conf", Err: fs.ErrNotExist},
+			wantBase: "rules.conf",
+			wantOK:   true,
+		},
+		{
+			name:     "single-wrapped PathError",
+			err:      fmt.Errorf("outer: %w", &fs.PathError{Op: "open", Path: "/secret/path/file.data", Err: fs.ErrNotExist}),
+			wantBase: "file.data",
+			wantOK:   true,
+		},
+		{
+			name: "double-wrapped PathError (Coraza style)",
+			err: fmt.Errorf("invalid WAF config from string: %w",
+				fmt.Errorf("failed to compile the directive \"secrule\": %w",
+					&fs.PathError{Op: "open", Path: "/app/rules/modsec.data", Err: fs.ErrNotExist})),
+			wantBase: "modsec.data",
+			wantOK:   true,
+		},
+		{
+			name:     "relative path",
+			err:      &fs.PathError{Op: "open", Path: "relative/file.txt", Err: fs.ErrNotExist},
+			wantBase: "file.txt",
+			wantOK:   true,
+		},
+		{
+			name:     "PathError Op stat (not just open)",
+			err:      &fs.PathError{Op: "stat", Path: "/var/lib/waf/stats.data", Err: fs.ErrNotExist},
+			wantBase: "stats.data",
+			wantOK:   true,
+		},
+		{
+			name:     "PathError with syscall.ENOENT (Unix)",
+			err:      &fs.PathError{Op: "open", Path: "/etc/coraza/x.data", Err: syscall.ENOENT},
+			wantBase: "x.data",
+			wantOK:   true,
+		},
+		{
+			name:     "PathError with different Err (not ErrNotExist)",
+			err:      &fs.PathError{Op: "open", Path: "/some/path", Err: fs.ErrPermission},
+			wantBase: "",
+			wantOK:   false,
+		},
+		{
+			name:     "non-PathError",
+			err:      errors.New("completely unrelated error"),
+			wantBase: "",
+			wantOK:   false,
+		},
+		{
+			name:     "ErrNotExist without PathError wrapper",
+			err:      fmt.Errorf("something went wrong: %w", fs.ErrNotExist),
+			wantBase: "",
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, ok := extractMissingFileBasename(tt.err)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantBase, base)
+		})
+	}
+}
+
+func TestSanitizeErrorMessage(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantSubstring string
+		wantNoAbsPath bool
+	}{
+		{
+			name:          "PathError sanitized to basename",
+			err:           &fs.PathError{Op: "open", Path: "/var/lib/operator/secret.data", Err: fs.ErrNotExist},
+			wantSubstring: "open secret.data: data does not exist",
+			wantNoAbsPath: true,
+		},
+		{
+			name: "wrapped PathError sanitized",
+			err: fmt.Errorf("invalid WAF config: %w",
+				&fs.PathError{Op: "open", Path: "/deep/nested/path/file.conf", Err: fs.ErrNotExist}),
+			wantSubstring: "open file.conf: data does not exist",
+			wantNoAbsPath: true,
+		},
+		{
+			name:          "ErrNotExist without PathError gets generic redaction",
+			err:           fmt.Errorf("something: %w", fs.ErrNotExist),
+			wantSubstring: "referenced file does not exist (path redacted)",
+			wantNoAbsPath: true,
+		},
+		{
+			name:          "non-file error passes through",
+			err:           errors.New("syntax error in directive"),
+			wantSubstring: "syntax error in directive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeErrorMessage(tt.err)
+			assert.Contains(t, result.Error(), tt.wantSubstring)
+			if tt.wantNoAbsPath {
+				assert.False(t, strings.Contains(result.Error(), "/var/"),
+					"sanitized error should not contain absolute paths")
+				assert.False(t, strings.Contains(result.Error(), "/deep/"),
+					"sanitized error should not contain absolute paths")
+			}
+		})
+	}
+}
+
+func TestSanitizeErrorMessage_NoAbsolutePathLeak(t *testing.T) {
+	paths := []string{
+		"/var/lib/operator/data/rules.data",
+		"/etc/coraza/secrets/api-keys.conf",
+		"/tmp/waf-runtime/cache/modsec.data",
+		"/home/operator/.config/rules.txt",
+	}
+	for _, p := range paths {
+		err := &fs.PathError{Op: "open", Path: p, Err: fs.ErrNotExist}
+		result := sanitizeErrorMessage(err).Error()
+		assert.False(t, strings.Contains(result, "/"),
+			"sanitized output for path %q should not contain any '/' but got: %s", p, result)
+	}
+}
+
+func TestShouldSkipMissingFileError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		secretData map[string][]byte
+		want       bool
+	}{
+		{
+			name:       "nil secretData always returns false",
+			err:        &fs.PathError{Op: "open", Path: "/path/to/rule.data", Err: fs.ErrNotExist},
+			secretData: nil,
+			want:       false,
+		},
+		{
+			name:       "basename found in secretData",
+			err:        &fs.PathError{Op: "open", Path: "/some/dir/rule.data", Err: fs.ErrNotExist},
+			secretData: map[string][]byte{"rule.data": []byte("content")},
+			want:       true,
+		},
+		{
+			name: "wrapped PathError, basename found",
+			err: fmt.Errorf("outer: %w",
+				&fs.PathError{Op: "open", Path: "/x/y/z/found.data", Err: fs.ErrNotExist}),
+			secretData: map[string][]byte{"found.data": []byte("x")},
+			want:       true,
+		},
+		{
+			name:       "basename not in secretData",
+			err:        &fs.PathError{Op: "open", Path: "/path/to/missing.data", Err: fs.ErrNotExist},
+			secretData: map[string][]byte{"other.data": []byte("content")},
+			want:       false,
+		},
+		{
+			name:       "non-PathError returns false",
+			err:        errors.New("generic error"),
+			secretData: map[string][]byte{"anything": []byte("x")},
+			want:       false,
+		},
+		{
+			name:       "ErrNotExist without PathError returns false",
+			err:        fmt.Errorf("wrapped: %w", fs.ErrNotExist),
+			secretData: map[string][]byte{"anything": []byte("x")},
+			want:       false,
+		},
+		{
+			name:       "PathError with ErrPermission returns false",
+			err:        &fs.PathError{Op: "open", Path: "/path/to/file.data", Err: fs.ErrPermission},
+			secretData: map[string][]byte{"file.data": []byte("x")},
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldSkipMissingFileError(tt.err, tt.secretData)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
**Describe the pull request**

The previous regex `open (.+): no such file or directory` was fragile: if Coraza or Go changed error wrapping, full container paths would leak into RuleSet status conditions and Kubernetes events.

Now uses errors.As to walk the error chain for *fs.PathError with fs.ErrNotExist, extracting the path structurally. A fail-safe catches bare ErrNotExist without PathError, returning a generic redacted message. Both sanitizeErrorMessage and shouldSkipMissingFileError share the same extractMissingFileBasename helper.


**Which issue this resolves**


**Additional context**

