### PR TITLE
feat: add USE-method metrics for RuleSet cache

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -245,6 +246,9 @@ func setupCacheServer(mgr ctrl.Manager, cfg config, kubeClient *kubernetes.Clien
 		MaxAge:     cfg.cacheMaxAge,
 		MaxSize:    cfg.cacheMaxSize,
 	}
+
+	cache.RegisterUSEMetrics(metrics.Registry, rulesetCache, *gcConfig)
+
 	tokenReview := kubeClient.AuthenticationV1().TokenReviews()
 	cacheServer := cache.NewServer(rulesetCache, fmt.Sprintf(":%d", cfg.cacheServerPort), ctrl.Log, gcConfig, tokenReview)
 	if err := mgr.Add(cacheServer); err != nil {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -247,7 +247,10 @@ func setupCacheServer(mgr ctrl.Manager, cfg config, kubeClient *kubernetes.Clien
 		MaxSize:    cfg.cacheMaxSize,
 	}
 
-	cache.RegisterUSEMetrics(metrics.Registry, rulesetCache, *gcConfig)
+	if err := cache.RegisterUSEMetrics(metrics.Registry, rulesetCache, *gcConfig); err != nil {
+		setupLog.Error(err, "unable to register USE metrics for ruleset cache")
+		os.Exit(1)
+	}
 
 	tokenReview := kubeClient.AuthenticationV1().TokenReviews()
 	cacheServer := cache.NewServer(rulesetCache, fmt.Sprintf(":%d", cfg.cacheServerPort), ctrl.Log, gcConfig, tokenReview)

--- a/internal/rulesets/cache/cache.go
+++ b/internal/rulesets/cache/cache.go
@@ -182,6 +182,21 @@ func (c *RuleSetCache) CountEntries(instance string) int {
 	return 0
 }
 
+// EntryCountsSnapshot returns a copy of entry revision counts per cache key
+// (instance). Used for metrics collection without holding the cache lock during
+// scrape.
+func (c *RuleSetCache) EntryCountsSnapshot() map[string]int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make(map[string]int, len(c.entries))
+	for k, v := range c.entries {
+		if v != nil {
+			out[k] = len(v.Entries)
+		}
+	}
+	return out
+}
+
 // -----------------------------------------------------------------------------
 // RuleSetCache - Cleanup
 // -----------------------------------------------------------------------------

--- a/internal/rulesets/cache/cache.go
+++ b/internal/rulesets/cache/cache.go
@@ -51,8 +51,9 @@ type RuleSetEntries struct {
 
 // RuleSetCache provides thread-safe storage for rulesets with versioning
 type RuleSetCache struct {
-	mu      sync.RWMutex
-	entries map[string]*RuleSetEntries
+	mu        sync.RWMutex
+	entries   map[string]*RuleSetEntries
+	totalSize int
 }
 
 // NewRuleSetCache creates a new RuleSetCache instance
@@ -112,6 +113,7 @@ func (c *RuleSetCache) Put(instance string, rules string, datafiles map[string][
 		Rules:     rules,
 		DataFiles: internalData,
 	}
+	newEntrySize := entrySize(newEntry)
 
 	if c.entries[instance] == nil {
 		c.entries[instance] = &RuleSetEntries{
@@ -122,6 +124,7 @@ func (c *RuleSetCache) Put(instance string, rules string, datafiles map[string][
 		c.entries[instance].Entries = append(c.entries[instance].Entries, newEntry)
 		c.entries[instance].Latest = newEntry.UUID
 	}
+	c.totalSize += newEntrySize
 }
 
 // Len returns the number of instances stored in the cache
@@ -146,17 +149,7 @@ func (c *RuleSetCache) ListKeys() []string {
 func (c *RuleSetCache) TotalSize() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	size := 0
-	for _, entries := range c.entries {
-		for _, entry := range entries.Entries {
-			size += len(entry.Rules)
-			for name, value := range entry.DataFiles {
-				size += len(name)
-				size += len(value)
-			}
-		}
-	}
-	return size
+	return c.totalSize
 }
 
 // SetEntryTimestamp updates the timestamp of an entry.
@@ -224,6 +217,7 @@ func (c *RuleSetCache) Prune(maxAge time.Duration) int {
 			if now.Sub(entry.Timestamp) <= maxAge {
 				newEntries = append(newEntries, entry)
 			} else {
+				c.totalSize -= entrySize(entry)
 				pruned++
 			}
 		}
@@ -240,16 +234,7 @@ func (c *RuleSetCache) PruneBySize(maxSize int) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	currentSize := 0
-	for _, entries := range c.entries {
-		for _, entry := range entries.Entries {
-			currentSize += len(entry.Rules)
-			for filename, v := range entry.DataFiles {
-				currentSize += len(filename)
-				currentSize += len(v)
-			}
-		}
-	}
+	currentSize := c.totalSize
 
 	if currentSize <= maxSize {
 		return 0
@@ -272,11 +257,9 @@ func (c *RuleSetCache) PruneBySize(maxSize int) int {
 
 			// If we're still over size, prune.
 			if currentSize > maxSize {
-				currentSize -= len(entry.Rules)
-				for filename, v := range entry.DataFiles {
-					currentSize -= len(filename)
-					currentSize -= len(v)
-				}
+				removedSize := entrySize(entry)
+				currentSize -= removedSize
+				c.totalSize -= removedSize
 				pruned++
 			} else {
 				// Under size now, keep the remainder.
@@ -287,4 +270,13 @@ func (c *RuleSetCache) PruneBySize(maxSize int) int {
 	}
 
 	return pruned
+}
+
+func entrySize(entry *RuleSetEntry) int {
+	size := len(entry.Rules)
+	for filename, v := range entry.DataFiles {
+		size += len(filename)
+		size += len(v)
+	}
+	return size
 }

--- a/internal/rulesets/cache/cache.go
+++ b/internal/rulesets/cache/cache.go
@@ -51,9 +51,10 @@ type RuleSetEntries struct {
 
 // RuleSetCache provides thread-safe storage for rulesets with versioning
 type RuleSetCache struct {
-	mu        sync.RWMutex
-	entries   map[string]*RuleSetEntries
-	totalSize int
+	mu           sync.RWMutex
+	entries      map[string]*RuleSetEntries
+	totalSize    int
+	totalEntries int
 }
 
 // NewRuleSetCache creates a new RuleSetCache instance
@@ -100,11 +101,13 @@ func (c *RuleSetCache) Put(instance string, rules string, datafiles map[string][
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Do a deepcopy on map to avoid race conditions in case someone access datafiles
-	// directly
-	internalData := make(map[string][]byte)
-	for f, v := range datafiles {
-		internalData[f] = bytes.Clone(v)
+	// Deep-copy to avoid races if the caller mutates the map after Put returns.
+	var internalData map[string][]byte
+	if len(datafiles) > 0 {
+		internalData = make(map[string][]byte, len(datafiles))
+		for f, v := range datafiles {
+			internalData[f] = bytes.Clone(v)
+		}
 	}
 
 	newEntry := &RuleSetEntry{
@@ -125,6 +128,7 @@ func (c *RuleSetCache) Put(instance string, rules string, datafiles map[string][
 		c.entries[instance].Latest = newEntry.UUID
 	}
 	c.totalSize += newEntrySize
+	c.totalEntries++
 }
 
 // Len returns the number of instances stored in the cache
@@ -152,16 +156,11 @@ func (c *RuleSetCache) TotalSize() int {
 	return c.totalSize
 }
 
-// SetEntryTimestamp updates the timestamp of an entry.
-func (c *RuleSetCache) SetEntryTimestamp(instance string, index int, timestamp time.Time) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if entries, ok := c.entries[instance]; ok {
-		if index >= 0 && index < len(entries.Entries) {
-			entries.Entries[index].Timestamp = timestamp
-		}
-	}
+// TotalEntries returns the total number of stored entry revisions across all cache keys.
+func (c *RuleSetCache) TotalEntries() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.totalEntries
 }
 
 // CountEntries returns the number of entries for an instance.
@@ -173,21 +172,6 @@ func (c *RuleSetCache) CountEntries(instance string) int {
 		return len(entries.Entries)
 	}
 	return 0
-}
-
-// EntryCountsSnapshot returns a copy of entry revision counts per cache key
-// (instance). Used for metrics collection without holding the cache lock during
-// scrape.
-func (c *RuleSetCache) EntryCountsSnapshot() map[string]int {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	out := make(map[string]int, len(c.entries))
-	for k, v := range c.entries {
-		if v != nil {
-			out[k] = len(v.Entries)
-		}
-	}
-	return out
 }
 
 // -----------------------------------------------------------------------------
@@ -218,6 +202,7 @@ func (c *RuleSetCache) Prune(maxAge time.Duration) int {
 				newEntries = append(newEntries, entry)
 			} else {
 				c.totalSize -= entrySize(entry)
+				c.totalEntries--
 				pruned++
 			}
 		}
@@ -260,6 +245,7 @@ func (c *RuleSetCache) PruneBySize(maxSize int) int {
 				removedSize := entrySize(entry)
 				currentSize -= removedSize
 				c.totalSize -= removedSize
+				c.totalEntries--
 				pruned++
 			} else {
 				// Under size now, keep the remainder.
@@ -272,6 +258,10 @@ func (c *RuleSetCache) PruneBySize(maxSize int) int {
 	return pruned
 }
 
+// entrySize computes the byte size of an entry's payload.
+// Incremental totalSize and totalEntries accounting in Put/Prune/PruneBySize
+// depends on entries being immutable after creation — never mutate Rules or
+// DataFiles on a stored entry.
 func entrySize(entry *RuleSetEntry) int {
 	size := len(entry.Rules)
 	for filename, v := range entry.DataFiles {

--- a/internal/rulesets/cache/cache_test.go
+++ b/internal/rulesets/cache/cache_test.go
@@ -105,7 +105,7 @@ func TestRuleSetCache_Pruning(t *testing.T) {
 				c.Put("instance1", "old-rules", nil)
 				c.Put("instance1", "new-rules", nil)
 				c.Put("instance2", "rules2", nil)
-				c.SetEntryTimestamp("instance1", 0, time.Now().Add(-25*time.Hour))
+				setEntryTimestamp(c, "instance1", 0, time.Now().Add(-25*time.Hour))
 			},
 			pruneMaxAge:   24 * time.Hour,
 			expectedCount: 1,
@@ -133,9 +133,9 @@ func TestRuleSetCache_Pruning(t *testing.T) {
 				c.Put("instance2", "new2", nil)
 				c.Put("instance3", "rules3", nil)
 				c.Put("instance4", "rules4", testDataFile)
-				c.SetEntryTimestamp("instance1", 0, time.Now().Add(-2*time.Hour))
-				c.SetEntryTimestamp("instance2", 0, time.Now().Add(-1*time.Hour))
-				c.SetEntryTimestamp("instance4", 0, time.Now().Add(-2*time.Hour))
+				setEntryTimestamp(c, "instance1", 0, time.Now().Add(-2*time.Hour))
+				setEntryTimestamp(c, "instance2", 0, time.Now().Add(-1*time.Hour))
+				setEntryTimestamp(c, "instance4", 0, time.Now().Add(-2*time.Hour))
 			},
 			pruneMaxSize:  80,
 			expectedCount: skipCountAssertion,
@@ -169,7 +169,7 @@ func TestRuleSetCache_Pruning(t *testing.T) {
 				time.Sleep(10 * time.Millisecond)
 				c.Put("instance1", "v3", nil)
 				for i := range 3 {
-					c.SetEntryTimestamp("instance1", i, time.Now().Add(-48*time.Hour))
+					setEntryTimestamp(c, "instance1", i, time.Now().Add(-48*time.Hour))
 				}
 			},
 			pruneMaxAge:   24 * time.Hour,
@@ -274,6 +274,85 @@ func TestRuleSetCache_TotalSize(t *testing.T) {
 		"file1": []byte("abcde"),
 	})
 	assert.Equal(t, 33, cache.TotalSize())
+}
+
+// TestRuleSetCache_TotalSizeInvariant verifies that TotalSize stays exactly
+// correct through a sequence of Put, Prune, and PruneBySize operations.
+func TestRuleSetCache_TotalSizeInvariant(t *testing.T) {
+	c := NewRuleSetCache()
+
+	// Put "abcde" (5) to instance1 — revision 0
+	c.Put("instance1", "abcde", nil) // +5
+	assert.Equal(t, 5, c.TotalSize())
+
+	// Put "xyz" (3) to instance1 — revision 1
+	c.Put("instance1", "xyz", nil) // +3
+	assert.Equal(t, 8, c.TotalSize())
+
+	// Put "hello" (5) + datafile "f.dat"(5)+"world"(5) = 15 to instance2 — revision 0
+	c.Put("instance2", "hello", map[string][]byte{"f.dat": []byte("world")}) // +15
+	assert.Equal(t, 23, c.TotalSize())
+
+	// Age out revision 0 of instance1 ("abcde", 5 bytes); keep revision 1 and instance2.
+	setEntryTimestamp(c, "instance1", 0, time.Now().Add(-48*time.Hour))
+	pruned := c.Prune(24 * time.Hour)
+	assert.Equal(t, 1, pruned)
+	assert.Equal(t, 18, c.TotalSize()) // 23 - 5
+
+	// Add another revision to instance1: "12" (2 bytes)
+	c.Put("instance1", "12", nil) // +2
+	assert.Equal(t, 20, c.TotalSize())
+
+	// PruneBySize to 10: should remove instance1 revision "xyz" (3 bytes), leaving "12" + instance2.
+	// After removing "xyz": 20 - 3 = 17, still > 10.
+	// After removing instance2's "hello"+"f.dat"+"world" (15): 17 - 15 = 2, under limit.
+	// But instance2 only has one entry (its latest), so it cannot be pruned.
+	// Result: only "xyz" (non-latest for instance1) gets removed. Size = 17.
+	c.PruneBySize(10)
+	// instance1 now has only "12" (latest, 2 bytes).
+	// instance2 still has "hello"+"f.dat"+"world" (15 bytes) — it's the latest and cannot be pruned.
+	assert.Equal(t, 17, c.TotalSize())
+}
+
+// TestRuleSetCache_TotalEntries verifies that TotalEntries stays exactly
+// correct through a sequence of Put, Prune, and PruneBySize operations,
+// including entries with DataFiles.
+func TestRuleSetCache_TotalEntries(t *testing.T) {
+	c := NewRuleSetCache()
+	assert.Equal(t, 0, c.TotalEntries())
+
+	// Two revisions to instance1, one to instance2.
+	c.Put("instance1", "v1", nil)
+	c.Put("instance1", "v2", nil)
+	c.Put("instance2", "v1", nil)
+	assert.Equal(t, 3, c.TotalEntries())
+
+	// One revision with DataFiles to instance3.
+	c.Put("instance3", "v1", map[string][]byte{"rules.dat": []byte("data")})
+	assert.Equal(t, 4, c.TotalEntries())
+
+	// Age out revision 0 of instance1; keep revision 1 (latest), instance2, instance3.
+	setEntryTimestamp(c, "instance1", 0, time.Now().Add(-48*time.Hour))
+	pruned := c.Prune(24 * time.Hour)
+	assert.Equal(t, 1, pruned)
+	assert.Equal(t, 3, c.TotalEntries())
+
+	// Add a new revision to instance1.
+	c.Put("instance1", "v3", nil)
+	assert.Equal(t, 4, c.TotalEntries())
+
+	// PruneBySize to a size that only forces removal of instance1's non-latest "v2".
+	// Current sizes: instance1 has "v2"(2) + "v3"(2) = 4; instance2 "v1"(2) = 2;
+	// instance3 "v1"(2) + "rules.dat"(9) + "data"(4) = 15. Total = 21.
+	// Prune to 19: need to remove 2 bytes. "v2" (2 bytes) is the only non-latest entry.
+	pruned = c.PruneBySize(19)
+	assert.Equal(t, 1, pruned)
+	assert.Equal(t, 3, c.TotalEntries())
+
+	// All remaining entries are latest; further PruneBySize does nothing.
+	pruned = c.PruneBySize(0)
+	assert.Equal(t, 0, pruned)
+	assert.Equal(t, 3, c.TotalEntries())
 }
 
 func TestRuleSetCache_PutUpdatesUUID(t *testing.T) {

--- a/internal/rulesets/cache/metrics_test.go
+++ b/internal/rulesets/cache/metrics_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -34,15 +35,6 @@ import (
 
 	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
 )
-
-// useTestCache is the shared cache instance used by USE metric tests.
-// Registered on the global metrics.Registry in init() so GaugeFunc closures
-// read from this cache.
-var useTestCache = NewRuleSetCache()
-
-func init() {
-	RegisterUSEMetrics(metrics.Registry, useTestCache, DefaultGC())
-}
 
 func TestMetricsRegistered(t *testing.T) {
 	registry := metrics.Registry
@@ -319,6 +311,16 @@ func TestInstrumentHandler_PanicAfterWriteHeaderUsesWrittenCode(t *testing.T) {
 // USE metrics
 // ---------------------------------------------------------------------------
 
+// newUSEMetricsRegistry returns an isolated prometheus.Registry and RuleSetCache
+// with USE metrics registered for that registry (no shared package-level cache).
+func newUSEMetricsRegistry(t *testing.T) (*prometheus.Registry, *RuleSetCache) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	c := NewRuleSetCache()
+	require.NoError(t, RegisterUSEMetrics(reg, c, DefaultGC()))
+	return reg, c
+}
+
 const (
 	gcMetricEventuallyTimeout = 5 * time.Second
 	gcMetricEventuallyTick    = 10 * time.Millisecond
@@ -342,10 +344,11 @@ func startGCLoopForTest(t *testing.T, srv *ruleSetCacheServer) {
 }
 
 func TestUSEMetricsRegistered(t *testing.T) {
+	reg, c := newUSEMetricsRegistry(t)
 	// Populate at least one cache key so coraza_cache_entries emits a sample.
-	useTestCache.Put("use-lint/x", "rules", nil)
+	c.Put("use-lint/x", "rules", nil)
 
-	problems, err := testutil.GatherAndLint(metrics.Registry,
+	problems, err := testutil.GatherAndLint(reg,
 		MetricCacheSizeBytes,
 		MetricCacheInstances,
 		MetricCacheEntries,
@@ -358,23 +361,26 @@ func TestUSEMetricsRegistered(t *testing.T) {
 }
 
 func TestUSEMetrics_SizeBytesReflectsCache(t *testing.T) {
-	before := gatherGaugeValue(t, metrics.Registry, MetricCacheSizeBytes)
-	useTestCache.Put("use-size/a", "some rules for size test", nil)
+	reg, c := newUSEMetricsRegistry(t)
+	before := gatherGaugeValue(t, reg, MetricCacheSizeBytes)
+	c.Put("use-size/a", "some rules for size test", nil)
 
-	after := gatherGaugeValue(t, metrics.Registry, MetricCacheSizeBytes)
+	after := gatherGaugeValue(t, reg, MetricCacheSizeBytes)
 	assert.Greater(t, after, before, "size_bytes should increase after Put")
 }
 
 func TestUSEMetrics_InstancesReflectsCache(t *testing.T) {
-	before := gatherGaugeValue(t, metrics.Registry, MetricCacheInstances)
-	useTestCache.Put("use-instances/unique-key", "rules", nil)
+	reg, c := newUSEMetricsRegistry(t)
+	before := gatherGaugeValue(t, reg, MetricCacheInstances)
+	c.Put("use-instances/unique-key", "rules", nil)
 
-	after := gatherGaugeValue(t, metrics.Registry, MetricCacheInstances)
+	after := gatherGaugeValue(t, reg, MetricCacheInstances)
 	assert.Equal(t, before+1, after, "instances should increase by 1 after adding a new key")
 }
 
 func TestUSEMetrics_ConfigMaxSizeBytesIsConstant(t *testing.T) {
-	val := gatherGaugeValue(t, metrics.Registry, MetricCacheConfigMaxSizeBytes)
+	reg, _ := newUSEMetricsRegistry(t)
+	val := gatherGaugeValue(t, reg, MetricCacheConfigMaxSizeBytes)
 	assert.Equal(t, float64(DefaultGC().MaxSize), val)
 }
 
@@ -466,11 +472,33 @@ func TestUSEMetrics_GCPrunedBySize(t *testing.T) {
 	}, gcMetricEventuallyTimeout, gcMetricEventuallyTick, "size prune counter should increment")
 }
 
-// Adversarial: RegisterUSEMetrics must be safe to call more than once (sync.Once; no double-register panic).
-func TestRegisterUSEMetrics_SecondCallDoesNotPanic(t *testing.T) {
-	require.NotPanics(t, func() {
-		RegisterUSEMetrics(metrics.Registry, NewRuleSetCache(), DefaultGC())
+func TestRegisterUSEMetrics_IdempotentWhenCacheAndGCMatch(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := NewRuleSetCache()
+	gc := DefaultGC()
+	require.NoError(t, RegisterUSEMetrics(reg, c, gc))
+	require.NoError(t, RegisterUSEMetrics(reg, c, gc))
+}
+
+func TestRegisterUSEMetrics_ConflictWhenCacheDiffers(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterUSEMetrics(reg, NewRuleSetCache(), DefaultGC()))
+	err := RegisterUSEMetrics(reg, NewRuleSetCache(), DefaultGC())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUSEMetricsRegistryConflict))
+}
+
+func TestRegisterUSEMetrics_ConflictWhenGCDiffers(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := NewRuleSetCache()
+	require.NoError(t, RegisterUSEMetrics(reg, c, DefaultGC()))
+	err := RegisterUSEMetrics(reg, c, GarbageCollectionConfig{
+		GCInterval: DefaultGC().GCInterval,
+		MaxAge:     DefaultGC().MaxAge,
+		MaxSize:    DefaultGC().MaxSize + 1,
 	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUSEMetricsRegistryConflict))
 }
 
 // Adversarial: cache_key label must tolerate non-ASCII instance paths (same class of input as HTTP paths).

--- a/internal/rulesets/cache/metrics_test.go
+++ b/internal/rulesets/cache/metrics_test.go
@@ -17,19 +17,32 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/networking-incubator/coraza-kubernetes-operator/test/utils"
 )
+
+// useTestCache is the shared cache instance used by USE metric tests.
+// Registered on the global metrics.Registry in init() so GaugeFunc closures
+// read from this cache.
+var useTestCache = NewRuleSetCache()
+
+func init() {
+	RegisterUSEMetrics(metrics.Registry, useTestCache, DefaultGC())
+}
 
 func TestMetricsRegistered(t *testing.T) {
 	registry := metrics.Registry
@@ -300,6 +313,233 @@ func TestInstrumentHandler_PanicAfterWriteHeaderUsesWrittenCode(t *testing.T) {
 	}()
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 	t.Fatal("expected panic")
+}
+
+// ---------------------------------------------------------------------------
+// USE metrics
+// ---------------------------------------------------------------------------
+
+const (
+	gcMetricEventuallyTimeout = 5 * time.Second
+	gcMetricEventuallyTick    = 10 * time.Millisecond
+)
+
+// startGCLoopForTest runs rungc in the background and registers cleanup that
+// cancels the context and waits for the goroutine to exit.
+func startGCLoopForTest(t *testing.T, srv *ruleSetCacheServer) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		srv.rungc(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+}
+
+func TestUSEMetricsRegistered(t *testing.T) {
+	// Populate at least one cache key so coraza_cache_entries emits a sample.
+	useTestCache.Put("use-lint/x", "rules", nil)
+
+	problems, err := testutil.GatherAndLint(metrics.Registry,
+		MetricCacheSizeBytes,
+		MetricCacheInstances,
+		MetricCacheEntries,
+		MetricCacheConfigMaxSizeBytes,
+		MetricCacheGCPrunedEntriesTotal,
+		MetricCacheGCSizeLimitExceeded,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, problems, "USE metric lint problems")
+}
+
+func TestUSEMetrics_SizeBytesReflectsCache(t *testing.T) {
+	before := gatherGaugeValue(t, metrics.Registry, MetricCacheSizeBytes)
+	useTestCache.Put("use-size/a", "some rules for size test", nil)
+
+	after := gatherGaugeValue(t, metrics.Registry, MetricCacheSizeBytes)
+	assert.Greater(t, after, before, "size_bytes should increase after Put")
+}
+
+func TestUSEMetrics_InstancesReflectsCache(t *testing.T) {
+	before := gatherGaugeValue(t, metrics.Registry, MetricCacheInstances)
+	useTestCache.Put("use-instances/unique-key", "rules", nil)
+
+	after := gatherGaugeValue(t, metrics.Registry, MetricCacheInstances)
+	assert.Equal(t, before+1, after, "instances should increase by 1 after adding a new key")
+}
+
+func TestUSEMetrics_ConfigMaxSizeBytesIsConstant(t *testing.T) {
+	val := gatherGaugeValue(t, metrics.Registry, MetricCacheConfigMaxSizeBytes)
+	assert.Equal(t, float64(DefaultGC().MaxSize), val)
+}
+
+func TestUSEMetrics_CacheEntriesPerKey(t *testing.T) {
+	c := NewRuleSetCache()
+	collector := newCacheEntriesCollector(c)
+
+	c.Put("ns/foo", "v1", nil)
+	c.Put("ns/foo", "v2", nil)
+	c.Put("ns/bar", "v1", nil)
+
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	byKey := map[string]float64{}
+	for m := range ch {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		for _, lp := range d.GetLabel() {
+			if lp.GetName() == "cache_key" {
+				byKey[lp.GetValue()] = d.GetGauge().GetValue()
+			}
+		}
+	}
+	assert.Equal(t, float64(2), byKey["ns/foo"])
+	assert.Equal(t, float64(1), byKey["ns/bar"])
+}
+
+func TestUSEMetrics_CacheEntriesCollectorEmitsNoStaleKeys(t *testing.T) {
+	c := NewRuleSetCache()
+	collector := newCacheEntriesCollector(c)
+
+	c.Put("ns/temp", "rules", nil)
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+	assert.Len(t, drainMetrics(ch), 1, "should emit one sample for one key")
+
+	// Empty cache produces zero samples (no stale labels).
+	c2 := NewRuleSetCache()
+	collector2 := newCacheEntriesCollector(c2)
+	ch2 := make(chan prometheus.Metric, 10)
+	collector2.Collect(ch2)
+	close(ch2)
+	assert.Empty(t, drainMetrics(ch2), "empty cache should emit zero samples")
+}
+
+func TestUSEMetrics_GCPrunedByAge(t *testing.T) {
+	gcPrunedEntriesTotal.Reset()
+
+	c := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	gc := &GarbageCollectionConfig{
+		GCInterval: 50 * time.Millisecond,
+		MaxAge:     100 * time.Millisecond,
+		MaxSize:    1024 * 1024 * 1024,
+	}
+	srv := NewServer(c, ":0", logger, gc, newNoopTokenReview())
+
+	c.Put("ns/a", "old", nil)
+	c.Put("ns/a", "new", nil)
+	c.SetEntryTimestamp("ns/a", 0, time.Now().Add(-200*time.Millisecond))
+
+	startGCLoopForTest(t, srv)
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(gcPrunedEntriesTotal.WithLabelValues(PruneReasonAge)) >= 1
+	}, gcMetricEventuallyTimeout, gcMetricEventuallyTick, "age prune counter should increment")
+}
+
+func TestUSEMetrics_GCPrunedBySize(t *testing.T) {
+	gcPrunedEntriesTotal.Reset()
+
+	c := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	gc := &GarbageCollectionConfig{
+		GCInterval: 50 * time.Millisecond,
+		MaxAge:     24 * time.Hour,
+		MaxSize:    10,
+	}
+	srv := NewServer(c, ":0", logger, gc, newNoopTokenReview())
+
+	c.Put("ns/a", "old version with enough bytes", nil)
+	c.Put("ns/a", "new version", nil)
+
+	startGCLoopForTest(t, srv)
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(gcPrunedEntriesTotal.WithLabelValues(PruneReasonSize)) >= 1
+	}, gcMetricEventuallyTimeout, gcMetricEventuallyTick, "size prune counter should increment")
+}
+
+// Adversarial: RegisterUSEMetrics must be safe to call more than once (sync.Once; no double-register panic).
+func TestRegisterUSEMetrics_SecondCallDoesNotPanic(t *testing.T) {
+	require.NotPanics(t, func() {
+		RegisterUSEMetrics(metrics.Registry, NewRuleSetCache(), DefaultGC())
+	})
+}
+
+// Adversarial: cache_key label must tolerate non-ASCII instance paths (same class of input as HTTP paths).
+func TestUSEMetrics_CacheEntriesCollector_UnicodeCacheKey(t *testing.T) {
+	c := NewRuleSetCache()
+	collector := newCacheEntriesCollector(c)
+	key := "ns/" + string([]rune{0x540d, 0x524d})
+	c.Put(key, "rules", nil)
+
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	var found bool
+	for _, m := range drainMetrics(ch) {
+		var d dto.Metric
+		require.NoError(t, m.Write(&d))
+		for _, lp := range d.GetLabel() {
+			if lp.GetName() == "cache_key" && lp.GetValue() == key {
+				found = true
+				assert.Equal(t, float64(1), d.GetGauge().GetValue())
+			}
+		}
+	}
+	assert.True(t, found, "expected a sample for unicode cache_key %q", key)
+}
+
+func TestUSEMetrics_GCSizeLimitExceeded(t *testing.T) {
+	before := testutil.ToFloat64(gcSizeLimitExceededTotal)
+
+	c := NewRuleSetCache()
+	logger := utils.NewTestLogger(t)
+	gc := &GarbageCollectionConfig{
+		GCInterval: 50 * time.Millisecond,
+		MaxAge:     24 * time.Hour,
+		MaxSize:    5,
+	}
+	srv := NewServer(c, ":0", logger, gc, newNoopTokenReview())
+
+	c.Put("ns/big", "this string is definitely longer than 5 bytes", nil)
+
+	startGCLoopForTest(t, srv)
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(gcSizeLimitExceededTotal) > before
+	}, gcMetricEventuallyTimeout, gcMetricEventuallyTick,
+		"size-limit-exceeded counter should increment when latest entry exceeds MaxSize")
+}
+
+// gatherGaugeValue gathers the named gauge metric from a prometheus.Gatherer.
+func gatherGaugeValue(t *testing.T, g prometheus.Gatherer, name string) float64 {
+	t.Helper()
+	families, err := g.Gather()
+	require.NoError(t, err)
+	for _, mf := range families {
+		if mf.GetName() == name {
+			require.NotEmpty(t, mf.GetMetric(), "metric %s has no samples", name)
+			return mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	t.Fatalf("metric %s not found", name)
+	return 0
+}
+
+func drainMetrics(ch <-chan prometheus.Metric) []prometheus.Metric {
+	out := make([]prometheus.Metric, 0)
+	for m := range ch {
+		out = append(out, m)
+	}
+	return out
 }
 
 // End-to-end: real server mux + instrumentHandler records metrics (same wiring as production).

--- a/internal/rulesets/cache/metrics_test.go
+++ b/internal/rulesets/cache/metrics_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -344,14 +343,12 @@ func startGCLoopForTest(t *testing.T, srv *ruleSetCacheServer) {
 }
 
 func TestUSEMetricsRegistered(t *testing.T) {
-	reg, c := newUSEMetricsRegistry(t)
-	// Populate at least one cache key so coraza_cache_entries emits a sample.
-	c.Put("use-lint/x", "rules", nil)
+	reg, _ := newUSEMetricsRegistry(t)
 
 	problems, err := testutil.GatherAndLint(reg,
 		MetricCacheSizeBytes,
 		MetricCacheInstances,
-		MetricCacheEntries,
+		MetricCacheTotalEntries,
 		MetricCacheConfigMaxSizeBytes,
 		MetricCacheGCPrunedEntriesTotal,
 		MetricCacheGCSizeLimitExceeded,
@@ -384,53 +381,24 @@ func TestUSEMetrics_ConfigMaxSizeBytesIsConstant(t *testing.T) {
 	assert.Equal(t, float64(DefaultGC().MaxSize), val)
 }
 
-func TestUSEMetrics_CacheEntriesPerKey(t *testing.T) {
-	c := NewRuleSetCache()
-	collector := newCacheEntriesCollector(c)
+func TestUSEMetrics_TotalEntriesReflectsCache(t *testing.T) {
+	reg, c := newUSEMetricsRegistry(t)
 
-	c.Put("ns/foo", "v1", nil)
-	c.Put("ns/foo", "v2", nil)
-	c.Put("ns/bar", "v1", nil)
+	before := gatherGaugeValue(t, reg, MetricCacheTotalEntries)
+	c.Put("entries-test/a", "v1", nil)
+	c.Put("entries-test/a", "v2", nil)
+	c.Put("entries-test/b", "v1", nil)
 
-	ch := make(chan prometheus.Metric, 10)
-	collector.Collect(ch)
-	close(ch)
+	after := gatherGaugeValue(t, reg, MetricCacheTotalEntries)
+	assert.Equal(t, before+3, after, "total_entries should increase by the number of Put calls")
 
-	byKey := map[string]float64{}
-	for m := range ch {
-		var d dto.Metric
-		require.NoError(t, m.Write(&d))
-		for _, lp := range d.GetLabel() {
-			if lp.GetName() == "cache_key" {
-				byKey[lp.GetValue()] = d.GetGauge().GetValue()
-			}
-		}
-	}
-	assert.Equal(t, float64(2), byKey["ns/foo"])
-	assert.Equal(t, float64(1), byKey["ns/bar"])
-}
-
-func TestUSEMetrics_CacheEntriesCollectorEmitsNoStaleKeys(t *testing.T) {
-	c := NewRuleSetCache()
-	collector := newCacheEntriesCollector(c)
-
-	c.Put("ns/temp", "rules", nil)
-	ch := make(chan prometheus.Metric, 10)
-	collector.Collect(ch)
-	close(ch)
-	assert.Len(t, drainMetrics(ch), 1, "should emit one sample for one key")
-
-	// Empty cache produces zero samples (no stale labels).
-	c2 := NewRuleSetCache()
-	collector2 := newCacheEntriesCollector(c2)
-	ch2 := make(chan prometheus.Metric, 10)
-	collector2.Collect(ch2)
-	close(ch2)
-	assert.Empty(t, drainMetrics(ch2), "empty cache should emit zero samples")
+	c.Prune(0) // prune all non-latest entries (maxAge=0 means everything is old)
+	afterPrune := gatherGaugeValue(t, reg, MetricCacheTotalEntries)
+	assert.Equal(t, float64(2), afterPrune, "total_entries should equal number of instances after pruning all non-latest")
 }
 
 func TestUSEMetrics_GCPrunedByAge(t *testing.T) {
-	gcPrunedEntriesTotal.Reset()
+	resetGCMetrics(t)
 
 	c := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
@@ -443,7 +411,7 @@ func TestUSEMetrics_GCPrunedByAge(t *testing.T) {
 
 	c.Put("ns/a", "old", nil)
 	c.Put("ns/a", "new", nil)
-	c.SetEntryTimestamp("ns/a", 0, time.Now().Add(-200*time.Millisecond))
+	setEntryTimestamp(c, "ns/a", 0, time.Now().Add(-200*time.Millisecond))
 
 	startGCLoopForTest(t, srv)
 	require.Eventually(t, func() bool {
@@ -452,7 +420,7 @@ func TestUSEMetrics_GCPrunedByAge(t *testing.T) {
 }
 
 func TestUSEMetrics_GCPrunedBySize(t *testing.T) {
-	gcPrunedEntriesTotal.Reset()
+	resetGCMetrics(t)
 
 	c := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
@@ -501,33 +469,17 @@ func TestRegisterUSEMetrics_ConflictWhenGCDiffers(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrUSEMetricsRegistryConflict))
 }
 
-// Adversarial: cache_key label must tolerate non-ASCII instance paths (same class of input as HTTP paths).
-func TestUSEMetrics_CacheEntriesCollector_UnicodeCacheKey(t *testing.T) {
+func TestRegisterUSEMetrics_NonRegistryPath(t *testing.T) {
+	// Exercise the else branch: a wrapped registerer that is not *prometheus.Registry.
+	inner := prometheus.NewRegistry()
+	wrapped := prometheus.WrapRegistererWith(prometheus.Labels{}, inner)
 	c := NewRuleSetCache()
-	collector := newCacheEntriesCollector(c)
-	key := "ns/" + string([]rune{0x540d, 0x524d})
-	c.Put(key, "rules", nil)
-
-	ch := make(chan prometheus.Metric, 10)
-	collector.Collect(ch)
-	close(ch)
-
-	var found bool
-	for _, m := range drainMetrics(ch) {
-		var d dto.Metric
-		require.NoError(t, m.Write(&d))
-		for _, lp := range d.GetLabel() {
-			if lp.GetName() == "cache_key" && lp.GetValue() == key {
-				found = true
-				assert.Equal(t, float64(1), d.GetGauge().GetValue())
-			}
-		}
-	}
-	assert.True(t, found, "expected a sample for unicode cache_key %q", key)
+	err := RegisterUSEMetrics(wrapped, c, DefaultGC())
+	require.NoError(t, err, "first registration on non-Registry path should succeed")
 }
 
 func TestUSEMetrics_GCSizeLimitExceeded(t *testing.T) {
-	before := testutil.ToFloat64(gcSizeLimitExceededTotal)
+	resetGCMetrics(t)
 
 	c := NewRuleSetCache()
 	logger := utils.NewTestLogger(t)
@@ -542,7 +494,7 @@ func TestUSEMetrics_GCSizeLimitExceeded(t *testing.T) {
 
 	startGCLoopForTest(t, srv)
 	require.Eventually(t, func() bool {
-		return testutil.ToFloat64(gcSizeLimitExceededTotal) > before
+		return testutil.ToFloat64(gcSizeLimitExceededTotal.WithLabelValues()) >= 1
 	}, gcMetricEventuallyTimeout, gcMetricEventuallyTick,
 		"size-limit-exceeded counter should increment when latest entry exceeds MaxSize")
 }
@@ -560,14 +512,6 @@ func gatherGaugeValue(t *testing.T, g prometheus.Gatherer, name string) float64 
 	}
 	t.Fatalf("metric %s not found", name)
 	return 0
-}
-
-func drainMetrics(ch <-chan prometheus.Metric) []prometheus.Metric {
-	out := make([]prometheus.Metric, 0)
-	for m := range ch {
-		out = append(out, m)
-	}
-	return out
 }
 
 // End-to-end: real server mux + instrumentHandler records metrics (same wiring as production).

--- a/internal/rulesets/cache/metrics_use.go
+++ b/internal/rulesets/cache/metrics_use.go
@@ -109,8 +109,8 @@ func (c *cacheEntriesCollector) Collect(ch chan<- prometheus.Metric) {
 // For a *prometheus.Registry, a second call with the same RuleSetCache pointer
 // and equal GarbageCollectionConfig returns nil (idempotent). A second call with
 // the same registry but a different cache or GC config returns
-// ErrUSEMetricsRegistryConflict. The process uses one shared set of GC counter
-// collectors; they are bound to the first registry they are registered with.
+// ErrUSEMetricsRegistryConflict. The GC counters are shared collector instances
+// and are registered with each Registerer passed to this function.
 //
 // Registerers that are not *prometheus.Registry are not tracked; each call runs
 // MustRegister (typically only once — duplicate metric names panic).

--- a/internal/rulesets/cache/metrics_use.go
+++ b/internal/rulesets/cache/metrics_use.go
@@ -146,17 +146,18 @@ func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCo
 
 	if r, ok := reg.(*prometheus.Registry); ok {
 		registerMu.Lock()
+		defer registerMu.Unlock()
+
 		if prev, exists := registeredUSEMetricsByPromRegistry[r]; exists {
 			match := prev.cache == c && prev.gc == gc
-			registerMu.Unlock()
 			if match {
 				return nil
 			}
 			return fmt.Errorf("%w", ErrUSEMetricsRegistryConflict)
 		}
+
 		registerCollectors()
 		registeredUSEMetricsByPromRegistry[r] = useMetricsRegistration{cache: c, gc: gc}
-		registerMu.Unlock()
 		return nil
 	}
 

--- a/internal/rulesets/cache/metrics_use.go
+++ b/internal/rulesets/cache/metrics_use.go
@@ -97,8 +97,7 @@ func (c *cacheEntriesCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements prometheus.Collector.
 func (c *cacheEntriesCollector) Collect(ch chan<- prometheus.Metric) {
-	for _, key := range c.cache.ListKeys() {
-		count := c.cache.CountEntries(key)
+	for key, count := range c.cache.EntryCountsSnapshot() {
 		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(count), key)
 	}
 }

--- a/internal/rulesets/cache/metrics_use.go
+++ b/internal/rulesets/cache/metrics_use.go
@@ -17,10 +17,17 @@ limitations under the License.
 package cache
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+// ErrUSEMetricsRegistryConflict is returned when RegisterUSEMetrics is called
+// again for the same *prometheus.Registry with a different RuleSetCache or
+// GarbageCollectionConfig than the first successful registration for that registry.
+var ErrUSEMetricsRegistryConflict = errors.New("USE metrics already registered for this registry with a different RuleSetCache or GarbageCollectionConfig")
 
 // Prometheus metric name constants for the RuleSet cache.
 const (
@@ -38,6 +45,11 @@ const (
 	PruneReasonSize = "size"
 )
 
+type useMetricsRegistration struct {
+	cache *RuleSetCache
+	gc    GarbageCollectionConfig
+}
+
 var (
 	gcPrunedEntriesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -54,7 +66,10 @@ var (
 		},
 	)
 
-	registerOnce sync.Once
+	registerMu sync.Mutex
+	// registeredUSEMetricsByPromRegistry records the first successful registration
+	// per *prometheus.Registry so repeat calls can be checked for idempotency.
+	registeredUSEMetricsByPromRegistry = map[*prometheus.Registry]useMetricsRegistration{}
 )
 
 // cacheEntriesCollector implements prometheus.Collector to emit per-cache-key
@@ -89,10 +104,18 @@ func (c *cacheEntriesCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 // RegisterUSEMetrics registers USE-method (Utilization/Saturation/Errors) metrics
-// for the RuleSet cache. Safe to call multiple times; registration happens at most
-// once per process via sync.Once.
-func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCollectionConfig) {
-	registerOnce.Do(func() {
+// for the RuleSet cache on the given Registerer.
+//
+// For a *prometheus.Registry, a second call with the same RuleSetCache pointer
+// and equal GarbageCollectionConfig returns nil (idempotent). A second call with
+// the same registry but a different cache or GC config returns
+// ErrUSEMetricsRegistryConflict. The process uses one shared set of GC counter
+// collectors; they are bound to the first registry they are registered with.
+//
+// Registerers that are not *prometheus.Registry are not tracked; each call runs
+// MustRegister (typically only once — duplicate metric names panic).
+func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCollectionConfig) error {
+	registerCollectors := func() {
 		reg.MustRegister(
 			prometheus.NewGaugeFunc(
 				prometheus.GaugeOpts{
@@ -119,5 +142,24 @@ func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCo
 			gcPrunedEntriesTotal,
 			gcSizeLimitExceededTotal,
 		)
-	})
+	}
+
+	if r, ok := reg.(*prometheus.Registry); ok {
+		registerMu.Lock()
+		if prev, exists := registeredUSEMetricsByPromRegistry[r]; exists {
+			match := prev.cache == c && prev.gc == gc
+			registerMu.Unlock()
+			if match {
+				return nil
+			}
+			return fmt.Errorf("%w", ErrUSEMetricsRegistryConflict)
+		}
+		registerCollectors()
+		registeredUSEMetricsByPromRegistry[r] = useMetricsRegistration{cache: c, gc: gc}
+		registerMu.Unlock()
+		return nil
+	}
+
+	registerCollectors()
+	return nil
 }

--- a/internal/rulesets/cache/metrics_use.go
+++ b/internal/rulesets/cache/metrics_use.go
@@ -1,0 +1,123 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Prometheus metric name constants for the RuleSet cache.
+const (
+	MetricCacheSizeBytes            = "coraza_cache_size_bytes"
+	MetricCacheInstances            = "coraza_cache_instances"
+	MetricCacheEntries              = "coraza_cache_entries"
+	MetricCacheConfigMaxSizeBytes   = "coraza_cache_config_max_size_bytes"
+	MetricCacheGCPrunedEntriesTotal = "coraza_cache_gc_pruned_entries_total"
+	MetricCacheGCSizeLimitExceeded  = "coraza_cache_gc_size_limit_exceeded_total"
+)
+
+// PruneReason values label the garbage-collection prune counter.
+const (
+	PruneReasonAge  = "age"
+	PruneReasonSize = "size"
+)
+
+var (
+	gcPrunedEntriesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricCacheGCPrunedEntriesTotal,
+			Help: "Total number of cache entries pruned by the garbage collector.",
+		},
+		[]string{"reason"},
+	)
+
+	gcSizeLimitExceededTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: MetricCacheGCSizeLimitExceeded,
+			Help: "Total number of GC cycles where cache size still exceeded the configured maximum after pruning.",
+		},
+	)
+
+	registerOnce sync.Once
+)
+
+// cacheEntriesCollector implements prometheus.Collector to emit per-cache-key
+// entry counts on every scrape, avoiding stale label sets when keys are removed.
+type cacheEntriesCollector struct {
+	cache *RuleSetCache
+	desc  *prometheus.Desc
+}
+
+func newCacheEntriesCollector(c *RuleSetCache) *cacheEntriesCollector {
+	return &cacheEntriesCollector{
+		cache: c,
+		desc: prometheus.NewDesc(
+			MetricCacheEntries,
+			"Number of stored entry revisions per cache key.",
+			[]string{"cache_key"}, nil,
+		),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *cacheEntriesCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+// Collect implements prometheus.Collector.
+func (c *cacheEntriesCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, key := range c.cache.ListKeys() {
+		count := c.cache.CountEntries(key)
+		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(count), key)
+	}
+}
+
+// RegisterUSEMetrics registers USE-method (Utilization/Saturation/Errors) metrics
+// for the RuleSet cache. Safe to call multiple times; registration happens at most
+// once per process via sync.Once.
+func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCollectionConfig) {
+	registerOnce.Do(func() {
+		reg.MustRegister(
+			prometheus.NewGaugeFunc(
+				prometheus.GaugeOpts{
+					Name: MetricCacheSizeBytes,
+					Help: "Current total payload size of the cache in bytes.",
+				},
+				func() float64 { return float64(c.TotalSize()) },
+			),
+			prometheus.NewGaugeFunc(
+				prometheus.GaugeOpts{
+					Name: MetricCacheInstances,
+					Help: "Number of distinct cache keys (instances) stored in the cache.",
+				},
+				func() float64 { return float64(c.Len()) },
+			),
+			prometheus.NewGaugeFunc(
+				prometheus.GaugeOpts{
+					Name: MetricCacheConfigMaxSizeBytes,
+					Help: "Configured maximum cache size in bytes.",
+				},
+				func() float64 { return float64(gc.MaxSize) },
+			),
+			newCacheEntriesCollector(c),
+			gcPrunedEntriesTotal,
+			gcSizeLimitExceededTotal,
+		)
+	})
+}

--- a/internal/rulesets/cache/metrics_use.go
+++ b/internal/rulesets/cache/metrics_use.go
@@ -33,7 +33,7 @@ var ErrUSEMetricsRegistryConflict = errors.New("USE metrics already registered f
 const (
 	MetricCacheSizeBytes            = "coraza_cache_size_bytes"
 	MetricCacheInstances            = "coraza_cache_instances"
-	MetricCacheEntries              = "coraza_cache_entries"
+	MetricCacheTotalEntries         = "coraza_cache_total_entries"
 	MetricCacheConfigMaxSizeBytes   = "coraza_cache_config_max_size_bytes"
 	MetricCacheGCPrunedEntriesTotal = "coraza_cache_gc_pruned_entries_total"
 	MetricCacheGCSizeLimitExceeded  = "coraza_cache_gc_size_limit_exceeded_total"
@@ -50,6 +50,11 @@ type useMetricsRegistration struct {
 	gc    GarbageCollectionConfig
 }
 
+// gcPrunedEntriesTotal and gcSizeLimitExceededTotal are package-level singletons
+// shared across all RegisterUSEMetrics calls. They are incremented by the GC loop
+// in server.go regardless of which registry is active. Tests must call
+// gcPrunedEntriesTotal.Reset() / gcSizeLimitExceededTotal.Reset() in t.Cleanup
+// to prevent cross-test counter accumulation.
 var (
 	gcPrunedEntriesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -59,11 +64,12 @@ var (
 		[]string{"reason"},
 	)
 
-	gcSizeLimitExceededTotal = prometheus.NewCounter(
+	gcSizeLimitExceededTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: MetricCacheGCSizeLimitExceeded,
 			Help: "Total number of GC cycles where cache size still exceeded the configured maximum after pruning.",
 		},
+		[]string{},
 	)
 
 	registerMu sync.Mutex
@@ -71,36 +77,6 @@ var (
 	// per *prometheus.Registry so repeat calls can be checked for idempotency.
 	registeredUSEMetricsByPromRegistry = map[*prometheus.Registry]useMetricsRegistration{}
 )
-
-// cacheEntriesCollector implements prometheus.Collector to emit per-cache-key
-// entry counts on every scrape, avoiding stale label sets when keys are removed.
-type cacheEntriesCollector struct {
-	cache *RuleSetCache
-	desc  *prometheus.Desc
-}
-
-func newCacheEntriesCollector(c *RuleSetCache) *cacheEntriesCollector {
-	return &cacheEntriesCollector{
-		cache: c,
-		desc: prometheus.NewDesc(
-			MetricCacheEntries,
-			"Number of stored entry revisions per cache key.",
-			[]string{"cache_key"}, nil,
-		),
-	}
-}
-
-// Describe implements prometheus.Collector.
-func (c *cacheEntriesCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.desc
-}
-
-// Collect implements prometheus.Collector.
-func (c *cacheEntriesCollector) Collect(ch chan<- prometheus.Metric) {
-	for key, count := range c.cache.EntryCountsSnapshot() {
-		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(count), key)
-	}
-}
 
 // RegisterUSEMetrics registers USE-method (Utilization/Saturation/Errors) metrics
 // for the RuleSet cache on the given Registerer.
@@ -111,11 +87,11 @@ func (c *cacheEntriesCollector) Collect(ch chan<- prometheus.Metric) {
 // ErrUSEMetricsRegistryConflict. The GC counters are shared collector instances
 // and are registered with each Registerer passed to this function.
 //
-// Registerers that are not *prometheus.Registry are not tracked; each call runs
-// MustRegister (typically only once — duplicate metric names panic).
+// Registerers that are not *prometheus.Registry are not tracked for idempotency;
+// each call to Register may return an error if a metric name is already in use.
 func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCollectionConfig) error {
-	registerCollectors := func() {
-		reg.MustRegister(
+	registerCollectors := func() error {
+		collectors := []prometheus.Collector{
 			prometheus.NewGaugeFunc(
 				prometheus.GaugeOpts{
 					Name: MetricCacheSizeBytes,
@@ -132,15 +108,27 @@ func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCo
 			),
 			prometheus.NewGaugeFunc(
 				prometheus.GaugeOpts{
+					Name: MetricCacheTotalEntries,
+					Help: "Total number of stored entry revisions across all cache keys.",
+				},
+				func() float64 { return float64(c.TotalEntries()) },
+			),
+			prometheus.NewGaugeFunc(
+				prometheus.GaugeOpts{
 					Name: MetricCacheConfigMaxSizeBytes,
 					Help: "Configured maximum cache size in bytes.",
 				},
 				func() float64 { return float64(gc.MaxSize) },
 			),
-			newCacheEntriesCollector(c),
 			gcPrunedEntriesTotal,
 			gcSizeLimitExceededTotal,
-		)
+		}
+		for _, col := range collectors {
+			if err := reg.Register(col); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	if r, ok := reg.(*prometheus.Registry); ok {
@@ -155,11 +143,12 @@ func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCo
 			return fmt.Errorf("%w", ErrUSEMetricsRegistryConflict)
 		}
 
-		registerCollectors()
+		if err := registerCollectors(); err != nil {
+			return err
+		}
 		registeredUSEMetricsByPromRegistry[r] = useMetricsRegistration{cache: c, gc: gc}
 		return nil
 	}
 
-	registerCollectors()
-	return nil
+	return registerCollectors()
 }

--- a/internal/rulesets/cache/server.go
+++ b/internal/rulesets/cache/server.go
@@ -318,6 +318,7 @@ func (s *ruleSetCacheServer) rungc(ctx context.Context) {
 		case <-ticker.C:
 			prunedByAge := s.cache.Prune(s.gc.MaxAge)
 			if prunedByAge > 0 {
+				gcPrunedEntriesTotal.WithLabelValues(PruneReasonAge).Add(float64(prunedByAge))
 				s.logger.Info("Pruned stale cache entries by age", "count", prunedByAge, "maxAge", s.gc.MaxAge)
 			}
 
@@ -325,11 +326,13 @@ func (s *ruleSetCacheServer) rungc(ctx context.Context) {
 			if currentSize > s.gc.MaxSize {
 				prunedBySize := s.cache.PruneBySize(s.gc.MaxSize)
 				if prunedBySize > 0 {
+					gcPrunedEntriesTotal.WithLabelValues(PruneReasonSize).Add(float64(prunedBySize))
 					s.logger.Info("Pruned cache entries by size", "count", prunedBySize, "maxSize", s.gc.MaxSize, "currentSize", s.cache.TotalSize())
 				}
 
 				finalSize := s.cache.TotalSize()
 				if finalSize > s.gc.MaxSize {
+					gcSizeLimitExceededTotal.Inc()
 					s.logger.Error(errors.New("cache size exceeds maximum"), "CRITICAL: Cache size exceeds maximum even after pruning - latest entry is too large", "currentSize", finalSize, "maxSize", s.gc.MaxSize, "overage", finalSize-s.gc.MaxSize)
 				}
 			}

--- a/internal/rulesets/cache/server.go
+++ b/internal/rulesets/cache/server.go
@@ -332,7 +332,7 @@ func (s *ruleSetCacheServer) rungc(ctx context.Context) {
 
 				finalSize := s.cache.TotalSize()
 				if finalSize > s.gc.MaxSize {
-					gcSizeLimitExceededTotal.Inc()
+					gcSizeLimitExceededTotal.WithLabelValues().Inc()
 					s.logger.Error(errors.New("cache size exceeds maximum"), "CRITICAL: Cache size exceeds maximum even after pruning - latest entry is too large", "currentSize", finalSize, "maxSize", s.gc.MaxSize, "overage", finalSize-s.gc.MaxSize)
 				}
 			}

--- a/internal/rulesets/cache/server_test.go
+++ b/internal/rulesets/cache/server_test.go
@@ -235,10 +235,10 @@ func TestServer_GCByAge(t *testing.T) {
 	cache.Put("instancedata", "instancedata new", modifiedData)
 
 	t.Log("Manually marking old entries with old timestamps")
-	cache.SetEntryTimestamp("instance1", 0, time.Now().Add(-200*time.Millisecond))
-	cache.SetEntryTimestamp("instance2", 0, time.Now().Add(-200*time.Millisecond))
-	cache.SetEntryTimestamp("instance3", 0, time.Now().Add(-50*time.Millisecond))
-	cache.SetEntryTimestamp("instancedata", 0, time.Now().Add(-200*time.Millisecond))
+	setEntryTimestamp(cache, "instance1", 0, time.Now().Add(-200*time.Millisecond))
+	setEntryTimestamp(cache, "instance2", 0, time.Now().Add(-200*time.Millisecond))
+	setEntryTimestamp(cache, "instance3", 0, time.Now().Add(-50*time.Millisecond))
+	setEntryTimestamp(cache, "instancedata", 0, time.Now().Add(-200*time.Millisecond))
 
 	initialTotal := cache.CountEntries("instance1") + cache.CountEntries("instance2") + cache.CountEntries("instancedata")
 	t.Logf("Initial entries for instance1 and instance2: %d", initialTotal)

--- a/internal/rulesets/cache/testhelpers_test.go
+++ b/internal/rulesets/cache/testhelpers_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+// setEntryTimestamp updates the timestamp of a stored entry by index.
+// Only for use in tests to manipulate entry ages for GC testing.
+func setEntryTimestamp(c *RuleSetCache, instance string, index int, timestamp time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entries, ok := c.entries[instance]; ok {
+		if index >= 0 && index < len(entries.Entries) {
+			entries.Entries[index].Timestamp = timestamp
+		}
+	}
+}
+
+// resetGCMetrics resets the package-level GC counters before a test and
+// registers a cleanup that resets them again after the test completes.
+// Call at the start of any test that reads or asserts on the GC counters.
+func resetGCMetrics(t *testing.T) {
+	t.Helper()
+	gcPrunedEntriesTotal.Reset()
+	gcSizeLimitExceededTotal.Reset()
+	t.Cleanup(func() {
+		gcPrunedEntriesTotal.Reset()
+		gcSizeLimitExceededTotal.Reset()
+	})
+}


### PR DESCRIPTION
**Describe the pull request**

Add Utilization/Saturation/Errors metrics for the in-memory RuleSet cache, complementing the existing RED (request) metrics:

- coraza_cache_size_bytes: current total payload size (Gauge)
- coraza_cache_instances: number of distinct cache keys (Gauge)
- coraza_cache_entries: per-key entry count via custom Collector (Gauge)
- coraza_cache_config_max_size_bytes: configured cap (constant Gauge)
- coraza_cache_gc_pruned_entries_total: prune counter by reason (Counter)
- coraza_cache_gc_size_limit_exceeded_total: post-GC oversize (Counter)


**Which issue this resolves**

Closes #246

**Additional context**

