### PR TITLE
Use different backend for FTW and increase conformance

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -25,20 +25,20 @@ Both tiers are rejected by default. For the complete list of affected rule IDs, 
 
 ## Overview
 
-Out of approximately 3,300 CoreRuleSet conformance tests, 190 tests (6%) are currently ignored, resulting in a 94% pass rate. These ignored tests fall into four categories:
+Out of approximately 4,600 CoreRuleSet conformance tests, 53 tests are currently ignored and 42 are overridden with adjusted expectations, resulting in a ~98% pass rate. These fall into four categories:
 
-| Category | Tests | Impact |
-|----------|-------|--------|
-| Enhanced Security | 45 | Positive - Envoy provides additional protection |
-| Tool Limitations | 113 | Requires alternative controls or monitoring |
-| Coraza/WASM Bugs | 13 | Requires fixes in Coraza or coraza-proxy-wasm |
-| Under Investigation | 19 | Requires further analysis |
+| Category | Tests | Type | Impact |
+|----------|-------|------|--------|
+| Enhanced Security | 42 | Overridden | Positive - Envoy provides additional protection |
+| Tool Limitations | 21 | Ignored | Requires alternative controls or monitoring |
+| Coraza/WASM Bugs | 13 | Ignored | Requires fixes in Coraza or coraza-proxy-wasm |
+| Under Investigation | 19 | Ignored | Requires further analysis |
 
 ---
 
-## Enhanced Security (45 tests)
+## Enhanced Security (42 overridden tests)
 
-These tests fail because Envoy blocks or sanitizes attacks before they reach the WAF. This represents defense-in-depth, not a security gap.
+These tests are overridden with adjusted expectations (in `.ftw-overrides.yml`) rather than ignored. Envoy blocks or sanitizes attacks before they reach the WAF. This represents defense-in-depth, not a security gap.
 
 ### Invalid HTTP Methods and Malformed Requests (9 tests)
 
@@ -86,38 +86,15 @@ Envoy enforces HTTP protocol specifications:
 
 ---
 
-## Tool Limitations (113 tests)
+## Tool Limitations (21 tests)
 
 These represent actual limitations that may allow attacks to bypass detection. Alternative controls are recommended.
 
-### Response Body Inspection (79 tests)
-
-Response body content is not available for inspection by phase 4 rules in the WASM environment.
-
-**Affected rule families:**
-- 950xxx: Data leakage detection (9 tests)
-- 951xxx: SQL error messages (20 tests)
-- 952xxx: Java error messages (10 tests)
-- 953xxx: PHP error messages (9 tests)
-- 954xxx: IIS error messages (7 tests)
-- 955xxx: Web shell detection (10 tests)
-- 956xxx: Ruby error messages (14 tests)
-
-**Impact:** Data leakage, error messages, and web shells in responses are not detected.
-
-**Root cause:** Envoy does not currently pass response body content to WASM filters for inspection, despite `SecResponseBodyAccess On` configuration.
-
-**Mitigation:**
-- Deploy as standalone reverse proxy for full response inspection
-- Implement application-level logging and monitoring
-- Use SIEM integration for data leakage detection
-- Monitor response status codes via Envoy access logs
-
-### Multipart Charset Detection (30 tests)
+### Multipart Charset Detection (17 tests)
 
 Illegal charset detection in multipart form headers does not function in the Envoy/Kubernetes environment.
 
-**Affected rule:** 922110 (all 30 test cases)
+**Affected rule:** 922110 (17 test cases)
 
 **Impact:** Charset-based encoding attacks (utf-7, utf-16, shift-jis, etc.) in multipart uploads are not detected.
 
@@ -199,7 +176,7 @@ These require further analysis to determine appropriate action:
 - **CoreRuleSet**: v4.24.1
 - **Envoy/Istio**: WASM filter environment
 - **coraza-proxy-wasm**: Latest
-- **Documentation Date**: 2026-03-17
-- **Test Coverage**: 94% pass rate (190 ignored / ~3,300 total)
+- **Documentation Date**: 2026-04-16
+- **Test Coverage**: ~98% pass rate (53 ignored + 42 overridden / ~4,600 total)
 
 For configuration details of ignored tests, see [test/conformance/ftw.yml](test/conformance/ftw.yml).

--- a/internal/controller/ruleset_controller_test.go
+++ b/internal/controller/ruleset_controller_test.go
@@ -695,9 +695,9 @@ func TestRuleSetReconciler_UnsupportedRules(t *testing.T) {
 	t.Run("ruleset with unsupported rule should be rejected", func(t *testing.T) {
 		ruleSetCache := cache.NewRuleSetCache()
 
-		t.Log("Creating ConfigMap with an unsupported response body inspection rule")
+		t.Log("Creating ConfigMap with an unsupported multipart charset detection rule")
 		cm := utils.NewTestConfigMap("unsupported-rules", testNamespace,
-			`SecRule RESPONSE_BODY "@rx error" "id:950150,phase:4,deny,status:403,msg:'Data leakage'"`)
+			`SecRule REQUEST_HEADERS "@rx charset" "id:922110,phase:1,deny,status:403,msg:'Charset attack'"`)
 		require.NoError(t, k8sClient.Create(ctx, cm))
 		t.Cleanup(func() {
 			if err := k8sClient.Delete(ctx, cm); err != nil {
@@ -751,8 +751,8 @@ func TestRuleSetReconciler_UnsupportedRules(t *testing.T) {
 		require.NotNil(t, ready)
 		assert.Equal(t, metav1.ConditionFalse, ready.Status)
 		assert.Equal(t, "UnsupportedRules", ready.Reason)
-		assert.Contains(t, ready.Message, "950150")
-		assert.Contains(t, ready.Message, "response body inspection")
+		assert.Contains(t, ready.Message, "922110")
+		assert.Contains(t, ready.Message, "multipart charset detection")
 
 		degraded := apimeta.FindStatusCondition(ruleSet.Status.Conditions, "Degraded")
 		require.NotNil(t, degraded)
@@ -842,7 +842,7 @@ func TestRuleSetReconciler_UnsupportedRules(t *testing.T) {
 		})
 
 		cmUnsupported := utils.NewTestConfigMap("mix-unsupported", testNamespace,
-			`SecRule RESPONSE_BODY "@rx leak" "id:956100,phase:4,deny,status:403"`)
+			`SecRule REQUEST_HEADERS "@rx charset" "id:922110,phase:1,deny,status:403"`)
 		require.NoError(t, k8sClient.Create(ctx, cmUnsupported))
 		t.Cleanup(func() {
 			if err := k8sClient.Delete(ctx, cmUnsupported); err != nil {
@@ -904,7 +904,7 @@ func TestRuleSetReconciler_UnsupportedRules(t *testing.T) {
 
 		t.Log("Creating ConfigMap with unsupported rules (simulating a bad update)")
 		cm := utils.NewTestConfigMap("update-to-unsupported-rules", testNamespace,
-			`SecRule RESPONSE_BODY "@rx error" "id:950150,phase:4,deny,status:403,msg:'Bad update'"`)
+			`SecRule REQUEST_HEADERS "@rx charset" "id:922110,phase:1,deny,status:403,msg:'Bad update'"`)
 		require.NoError(t, k8sClient.Create(ctx, cm))
 		t.Cleanup(func() {
 			if err := k8sClient.Delete(ctx, cm); err != nil {
@@ -948,8 +948,8 @@ func TestRuleSetReconciler_UnsupportedRules(t *testing.T) {
 	t.Run("ruleset with skip annotation should be cached with unsupported rules listed in status", func(t *testing.T) {
 		ruleSetCache := cache.NewRuleSetCache()
 
-		t.Log("Creating ConfigMap with an unsupported response body inspection rule")
-		const unsupportedRule = `SecRule RESPONSE_BODY "@rx error" "id:950150,phase:4,deny,status:403,msg:'Data leakage'"`
+		t.Log("Creating ConfigMap with an unsupported multipart charset detection rule")
+		const unsupportedRule = `SecRule REQUEST_HEADERS "@rx charset" "id:922110,phase:1,deny,status:403,msg:'Charset attack'"`
 		cm := utils.NewTestConfigMap("skip-annotation-rules", testNamespace, unsupportedRule)
 		require.NoError(t, k8sClient.Create(ctx, cm))
 		t.Cleanup(func() {
@@ -995,7 +995,7 @@ func TestRuleSetReconciler_UnsupportedRules(t *testing.T) {
 		cacheKey := testNamespace + "/skip-annotation-ruleset"
 		entry, ok := ruleSetCache.Get(cacheKey)
 		assert.True(t, ok, "cache should contain entry when annotation overrides unsupported rules check")
-		assert.Contains(t, entry.Rules, "id:950150")
+		assert.Contains(t, entry.Rules, "id:922110")
 
 		t.Log("Verifying Ready=True with unsupported rules listed in the message")
 		require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{
@@ -1006,7 +1006,7 @@ func TestRuleSetReconciler_UnsupportedRules(t *testing.T) {
 		require.NotNil(t, ready)
 		assert.Equal(t, metav1.ConditionTrue, ready.Status)
 		assert.Equal(t, "RulesCached", ready.Reason)
-		assert.Contains(t, ready.Message, "950150", "ready message should list the detected unsupported rule ID")
+		assert.Contains(t, ready.Message, "922110", "ready message should list the detected unsupported rule ID")
 
 		t.Log("Verifying Degraded condition is absent")
 		degraded := apimeta.FindStatusCondition(ruleSet.Status.Conditions, "Degraded")

--- a/internal/rulesets/unsupported.go
+++ b/internal/rulesets/unsupported.go
@@ -149,24 +149,6 @@ func buildRegistry() map[int]UnsupportedRule {
 	// Incompatible Tier — rules that do not function in WASM mode
 	// -------------------------------------------------------------------------
 
-	// Response body inspection: Envoy does not pass response body to WASM filters.
-	for _, id := range []int{
-		950150,
-		951110, 951120, 951130, 951140, 951150, 951160, 951170, 951180, 951190, 951200, 951210, 951220, 951230, 951240, 951250, 951260,
-		952110,
-		953101, 953120,
-		954100, 954101, 954120,
-		955100, 955110, 955120, 955260, 955400,
-		956100, 956110,
-	} {
-		r[id] = UnsupportedRule{
-			ID:          id,
-			Category:    "response body inspection",
-			Tier:        TierIncompatible,
-			Description: "response body inspection is not supported in Envoy WASM",
-		}
-	}
-
 	// Multipart charset detection: Envoy body handling prevents detection.
 	r[922110] = UnsupportedRule{
 		ID:          922110,

--- a/internal/rulesets/unsupported_test.go
+++ b/internal/rulesets/unsupported_test.go
@@ -31,9 +31,9 @@ func TestRegistryCompleteness(t *testing.T) {
 	total := len(incompatible) + len(redundant)
 
 	assert.Equal(t, total, len(unsupportedRules), "total registry size should equal sum of tiers")
-	assert.Len(t, incompatible, 46, "incompatible tier count")
+	assert.Len(t, incompatible, 16, "incompatible tier count")
 	assert.Len(t, redundant, 21, "redundant tier count")
-	assert.Equal(t, 67, total, "total unsupported rules")
+	assert.Equal(t, 37, total, "total unsupported rules")
 }
 
 func TestAllUnsupportedRuleIDs(t *testing.T) {
@@ -56,28 +56,6 @@ func TestAllUnsupportedRuleIDs(t *testing.T) {
 	}
 	for _, id := range redundant {
 		assert.True(t, idSet[id], "redundant ID %d should be in AllUnsupportedRuleIDs", id)
-	}
-}
-
-func TestCheckUnsupportedRules_ResponseBodyInspection(t *testing.T) {
-	responseBodyIDs := []int{
-		950150,
-		951110, 951120, 951130, 951140, 951150, 951160, 951170, 951180, 951190, 951200, 951210, 951220, 951230, 951240, 951250, 951260,
-		952110,
-		953101, 953120,
-		954100, 954101, 954120,
-		955100, 955110, 955120, 955260, 955400,
-		956100, 956110,
-	}
-
-	for _, id := range responseBodyIDs {
-		t.Run(fmt.Sprintf("rule_%d", id), func(t *testing.T) {
-			found := CheckUnsupportedRules(secRuleWithID(id))
-			require.Len(t, found, 1)
-			assert.Equal(t, id, found[0].ID)
-			assert.Equal(t, "response body inspection", found[0].Category)
-			assert.Equal(t, TierIncompatible, found[0].Tier)
-		})
 	}
 }
 
@@ -238,22 +216,22 @@ func TestCheckUnsupportedRules_NoIDs(t *testing.T) {
 }
 
 func TestCheckUnsupportedRules_MixedSupportedAndUnsupported(t *testing.T) {
-	rules := secRulesWithIDs(1, 950150, 2, 922110, 3)
+	rules := secRulesWithIDs(1, 920274, 2, 922110, 3)
 	found := CheckUnsupportedRules(rules)
 	require.Len(t, found, 2)
-	assert.Equal(t, 922110, found[0].ID)
-	assert.Equal(t, 950150, found[1].ID)
+	assert.Equal(t, 920274, found[0].ID)
+	assert.Equal(t, 922110, found[1].ID)
 }
 
 func TestCheckUnsupportedRules_DuplicateIDsDeduped(t *testing.T) {
-	rules := secRuleWithID(950150) + "\n" + secRuleWithID(950150)
+	rules := secRuleWithID(922110) + "\n" + secRuleWithID(922110)
 	found := CheckUnsupportedRules(rules)
 	require.Len(t, found, 1)
-	assert.Equal(t, 950150, found[0].ID)
+	assert.Equal(t, 922110, found[0].ID)
 }
 
 func TestCheckUnsupportedRules_CommentedOutRulesIgnored(t *testing.T) {
-	rules := `# SecRule RESPONSE_BODY "@rx error" "id:950150,phase:4,deny"
+	rules := `# SecRule REQUEST_HEADERS "@rx charset" "id:922110,phase:1,deny"
 SecRule REQUEST_URI "@contains /admin" "id:1,phase:1,deny"`
 	found := CheckUnsupportedRules(rules)
 	assert.Nil(t, found, "commented-out unsupported rule should be ignored")
@@ -261,7 +239,7 @@ SecRule REQUEST_URI "@contains /admin" "id:1,phase:1,deny"`
 
 func TestCheckUnsupportedRules_MixedCommentAndActive(t *testing.T) {
 	rules := `# This rule is disabled:
-# SecRule RESPONSE_BODY "@rx error" "id:950150,phase:4,deny"
+# SecRule REQUEST_HEADERS "@rx charset" "id:922110,phase:1,deny"
 SecRule REQUEST_URI "@rx test" "id:911100,phase:1,pass"`
 	found := CheckUnsupportedRules(rules)
 	require.Len(t, found, 1)
@@ -269,14 +247,14 @@ SecRule REQUEST_URI "@rx test" "id:911100,phase:1,pass"`
 }
 
 func TestCheckUnsupportedRules_QuotedIDs(t *testing.T) {
-	rules := `SecRule REQUEST_URI "@rx test" "id:'950150',phase:1,pass"`
+	rules := `SecRule REQUEST_URI "@rx test" "id:'922110',phase:1,pass"`
 	found := CheckUnsupportedRules(rules)
 	require.Len(t, found, 1)
-	assert.Equal(t, 950150, found[0].ID)
+	assert.Equal(t, 922110, found[0].ID)
 }
 
 func TestCheckUnsupportedRules_MixedTiers(t *testing.T) {
-	rules := secRulesWithIDs(950150, 911100)
+	rules := secRulesWithIDs(922110, 911100)
 	found := CheckUnsupportedRules(rules)
 	require.Len(t, found, 2)
 
@@ -291,24 +269,24 @@ func TestFormatUnsupportedMessage_Empty(t *testing.T) {
 
 func TestFormatUnsupportedMessage_SingleRule(t *testing.T) {
 	found := []UnsupportedRule{
-		{ID: 950150, Category: "response body inspection", Tier: TierIncompatible, Description: "response body inspection is not supported in Envoy WASM"},
+		{ID: 922110, Category: "multipart charset detection", Tier: TierIncompatible, Description: "multipart charset detection does not function in Envoy/Kubernetes"},
 	}
 	msg := FormatUnsupportedMessage(found)
 	assert.Contains(t, msg, "1 unsupported rule(s)")
-	assert.Contains(t, msg, "rule 950150")
-	assert.Contains(t, msg, "response body inspection")
+	assert.Contains(t, msg, "rule 922110")
+	assert.Contains(t, msg, "multipart charset detection")
 	assert.Contains(t, msg, "LIMITATIONS.md")
 }
 
 func TestFormatUnsupportedMessage_MultipleRules(t *testing.T) {
 	found := []UnsupportedRule{
+		{ID: 920274, Category: "PL4 false positives", Tier: TierIncompatible, Description: "PL4 false positives from Envoy :path pseudo-header population"},
 		{ID: 922110, Category: "multipart charset detection", Tier: TierIncompatible, Description: "multipart charset detection does not function"},
-		{ID: 950150, Category: "response body inspection", Tier: TierIncompatible, Description: "response body inspection not supported"},
 	}
 	msg := FormatUnsupportedMessage(found)
 	assert.Contains(t, msg, "2 unsupported rule(s)")
+	assert.Contains(t, msg, "rule 920274")
 	assert.Contains(t, msg, "rule 922110")
-	assert.Contains(t, msg, "rule 950150")
 }
 
 // -----------------------------------------------------------------------------

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -110,7 +110,7 @@ func TestCoreRuleSetConformance(t *testing.T) {
 	s.CreateGateway(ns, gwName)
 	s.ExpectGatewayProgrammed(ns, gwName)
 	s.Step("deploy echo backend")
-	s.CreateEchoBackend(ns, "echo")
+	s.CreateConformanceEcho(ns, "echo")
 	s.CreateHTTPRoute(ns, "echo-route", gwName, "echo")
 
 	// -------------------------------------------------------------------------

--- a/test/conformance/ftw.yml
+++ b/test/conformance/ftw.yml
@@ -28,99 +28,6 @@ testoverride:
     # IMPACT: Data leakage, error messages, and web shells in responses are NOT detected
     # WORKAROUND: Use separate response logging/monitoring or deploy as reverse proxy
 
-    # RESPONSE-950-DATA-LEAKAGES (9 tests)
-    '950150-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '950150-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '950150-3': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '950150-4': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '950150-5': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '950150-6': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '950150-7': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '950150-8': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '950150-9': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-
-    # RESPONSE-951-DATA-LEAKAGES-SQL (20 tests)
-    '951110-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951120-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951130-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951140-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951150-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951160-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951170-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951180-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951190-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951200-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951210-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951210-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951220-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951220-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951230-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951230-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951240-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951240-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951250-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '951260-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-
-    # RESPONSE-952-DATA-LEAKAGES-JAVA (10 tests)
-    '952110-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '952110-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '952110-3': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '952110-4': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '952110-5': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '952110-6': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '952110-7': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '952110-8': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '952110-9': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '952110-10': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-
-    # RESPONSE-953-DATA-LEAKAGES-PHP (9 tests)
-    '953101-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '953101-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '953101-3': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '953101-4': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '953101-5': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '953120-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '953120-3': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '953120-5': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '953120-7': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-
-    # RESPONSE-954-DATA-LEAKAGES-IIS (7 tests)
-    '954100-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '954100-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '954100-3': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '954101-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '954101-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '954120-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '954120-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-
-    # RESPONSE-955-WEB-SHELLS (10 tests)
-    '955100-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '955100-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '955100-3': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '955110-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '955120-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '955120-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '955260-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '955400-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '955400-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '955400-3': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-
-    # RESPONSE-956-DATA-LEAKAGES-RUBY (14 tests)
-    '956100-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-3': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-4': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-5': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-6': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-7': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-8': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-9': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-10': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956100-11': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956110-1': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956110-2': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-    '956110-3': 'TOOL LIMITATION: Response body inspection not supported in Envoy WASM'
-
     # Multipart Charset Detection - Envoy body handling issue (30 tests)
     # NOTE: coraza-proxy-wasm unit tests PROVE this works in WASM
     # ISSUE: Envoy request body handling prevents detection in K8s environment
@@ -128,32 +35,19 @@ testoverride:
     '922110-2': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-3': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-4': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-5': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-6': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-7': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-8': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-9': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-10': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-11': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-12': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-13': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-14': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-15': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-16': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-17': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-18': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-19': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-20': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-21': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-22': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-23': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-24': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-25': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-26': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-27': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-28': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
     '922110-29': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
-    '922110-30': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
 
     # PL4 False Positives - Envoy :path header population (4 tests)
     '920274-2': 'TOOL LIMITATION: PL4 false positive - Envoy populates :path with invalid chars'
@@ -260,5 +154,5 @@ testoverride:
     #   - PL4 false positives: 2 tests
     #   - retry_once: 5 tests
     #
-    # Test Pass Rate: ~95% (145 ignored + 42 overridden out of ~3,300 total tests)
+    # Test Pass Rate: ~98% (64 ignored + 42 overridden out of ~3,300 total tests)
     # =============================================================================

--- a/test/conformance/ftw.yml
+++ b/test/conformance/ftw.yml
@@ -23,12 +23,7 @@ testoverride:
     # IMPACT: Could allow attacks to bypass detection
     # ---------------------------------------------------------------------------
 
-    # Response Body Inspection - Envoy/Istio WASM limitation (79 tests)
-    # NOTE: Response bodies are NOT available for inspection in WASM environment
-    # IMPACT: Data leakage, error messages, and web shells in responses are NOT detected
-    # WORKAROUND: Use separate response logging/monitoring or deploy as reverse proxy
-
-    # Multipart Charset Detection - Envoy body handling issue (30 tests)
+    # Multipart Charset Detection - Envoy body handling issue (17 tests)
     # NOTE: coraza-proxy-wasm unit tests PROVE this works in WASM
     # ISSUE: Envoy request body handling prevents detection in K8s environment
     '922110-1': 'TOOL LIMITATION: Multipart charset detection - Envoy body handling issue'
@@ -125,15 +120,14 @@ testoverride:
     '980170-3': 'INVESTIGATE: retry_once mechanism not working in environment'
 
     # =============================================================================
-    # Summary of Ignored Tests by Category (Total: 145 tests):
+    # Summary of Ignored Tests by Category (Total: 53 tests):
     #
     # NOTE: 42 ENHANCED SECURITY tests moved to .ftw-overrides.yml as platform
     # overrides (they now run with adjusted expectations instead of being skipped).
     #
-    # CATEGORY 2: TOOL LIMITATION (113 tests)
+    # CATEGORY 2: TOOL LIMITATION (21 tests)
     #   - Environmental constraints that could cause false negatives
-    #   - Response body inspection: 79 tests
-    #   - Multipart charset detection: 30 tests
+    #   - Multipart charset detection: 17 tests
     #   - PL4 false positives: 4 tests
     #
     # CATEGORY 3: CORAZA/WASM ISSUES (13 tests)
@@ -154,5 +148,5 @@ testoverride:
     #   - PL4 false positives: 2 tests
     #   - retry_once: 5 tests
     #
-    # Test Pass Rate: ~98% (64 ignored + 42 overridden out of ~3,300 total tests)
+    # Test Pass Rate: ~98% (53 ignored + 42 overridden out of ~4,600 total tests)
     # =============================================================================

--- a/test/framework/resources.go
+++ b/test/framework/resources.go
@@ -135,6 +135,15 @@ func defaultEchoImage() string {
 	return fallbackEchoImage
 }
 
+const fallbackConformanceImage = "ghcr.io/coreruleset/albedo:0.3.0"
+
+func defaultConformanceEchoImage() string {
+	if image := os.Getenv("CONFORMANCE_ECHO_IMAGE"); image != "" {
+		return image
+	}
+	return fallbackConformanceImage
+}
+
 // SimpleBlockRule generates a SecLang rule that denies requests containing
 // the target string with the given rule ID.
 func SimpleBlockRule(id int, target string) string {
@@ -515,7 +524,7 @@ func (s *Scenario) CreateHTTPRoute(namespace, name, gatewayName, backendName str
 // CreateConformanceEcho deploys the Albedo backend (OWASP/Coreruleset backend)
 // and waits for at least one pod to be Ready. The image is used for FTW tests
 func (s *Scenario) CreateConformanceEcho(namespace, name string) {
-	s.createEchoBackend(namespace, name, "ghcr.io/coreruleset/albedo:0.3.0", 8080)
+	s.createEchoBackend(namespace, name, defaultConformanceEchoImage(), 8080)
 }
 
 // CreateEchoBackend deploys the Gateway API echo server (Deployment + Service)

--- a/test/framework/resources.go
+++ b/test/framework/resources.go
@@ -512,16 +512,24 @@ func (s *Scenario) CreateHTTPRoute(namespace, name, gatewayName, backendName str
 	})
 }
 
+// CreateConformanceEcho deploys the Albedo backend (OWASP/Coreruleset backend)
+// and waits for at least one pod to be Ready. The image is used for FTW tests
+func (s *Scenario) CreateConformanceEcho(namespace, name string) {
+	s.createEchoBackend(namespace, name, "ghcr.io/coreruleset/albedo:0.3.0", 8080)
+}
+
 // CreateEchoBackend deploys the Gateway API echo server (Deployment + Service)
 // and waits for at least one pod to be Ready. The echo image defaults to
 // ECHO_IMAGE env var or the built-in Gateway API conformance echo image.
 func (s *Scenario) CreateEchoBackend(namespace, name string) {
+	s.createEchoBackend(namespace, name, defaultEchoImage(), 3000)
+}
+
+func (s *Scenario) createEchoBackend(namespace, name, echoImage string, containerPort int32) {
 	s.T.Helper()
 	ctx := s.T.Context()
 
-	echoImage := defaultEchoImage()
 	replicas := int32(1)
-	containerPort := int32(3000)
 	servicePort := int32(80)
 
 	dep := &appsv1.Deployment{


### PR DESCRIPTION
This PR:
* Changes the echo image to the same used by Coraza tests (which properly reflects body request/response tests)
* Remove tests that were once ignored due to this change
