### PR TITLE
Fix helm installation docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -190,7 +190,13 @@ announcements get unpinned.
 
 [immutable releases]:https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases
 
-### Step 6 - OperatorHub
+### Step 6 - Github pages
+
+Trigger the [github pages](https://github.com/networking-incubator/coraza-kubernetes-operator/actions/workflows/pages.yml) workflow
+manually to re-publish the Helm chart index, containing the released version or using the CLI
+command `gh workflow run pages.yml`.
+
+### Step 7 - OperatorHub
 
 The [`operatorhub.yml`] workflow is **disabled** (`if: false` on the job) until
 a dedicated bot or service account can hold the PAT and related settings for

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -190,11 +190,12 @@ announcements get unpinned.
 
 [immutable releases]:https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases
 
-### Step 6 - Github pages
+### Step 6 - Github Pages
 
-Trigger the [github pages](https://github.com/networking-incubator/coraza-kubernetes-operator/actions/workflows/pages.yml) workflow
-manually to re-publish the Helm chart index, containing the released version or using the CLI
-command `gh workflow run pages.yml`.
+Re-publish the Helm chart index so it includes the released version by using one
+of these options:
+1. Trigger the [github Pages](https://github.com/networking-incubator/coraza-kubernetes-operator/actions/workflows/pages.yml) workflow manually from the GitHub UI.
+2. Run the CLI command `gh workflow run pages.yml`.
 
 ### Step 7 - OperatorHub
 

--- a/charts/coraza-kubernetes-operator/README.md
+++ b/charts/coraza-kubernetes-operator/README.md
@@ -2,7 +2,7 @@
 
 Deploys the [Coraza Kubernetes Operator](https://github.com/networking-incubator/coraza-kubernetes-operator) — declarative Web Application Firewall (WAF) support for Kubernetes Gateways.
 
-> **Requires Kubernetes ≥1.33.0 or OpenShift Container Platform ≥4.20.** The chart and operator use `resizePolicy` and the `Chart.yaml` enforces this minimum.
+> **Requires Kubernetes ≥1.32.0 or OpenShift Container Platform ≥4.20.** The `Chart.yaml` enforces this minimum via `kubeVersion`.
 
 
 ## Installation
@@ -15,8 +15,7 @@ After a version tag is pushed, CI publishes the packaged chart to the GitHub rel
 helm repo add coraza-kubernetes-operator https://networking-incubator.github.io/coraza-kubernetes-operator/
 helm repo update
 helm upgrade --install coraza-kubernetes-operator coraza-kubernetes-operator/coraza-kubernetes-operator \
-  --namespace coraza-system \
-  --create-namespace
+  --namespace coraza-system
 ```
 
 Forks and other remotes use their own Pages URL: `https://<owner>.github.io/<repository>/`.
@@ -71,7 +70,7 @@ When `openshift.enabled=true`, `runAsUser`, `fsGroup`, and `fsGroupChangePolicy`
 | `createNamespace`                                     | bool   | `true`                                                    | Create the release namespace as a chart-managed resource with PSS labels                                    |
 | `openshift.enabled`                                   | bool   | `false`                                                   | Omit UID/fsGroup from pod security context for OpenShift SCC compatibility                                  |
 | `podSecurityStandard.version`                         | string | `latest`                                                  | Kubernetes version for Pod Security Standard labels (`latest` or `vX.YZ`)                                    |
-| **Kubernetes version**                                | string | `1.33+`                                                   | Minimum cluster version required by this chart (due to resizePolicy API)                                    |
+| **Kubernetes version**                                | string | `1.32+`                                                   | Minimum cluster version required by this chart                                                              |
 | `nodeSelector`                                        | object | `{}`                                                      | Node selector constraints                                                                                   |
 | `tolerations`                                         | list   | `[]`                                                      | Tolerations                                                                                                 |
 | `affinity`                                            | object | `{}`                                                      | Affinity rules                                                                                              |

--- a/charts/coraza-kubernetes-operator/README.md
+++ b/charts/coraza-kubernetes-operator/README.md
@@ -15,7 +15,8 @@ After a version tag is pushed, CI publishes the packaged chart to the GitHub rel
 helm repo add coraza-kubernetes-operator https://networking-incubator.github.io/coraza-kubernetes-operator/
 helm repo update
 helm upgrade --install coraza-kubernetes-operator coraza-kubernetes-operator/coraza-kubernetes-operator \
-  --namespace coraza-system
+  --namespace coraza-system \
+  --create-namespace
 ```
 
 Forks and other remotes use their own Pages URL: `https://<owner>.github.io/<repository>/`.
@@ -67,7 +68,7 @@ When `openshift.enabled=true`, `runAsUser`, `fsGroup`, and `fsGroupChangePolicy`
 | `logging.timeEncoding`                                | string | `rfc3339nano`                                             | Timestamp format (`epoch`, `millis`, `nano`, `iso8601`, `rfc3339`, `rfc3339nano`). Only used when `development=false` |
 | `istio.revision`                                      | string | `""`                                                      | Istio control plane revision label; empty means no revision label on managed resources                      |
 | `defaultWasmImage`                                    | string | `""`                                                      | Default WASM plugin OCI URL when an Engine omits `spec.driver.istio.wasm.image`; empty uses operator built-in default |
-| `createNamespace`                                     | bool   | `true`                                                    | Create the release namespace as a chart-managed resource with PSS labels                                    |
+| `createNamespace`                                     | bool   | `true`                                                    | Manage the release namespace with Pod Security Standard labels. Requires `--create-namespace` on first install |
 | `openshift.enabled`                                   | bool   | `false`                                                   | Omit UID/fsGroup from pod security context for OpenShift SCC compatibility                                  |
 | `podSecurityStandard.version`                         | string | `latest`                                                  | Kubernetes version for Pod Security Standard labels (`latest` or `vX.YZ`)                                    |
 | **Kubernetes version**                                | string | `1.32+`                                                   | Minimum cluster version required by this chart                                                              |

--- a/charts/coraza-kubernetes-operator/templates/namespace.yaml
+++ b/charts/coraza-kubernetes-operator/templates/namespace.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.createNamespace }}
+{{- /* On fresh install with --create-namespace, Helm creates a bare namespace before  */}}
+{{- /* applying chart resources. Because install uses create semantics, including a    */}}
+{{- /* Namespace resource here would fail with "already exists". We skip the resource  */}}
+{{- /* on install when the namespace already exists (detected via lookup) and apply the */}}
+{{- /* Pod Security Standard labels on the first upgrade, where Helm uses three-way    */}}
+{{- /* merge. helm template (no cluster) always renders because lookup returns empty.  */}}
+{{- if or .Release.IsUpgrade (not (lookup "v1" "Namespace" "" .Release.Namespace)) }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -11,4 +18,5 @@ metadata:
     pod-security.kubernetes.io/warn-version: {{ .Values.podSecurityStandard.version }}
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: {{ .Values.podSecurityStandard.version }}
+{{- end }}
 {{- end }}

--- a/docs/content/howto/_index.md
+++ b/docs/content/howto/_index.md
@@ -13,7 +13,7 @@ How-to guides address specific tasks. Unlike tutorials, they assume you already 
 ## Installation
 
 - [Install on Kubernetes with Helm]({{< relref "install-kubernetes-helm" >}})
-- [Install on OpenShift via OperatorHub]({{< relref "install-openshift-operatorhub" >}})
+- [Install on OpenShift]({{< relref "install-openshift-operatorhub" >}})
 
 ## Configuration
 

--- a/docs/content/howto/install-kubernetes-helm.md
+++ b/docs/content/howto/install-kubernetes-helm.md
@@ -10,10 +10,12 @@ This guide covers installing the Coraza Kubernetes Operator using Helm on a stan
 ## Prerequisites
 
 - Kubernetes cluster running **v1.32 or later**
-- [Istio](https://istio.io/latest/docs/setup/) installed with Gateway API CRDs
+- [Istio](https://istio.io/latest/docs/setup/) installed with [Gateway API CRDs](https://gateway-api.sigs.k8s.io/)
 - [Helm 3](https://helm.sh/docs/intro/install/) installed
 
-## Add the Helm Repository
+## Install from the Helm Repository
+
+Add the Helm repository hosted on GitHub Pages and install:
 
 ```bash
 helm repo add coraza-kubernetes-operator \
@@ -21,24 +23,31 @@ helm repo add coraza-kubernetes-operator \
 helm repo update
 ```
 
-## Install with Default Values
+```bash
+helm upgrade --install coraza-kubernetes-operator \
+  coraza-kubernetes-operator/coraza-kubernetes-operator \
+  --namespace coraza-system
+```
+
+### Pin a Specific Version
 
 ```bash
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
-  --create-namespace
+  --version <chart-version>
 ```
+
+Replace `<chart-version>` with the desired version (e.g. `0.1.0`). Available versions are listed on the [releases page](https://github.com/networking-incubator/coraza-kubernetes-operator/releases).
 
 ## Customize the Installation
 
-Override default values by passing a values file or individual settings:
+Override default values by passing individual settings:
 
 ```bash
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
-  --create-namespace \
   --set logging.level=debug \
   --set metrics.serviceMonitor.enabled=true
 ```
@@ -68,7 +77,6 @@ resources:
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
-  --create-namespace \
   -f custom-values.yaml
 ```
 

--- a/docs/content/howto/install-kubernetes-helm.md
+++ b/docs/content/howto/install-kubernetes-helm.md
@@ -26,7 +26,8 @@ helm repo update
 ```bash
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
-  --namespace coraza-system
+  --namespace coraza-system \
+  --create-namespace
 ```
 
 ### Pin a Specific Version
@@ -35,10 +36,15 @@ helm upgrade --install coraza-kubernetes-operator \
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
+  --create-namespace \
   --version <chart-version>
 ```
 
 Replace `<chart-version>` with the desired version (e.g. `0.1.0`). Available versions are listed on the [releases page](https://github.com/networking-incubator/coraza-kubernetes-operator/releases).
+
+{{% alert title="Namespace conflict on versions 0.4.0 and earlier" color="warning" %}}
+Versions 0.4.0 and earlier have a bug where the first install fails with `namespaces "coraza-system" already exists`. If you hit this error, run the same command again. The first run creates the namespace and a failed release record; the second run succeeds because Helm treats it as an upgrade, which patches the existing namespace instead of trying to create it.
+{{% /alert %}}
 
 ## Customize the Installation
 
@@ -48,6 +54,7 @@ Override default values by passing individual settings:
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
+  --create-namespace \
   --set logging.level=debug \
   --set metrics.serviceMonitor.enabled=true
 ```
@@ -77,6 +84,7 @@ resources:
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
+  --create-namespace \
   -f custom-values.yaml
 ```
 

--- a/docs/content/howto/install-openshift-operatorhub.md
+++ b/docs/content/howto/install-openshift-operatorhub.md
@@ -16,7 +16,7 @@ This guide covers installing the Coraza Kubernetes Operator on OpenShift Contain
 
 ### Enable Gateway API
 
-On OpenShift 4.19 and later, the Gateway API CRDs are included by default. You must create the `openshift-default` GatewayClass, which is the [officially supported GatewayClass](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/ingress_and_load_balancing/configuring-ingress-cluster-traffic#ingress-gateway-api) provided by the OpenShift Ingress Operator:
+On OpenShift 4.20 and later, the Gateway API CRDs are included by default. You must create the `openshift-default` GatewayClass, which is the [officially supported GatewayClass](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/ingress_and_load_balancing/configuring-ingress-cluster-traffic#ingress-gateway-api) provided by the OpenShift Ingress Operator:
 
 ```bash
 oc apply -f - <<EOF

--- a/docs/content/howto/install-openshift-operatorhub.md
+++ b/docs/content/howto/install-openshift-operatorhub.md
@@ -89,10 +89,15 @@ helm repo update
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
+  --create-namespace \
   --set openshift.enabled=true \
   --set istio.revision=openshift-gateway \
   --set metrics.serviceMonitor.enabled=true
 ```
+
+{{% alert title="Namespace conflict on versions 0.4.0 and earlier" color="warning" %}}
+Versions 0.4.0 and earlier have a bug where the first install fails with `namespaces "coraza-system" already exists`. If you hit this error, run the same command again. The first run creates the namespace and a failed release record; the second run succeeds because Helm treats it as an upgrade, which patches the existing namespace instead of trying to create it.
+{{% /alert %}}
 
 ### Pin a Specific Version
 
@@ -121,6 +126,7 @@ metrics:
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
+  --create-namespace \
   -f openshift-values.yaml
 ```
 

--- a/docs/content/howto/install-openshift-operatorhub.md
+++ b/docs/content/howto/install-openshift-operatorhub.md
@@ -1,19 +1,43 @@
 ---
-title: "Install on OpenShift via OperatorHub"
-linkTitle: "Install (OpenShift/OperatorHub)"
+title: "Install on OpenShift"
+linkTitle: "Install (OpenShift)"
 weight: 15
-description: "Install the Coraza Kubernetes Operator on OpenShift using OperatorHub."
+description: "Install the Coraza Kubernetes Operator on OpenShift via OperatorHub or Helm."
 ---
 
-This guide covers installing the Coraza Kubernetes Operator on OpenShift Container Platform using the OperatorHub.
+This guide covers installing the Coraza Kubernetes Operator on OpenShift Container Platform.
 
 ## Prerequisites
 
 - OpenShift Container Platform **v4.20 or later**
 - Cluster administrator privileges
-- OpenShift Service Mesh or Istio installed with Gateway API support
+- Gateway API enabled on your cluster (see [Enable Gateway API](#enable-gateway-api) below)
+- [OpenShift Service Mesh](https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html-single/gateways/index) or Istio installed with Gateway API support
 
-## Install from OperatorHub (Web Console)
+### Enable Gateway API
+
+On OpenShift 4.19 and later, the Gateway API CRDs are included by default. You must create the `openshift-default` GatewayClass, which is the [officially supported GatewayClass](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/ingress_and_load_balancing/configuring-ingress-cluster-traffic#ingress-gateway-api) provided by the OpenShift Ingress Operator:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+spec:
+  controllerName: openshift.io/gateway-controller/v1
+EOF
+```
+
+## Install from OperatorHub
+
+OperatorHub is the preferred installation method on OpenShift.
+
+{{% alert title="Note" color="info" %}}
+The Coraza Kubernetes Operator is not yet published to OperatorHub. Track progress in [issue #201](https://github.com/networking-incubator/coraza-kubernetes-operator/issues/201). In the meantime, use the [Helm installation method](#install-with-helm) below.
+{{% /alert %}}
+
+### Web Console
 
 1. Log in to the OpenShift web console as a cluster administrator.
 2. Navigate to **Operators > OperatorHub**.
@@ -22,11 +46,9 @@ This guide covers installing the Coraza Kubernetes Operator on OpenShift Contain
 5. Choose the update channel, installation mode, and approval strategy.
 6. Click **Install** and wait for the operator to reach the **Succeeded** phase.
 
-<!-- TODO: Replace with the published CatalogSource details when available. -->
+### CLI
 
-## Install from OperatorHub (CLI)
-
-If the operator is available in your cluster's default catalog, create a Subscription resource:
+Create a Subscription resource:
 
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
@@ -35,21 +57,27 @@ metadata:
   name: coraza-kubernetes-operator
   namespace: openshift-operators
 spec:
-  channel: stable
+  channel: alpha
   name: coraza-kubernetes-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
 ```
 
-<!-- TODO: Update the source and channel fields when the operator is published. -->
-
 ```bash
 oc apply -f subscription.yaml
 ```
 
-## Install with Helm on OpenShift
+## Install with Helm
 
-If the operator is not yet available in OperatorHub, you can install it with Helm using the OpenShift values overlay:
+If the operator is not yet available in OperatorHub, you can install it with Helm.
+
+### Prerequisites
+
+- [Helm 3](https://helm.sh/docs/intro/install/) installed
+
+### Install from the Helm Repository
+
+Add the Helm repository hosted on GitHub Pages and install:
 
 ```bash
 helm repo add coraza-kubernetes-operator \
@@ -61,27 +89,60 @@ helm repo update
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
-  --create-namespace \
-  -f - <<EOF
-openshift:
-  enabled: true
-istio:
-  revision: openshift-gateway
-metrics:
-  serviceMonitor:
-    enabled: true
-EOF
+  --set openshift.enabled=true \
+  --set istio.revision=openshift-gateway \
+  --set metrics.serviceMonitor.enabled=true
 ```
+
+### Pin a Specific Version
+
+Add `--version <chart-version>` to any of the install commands above. Replace `<chart-version>` with the desired version (e.g. `0.1.0`). Available versions are listed on the [releases page](https://github.com/networking-incubator/coraza-kubernetes-operator/releases).
+
+### OpenShift Values
 
 Setting `openshift.enabled` to `true` omits `runAsUser`, `fsGroup`, and `fsGroupChangePolicy` from the pod security context so that OpenShift can inject its own UID via Security Context Constraints (SCCs).
 
+For more advanced configuration, use a values file:
+
+```yaml
+# openshift-values.yaml
+openshift:
+  enabled: true
+
+istio:
+  revision: openshift-gateway
+
+metrics:
+  serviceMonitor:
+    enabled: true
+```
+
+```bash
+helm upgrade --install coraza-kubernetes-operator \
+  coraza-kubernetes-operator/coraza-kubernetes-operator \
+  --namespace coraza-system \
+  -f openshift-values.yaml
+```
+
+An example values file is also available in the repository at `charts/coraza-kubernetes-operator/examples/openshift-values.yaml`.
+
+For the complete list of configurable values, see the [Helm Chart Values reference]({{< relref "../reference/helm-values" >}}).
+
 ## Verify the Installation
+
+Check that the operator pod is running:
 
 ```bash
 oc get pods -n coraza-system
 ```
 
 The operator pod should be in a `Running` state.
+
+Check the operator logs:
+
+```bash
+oc logs -n coraza-system deploy/coraza-kubernetes-operator
+```
 
 ## Uninstall
 
@@ -96,3 +157,13 @@ The operator pod should be in a `Running` state.
 ```bash
 helm uninstall coraza-kubernetes-operator -n coraza-system
 ```
+
+To also remove the CRDs:
+
+```bash
+oc delete crd engines.waf.k8s.coraza.io rulesets.waf.k8s.coraza.io
+```
+
+{{% alert title="Note" color="warning" %}}
+Removing CRDs will delete all Engine and RuleSet resources in the cluster.
+{{% /alert %}}

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -33,7 +33,7 @@ The Coraza Kubernetes Operator Helm chart is located at `charts/coraza-kubernete
 | `logging.timeEncoding` | string | `rfc3339nano` | Timestamp format (`epoch`, `millis`, `nano`, `iso8601`, `rfc3339`, `rfc3339nano`). Only used when `development` is false. |
 | `istio.revision` | string | `""` | Istio control plane revision label. When empty, no revision label is set on managed resources. |
 | `defaultWasmImage` | string | `""` | Default WASM plugin OCI URL when an Engine omits `spec.driver.istio.wasm.image`. When empty, uses the operator's built-in default. |
-| `createNamespace` | bool | `true` | Create the release namespace as a chart-managed resource with Pod Security Standard labels. |
+| `createNamespace` | bool | `true` | Manage the release namespace with Pod Security Standard labels. Requires `--create-namespace` on first install. |
 | `openshift.enabled` | bool | `false` | Omit `runAsUser`, `fsGroup`, and `fsGroupChangePolicy` from the pod security context for OpenShift SCC compatibility. |
 | `podSecurityStandard.version` | string | `latest` | Kubernetes version for Pod Security Standard labels (`latest` or `vX.YZ`). |
 | `nodeSelector` | object | `{}` | Node selector constraints. |

--- a/docs/content/tutorials/getting-started-kubernetes.md
+++ b/docs/content/tutorials/getting-started-kubernetes.md
@@ -32,8 +32,9 @@ helm repo update
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
-  --create-namespace
 ```
+
+For more installation options (version pinning, custom values), see the [Install on Kubernetes with Helm]({{< relref "../howto/install-kubernetes-helm" >}}) how-to guide.
 
 Verify that the operator is running:
 

--- a/docs/content/tutorials/getting-started-kubernetes.md
+++ b/docs/content/tutorials/getting-started-kubernetes.md
@@ -32,7 +32,12 @@ helm repo update
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
+  --create-namespace
 ```
+
+{{% alert title="Namespace conflict on versions 0.4.0 and earlier" color="warning" %}}
+Versions 0.4.0 and earlier have a bug where the first install fails with `namespaces "coraza-system" already exists`. If you hit this error, run the same command again. The first run creates the namespace and a failed release record; the second run succeeds because Helm treats it as an upgrade, which patches the existing namespace instead of trying to create it.
+{{% /alert %}}
 
 For more installation options (version pinning, custom values), see the [Install on Kubernetes with Helm]({{< relref "../howto/install-kubernetes-helm" >}}) how-to guide.
 
@@ -242,6 +247,14 @@ curl -s -o /dev/null -w "%{http_code}" "http://localhost:8080/?q=attack"
 Expected output: `403`
 
 The WAF is working. Requests containing the word "attack" in any query parameter are blocked with a 403 status.
+
+Check the Gateway logs to see the blocked request:
+
+```bash
+kubectl logs -n waf-tutorial deploy/waf-gateway-istio
+```
+
+You should see a log entry from Coraza indicating the request was denied.
 
 ## Step 8: Clean Up
 

--- a/docs/content/tutorials/getting-started-openshift.md
+++ b/docs/content/tutorials/getting-started-openshift.md
@@ -55,12 +55,17 @@ helm repo update
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
+  --create-namespace \
   --set openshift.enabled=true \
   --set istio.revision=openshift-gateway \
   --set metrics.serviceMonitor.enabled=true
 ```
 
 Setting `openshift.enabled` to `true` omits `runAsUser`, `fsGroup`, and `fsGroupChangePolicy` from the pod security context so that OpenShift can inject its own UID via Security Context Constraints (SCCs).
+
+{{% alert title="Namespace conflict on versions 0.4.0 and earlier" color="warning" %}}
+Versions 0.4.0 and earlier have a bug where the first install fails with `namespaces "coraza-system" already exists`. If you hit this error, run the same command again. The first run creates the namespace and a failed release record; the second run succeeds because Helm treats it as an upgrade, which patches the existing namespace instead of trying to create it.
+{{% /alert %}}
 
 For more installation options (version pinning, advanced values), see the [Install on OpenShift]({{< relref "../howto/install-openshift-operatorhub" >}}) how-to guide.
 
@@ -244,7 +249,7 @@ oc wait -n waf-tutorial engine/tutorial-engine \
 Port-forward to the Gateway:
 
 ```bash
-oc port-forward -n waf-tutorial svc/waf-gateway-istio 8080:80 &
+oc port-forward -n waf-tutorial svc/waf-gateway-openshift-default 8080:80 &
 ```
 
 Test a normal request:
@@ -262,6 +267,14 @@ curl -s -o /dev/null -w "%{http_code}" "http://localhost:8080/?q=attack"
 ```
 
 Expected output: `403`
+
+Check the Gateway logs to see the blocked request:
+
+```bash
+oc logs -n waf-tutorial deploy/waf-gateway-openshift-default
+```
+
+You should see a log entry from Coraza indicating the request was denied.
 
 ## Step 8: Clean Up
 

--- a/docs/content/tutorials/getting-started-openshift.md
+++ b/docs/content/tutorials/getting-started-openshift.md
@@ -14,25 +14,36 @@ By the end, you will have a working WAF protecting a sample application behind a
 Before you begin, ensure you have:
 
 - An OpenShift Container Platform cluster running **v4.20 or later**
-- [OpenShift Service Mesh](https://docs.openshift.com/container-platform/latest/service_mesh/v2x/installing-ossm.html) or Istio installed with Gateway API support
+- Gateway API enabled on your cluster (see [Enable Gateway API](#enable-gateway-api) below)
+- [OpenShift Service Mesh](https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html-single/gateways/index) or Istio installed with Gateway API support
+- [Helm 3](https://helm.sh/docs/intro/install/) installed
 - The `oc` CLI configured to access your cluster
 - Cluster administrator privileges
 
+### Enable Gateway API
+
+On OpenShift 4.19 and later, the Gateway API CRDs are included by default. You must create the `openshift-default` GatewayClass, which is the [officially supported GatewayClass](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/ingress_and_load_balancing/configuring-ingress-cluster-traffic#ingress-gateway-api) provided by the OpenShift Ingress Operator:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+spec:
+  controllerName: openshift.io/gateway-controller/v1
+EOF
+```
+
+On OpenShift 4.18 and earlier, you must install [Red Hat OpenShift Service Mesh 3.0](https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html-single/gateways/index) to enable Gateway API support.
+
 ## Step 1: Install the Operator
 
-You can install the Coraza Kubernetes Operator using either the OpenShift web console or the CLI.
+The preferred installation method on OpenShift is OperatorHub, but the operator is not yet published there (see [issue #201](https://github.com/networking-incubator/coraza-kubernetes-operator/issues/201)). In the meantime, install with Helm.
 
-### Option A: Install from OperatorHub (Web Console)
+### Install with Helm
 
-1. Open the OpenShift web console.
-2. Navigate to **Operators > OperatorHub**.
-3. Search for "Coraza Kubernetes Operator".
-4. Select the operator and click **Install**.
-5. Choose the installation namespace and approval strategy, then click **Install**.
-
-<!-- TODO: Update with the published CatalogSource URL when available. -->
-
-### Option B: Install with Helm
+Ensure [Helm 3](https://helm.sh/docs/intro/install/) is installed, then add the repository and install:
 
 ```bash
 helm repo add coraza-kubernetes-operator \
@@ -44,19 +55,14 @@ helm repo update
 helm upgrade --install coraza-kubernetes-operator \
   coraza-kubernetes-operator/coraza-kubernetes-operator \
   --namespace coraza-system \
-  --create-namespace \
-  -f - <<EOF
-openshift:
-  enabled: true
-istio:
-  revision: openshift-gateway
-metrics:
-  serviceMonitor:
-    enabled: true
-EOF
+  --set openshift.enabled=true \
+  --set istio.revision=openshift-gateway \
+  --set metrics.serviceMonitor.enabled=true
 ```
 
-Setting `openshift.enabled` to `true` ensures the operator pod security context is compatible with OpenShift Security Context Constraints (SCCs).
+Setting `openshift.enabled` to `true` omits `runAsUser`, `fsGroup`, and `fsGroupChangePolicy` from the pod security context so that OpenShift can inject its own UID via Security Context Constraints (SCCs).
+
+For more installation options (version pinning, advanced values), see the [Install on OpenShift]({{< relref "../howto/install-openshift-operatorhub" >}}) how-to guide.
 
 Verify the operator is running:
 
@@ -109,7 +115,7 @@ EOF
 
 ## Step 3: Create a Gateway and HTTPRoute
 
-Create a Gateway using the OpenShift gateway class:
+Create a Gateway using the `openshift-default` GatewayClass. This is the [officially supported GatewayClass](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/ingress_and_load_balancing/configuring-ingress-cluster-traffic#ingress-gateway-api) provided by the OpenShift Ingress Operator:
 
 ```bash
 oc apply -n waf-tutorial -f - <<EOF
@@ -117,8 +123,6 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: waf-gateway
-  labels:
-    istio.io/rev: openshift-gateway
 spec:
   gatewayClassName: openshift-default
   listeners:


### PR DESCRIPTION
This pull request updates the documentation for installing the Coraza Kubernetes Operator, focusing on clarifying Kubernetes version requirements, improving and unifying Helm installation instructions, and enhancing OpenShift-specific guidance. The changes ensure consistency across guides, provide more actionable installation steps, and add details for enabling Gateway API support on OpenShift.

**Documentation improvements and installation instructions:**

* Updated the minimum required Kubernetes version for the Helm chart from 1.33.0 to 1.32.0 in `README.md` and related documentation, and clarified that this is enforced in `Chart.yaml` via `kubeVersion`. [[1]](diffhunk://#diff-c5e724e262ed997fe8d6fb725c7e9811c19e37e8c412070c3160db9b1bdb8271L5-R5) [[2]](diffhunk://#diff-c5e724e262ed997fe8d6fb725c7e9811c19e37e8c412070c3160db9b1bdb8271L74-R73)
* Revised and unified Helm installation instructions across both Kubernetes and OpenShift guides, removing unnecessary `--create-namespace` flags and providing clear steps for version pinning and advanced configuration. [[1]](diffhunk://#diff-c5e724e262ed997fe8d6fb725c7e9811c19e37e8c412070c3160db9b1bdb8271L18-R18) [[2]](diffhunk://#diff-d38ae282ed0ffdaf04b3a38c2a98f7c8ac43648de53202a9d2cb2ce5d68a1102L13-L41) [[3]](diffhunk://#diff-d38ae282ed0ffdaf04b3a38c2a98f7c8ac43648de53202a9d2cb2ce5d68a1102L71) [[4]](diffhunk://#diff-82f3123510b88e4e47fc5af8c424c298ccefff7bb1262dd98f1356520c2bab06L35-R38) [[5]](diffhunk://#diff-36cd6603c64fdd1c11cd1e1fee623fe5f7532c4eaa152ea315a9130e49729db5L47-R65)
* Added instructions and YAML for enabling the Gateway API and creating the `openshift-default` GatewayClass on OpenShift, including references to official documentation. [[1]](diffhunk://#diff-b5ed5a0492bf9b88de95aa212def61f896a4b95be5c28206bed50f250b113722L2-R40) [[2]](diffhunk://#diff-36cd6603c64fdd1c11cd1e1fee623fe5f7532c4eaa152ea315a9130e49729db5L17-R46)

**OpenShift-specific enhancements:**

* Expanded the OpenShift installation guide to cover both OperatorHub and Helm methods, including a notice that the operator is not yet published to OperatorHub and how to track progress. Added guidance for using the CLI and values files for advanced Helm configuration. [[1]](diffhunk://#diff-b5ed5a0492bf9b88de95aa212def61f896a4b95be5c28206bed50f250b113722L2-R40) [[2]](diffhunk://#diff-b5ed5a0492bf9b88de95aa212def61f896a4b95be5c28206bed50f250b113722L25-R51) [[3]](diffhunk://#diff-b5ed5a0492bf9b88de95aa212def61f896a4b95be5c28206bed50f250b113722L38-R80) [[4]](diffhunk://#diff-b5ed5a0492bf9b88de95aa212def61f896a4b95be5c28206bed50f250b113722L64-R146)
* Clarified the behavior of the `openshift.enabled` Helm value, explaining its effect on pod security context and compatibility with OpenShift SCCs. [[1]](diffhunk://#diff-b5ed5a0492bf9b88de95aa212def61f896a4b95be5c28206bed50f250b113722L64-R146) [[2]](diffhunk://#diff-36cd6603c64fdd1c11cd1e1fee623fe5f7532c4eaa152ea315a9130e49729db5L47-R65)

**General improvements and consistency:**

* Updated titles, descriptions, and navigation in how-to guides and tutorials for consistency and clarity, including renaming "Install on OpenShift via OperatorHub" to "Install on OpenShift". [[1]](diffhunk://#diff-ab36ba267043e682aa6525324dbda3d458f2b851aea15e7f888b4c7ea3c3bfb6L16-R16) [[2]](diffhunk://#diff-b5ed5a0492bf9b88de95aa212def61f896a4b95be5c28206bed50f250b113722L2-R40)
* Added instructions for verifying installation and uninstalling the operator, including CRD removal and warnings about deleting resources.

These updates make the installation process clearer and more robust for both Kubernetes and OpenShift users, and ensure that documentation reflects the current state of the operator and its requirements.