### PR TITLE
fix: manager could start with broken engine

### DIFF
--- a/internal/controller/engine_controller_istio_prerequisites.go
+++ b/internal/controller/engine_controller_istio_prerequisites.go
@@ -61,13 +61,13 @@ func NewIstioPrerequisites(c client.Client, reader client.Reader, operatorName, 
 
 // Start applies the Istio ServiceEntry and DestinationRule for the
 // RuleSet cache server. It satisfies the manager.Runnable interface.
+//
+// Returning an error shuts down the manager, which is correct: without
+// mesh prerequisites the cache server is unreachable and Engines cannot
+// function. Kubernetes pod-restart backoff provides the retry mechanism.
 func (p *IstioPrerequisites) Start(ctx context.Context) error {
 	log := ctrl.Log.WithName("istio-prerequisites")
-
-	if err := p.apply(ctx, log); err != nil {
-		log.Error(err, "Failed to apply Istio prerequisites (controllers will continue without them)")
-	}
-	return nil
+	return p.apply(ctx, log)
 }
 
 func (p *IstioPrerequisites) apply(ctx context.Context, log logr.Logger) error {

--- a/internal/controller/engine_controller_istio_prerequisites_test.go
+++ b/internal/controller/engine_controller_istio_prerequisites_test.go
@@ -217,17 +217,27 @@ func TestIstioPrerequisites_ApplyDeploymentNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "looking up owner Deployment")
 }
 
-func TestIstioPrerequisites_StartReturnsNilOnError(t *testing.T) {
+func TestIstioPrerequisites_StartPropagatesError(t *testing.T) {
 	ctx := context.Background()
 	namespace := setupTestNamespace(t, ctx)
 
 	p := NewIstioPrerequisites(k8sClient, k8sClient, "no-such-deploy", namespace, "")
 	err := p.Start(ctx)
-	assert.NoError(t, err, "Start() must return nil even when apply fails")
+	require.Error(t, err, "Start() must propagate apply errors to shut down the manager")
+	assert.Contains(t, err.Error(), "looking up owner Deployment")
+}
+
+func TestIstioPrerequisites_StartSucceeds(t *testing.T) {
+	ctx := context.Background()
+	namespace := setupTestNamespace(t, ctx)
+	createDeployment(t, ctx, "start-ok", namespace)
+
+	p := NewIstioPrerequisites(k8sClient, k8sClient, "start-ok", namespace, "")
+	require.NoError(t, p.Start(ctx))
 }
 
 // -----------------------------------------------------------------------------
-// Helpers
+// Test Utilities
 // -----------------------------------------------------------------------------
 
 func newTestPrereqs(operatorName, namespace, istioRevision string) *IstioPrerequisites {


### PR DESCRIPTION
Previously if the ServiceEntry and Destination rule for the RuleSet cache server could not be created, we would log the error but continue anyway, leaving the controller in a broken state. This patch explicitly throws an error.