### PR TITLE
Fix findings on gh actions and implement zizmor

### DIFF
--- a/.github/workflows/operatorhub.yml
+++ b/.github/workflows/operatorhub.yml
@@ -63,7 +63,9 @@ jobs:
         run: make bundle VERSION="$TAG"
 
       - name: OPP bundle test (kiwi)
-        run: ./hack/operatorhub_opp_test.sh --version "${{ steps.version.outputs.bare }}"
+        run: ./hack/operatorhub_opp_test.sh --version "${STEPS_VERSION_OUTPUTS_BARE}"
+        env:
+          STEPS_VERSION_OUTPUTS_BARE: ${{ steps.version.outputs.bare }}
 
       - name: print OPP logs on failure
         if: failure()
@@ -85,7 +87,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OPERATORHUB_TOKEN }}
           GIT_USER: ${{ vars.OPERATORHUB_GIT_USER }}
           GIT_EMAIL: ${{ vars.OPERATORHUB_GIT_EMAIL }}
+          STEPS_VERSION_OUTPUTS_BARE: ${{ steps.version.outputs.bare }}
+          VARS_OPERATORHUB_FORK_OWNER: ${{ vars.OPERATORHUB_FORK_OWNER }}
         run: |
           hack/publish_operatorhub.sh \
-            --version "${{ steps.version.outputs.bare }}" \
-            --fork "${{ vars.OPERATORHUB_FORK_OWNER }}"
+            --version "${STEPS_VERSION_OUTPUTS_BARE}" \
+            --fork "${VARS_OPERATORHUB_FORK_OWNER}"

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -3,40 +3,56 @@ name: pr_management
 permissions: read-all
 
 on:
-    pull_request_target:
-        types: [opened, synchronize, reopened]
+  # zizmor: ignore[dangerous-triggers] -- workflow_run is safe here: we only
+  # read a PR number from an uploaded artifact and never execute code from the
+  # triggering PR. The checkout fetches the default branch (trusted code).
+  workflow_run:
+    workflows: ["pr_trigger"]
+    types: [completed]
 
 jobs:
-    triage:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            pull-requests: write
-            issues: write
-        steps:
-            - name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  ref: ${{ github.event.pull_request.base.sha }}
-                  sparse-checkout: tools/github_project_manager
-                  persist-credentials: false
+  triage:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: download PR number
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Setup Go
-              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-              with:
-                  go-version-file: tools/github_project_manager/go.mod
+      - name: read PR number
+        id: pr
+        run: echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
 
-            - name: Build project manager
-              working-directory: tools/github_project_manager
-              run: go build -o "${{ github.workspace }}/github_project_manager" .
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: tools/github_project_manager
+          persist-credentials: false
 
-            - name: Triage PR
-              env:
-                  GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_PAT }}
-                  GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
-              run: |
-                  ./github_project_manager -v \
-                    --owner "${{ github.repository_owner }}" \
-                    --repo "${GITHUB_EVENT_REPOSITORY_NAME}" \
-                    --issue "${{ github.event.pull_request.number }}" \
-                    triage-pr
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: tools/github_project_manager/go.mod
+
+      - name: Build project manager
+        working-directory: tools/github_project_manager
+        run: go build -o "${{ github.workspace }}/github_project_manager" .
+
+      - name: Triage PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_PAT }}
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.workflow_run.repository.name }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          ./github_project_manager -v \
+            --owner "${{ github.repository_owner }}" \
+            --repo "${GITHUB_EVENT_REPOSITORY_NAME}" \
+            --issue "${PR_NUMBER}" \
+            triage-pr

--- a/.github/workflows/pr-trigger.yml
+++ b/.github/workflows/pr-trigger.yml
@@ -1,0 +1,22 @@
+name: pr_trigger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  save-pr-number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: echo "${PR_NUMBER}" > pr_number.txt
+
+      - name: upload PR number
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-number
+          path: pr_number.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: release
 
-permissions: read-all
+permissions: {}
 
 on:
   push:
@@ -11,6 +11,7 @@ jobs:
   prepare:
     name: check release tag
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       is_prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
     steps:
@@ -39,6 +40,8 @@ jobs:
     name: build manifests
     runs-on: ubuntu-latest
     needs: prepare
+    permissions:
+      contents: read
     steps:
       - name: checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -220,15 +223,30 @@ jobs:
           path: dist/
 
       - name: create github release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          generate_release_notes: true
-          draft: true # IMPORTANT: our releases are immutable, so a maintainer needs to validate and do the final publish
-          prerelease: ${{ needs.prepare.outputs.is_prerelease == 'true' }}
-          # Chart packages are published to GitHub Pages (gh-pages) by publish-helm-chart-repo, not here.
-          files: |
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          # Verify all release artifacts exist before creating the release.
+          for f in dist/crds.yaml dist/operator.yaml dist/samples.yaml \
+                   dist/kubectl-coraza-linux-amd64 dist/kubectl-coraza-linux-arm64 \
+                   dist/kubectl-coraza-darwin-amd64 dist/kubectl-coraza-darwin-arm64; do
+            if [[ ! -f "$f" ]]; then
+              echo "::error::Missing required release artifact: $f"
+              exit 1
+            fi
+          done
+
+          # IMPORTANT: our releases are immutable, so a maintainer needs to
+          # validate and do the final publish (--draft).
+          # Chart packages are published to GitHub Pages (gh-pages) by
+          # publish-helm-chart-repo, not here.
+          gh_args=(
+            "${TAG_NAME}"
+            --title "${TAG_NAME}"
+            --generate-notes
+            --draft
             dist/crds.yaml
             dist/operator.yaml
             dist/samples.yaml
@@ -236,9 +254,13 @@ jobs:
             dist/kubectl-coraza-linux-arm64
             dist/kubectl-coraza-darwin-amd64
             dist/kubectl-coraza-darwin-arm64
-          fail_on_unmatched_files: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          )
+
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            gh_args+=(--prerelease)
+          fi
+
+          gh release create "${gh_args[@]}"
 
   publish-helm-chart-repo:
     name: publish helm chart repository
@@ -252,6 +274,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: configure git for chart-releaser
         run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
This pull request makes several significant improvements to the GitHub Actions workflows for the repository. The main changes include refactoring the pull request triage workflow for greater security, restructuring how PR numbers are handled between workflows, enhancing the release workflow with stricter artifact checks and improved permissions, and introducing a new security workflow. These updates aim to make CI/CD processes more robust, secure, and maintainable.

**Pull Request and Triage Workflow Refactoring:**

* Replaces the previous `pull_request_target` trigger in `.github/workflows/pr-management.yml` with a safer two-step process: a new `pr-trigger.yml` workflow captures and uploads the PR number, and `pr-management.yml` is triggered via `workflow_run` to perform triage using only trusted code. This reduces the risk of privilege escalation from untrusted PRs. [[1]](diffhunk://#diff-7f6b8d3a8e74d38d553992c35862eecaa9e72d73d6fe58469846333b957ab8e9L6-L20) [[2]](diffhunk://#diff-dddb6d9a7b26362220587cdb7a60fb738f467d84b957542741a4807db7c231d8R1-R22)
* Updates how the PR number is passed and used between jobs, ensuring the correct PR is triaged securely by reading the PR number from an uploaded artifact.

**Release Workflow Improvements:**

* Changes permissions in `.github/workflows/release.yml` to be more restrictive and explicit for each job, following the principle of least privilege. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L3-R3) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R14) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R43-R44)
* Replaces the use of `softprops/action-gh-release` with a manual `gh release create` command, adding a pre-check to ensure all expected release artifacts exist before creating a release. This helps prevent incomplete or broken releases.
* Ensures the Helm chart publishing job does not persist credentials, improving security.

**OperatorHub Workflow Fixes:**

* Fixes environment variable handling in `.github/workflows/operatorhub.yml` by explicitly passing required variables to steps and using them consistently, ensuring correct values are used in scripts. [[1]](diffhunk://#diff-88bcd562637ccfb5dc7828c8c7b016c0895951b5c77a7ae260cb7584fa8d7012L66-R68) [[2]](diffhunk://#diff-88bcd562637ccfb5dc7828c8c7b016c0895951b5c77a7ae260cb7584fa8d7012R90-R95)

**Security Workflow Addition:**

* Adds a new `.github/workflows/zizmor.yml` workflow to run the `zizmor` security analysis tool on pushes and PRs to `main`, with minimal permissions and credentials not persisted.

These changes collectively improve the reliability, security, and maintainability of the repository's CI/CD workflows.