### PR TITLE
feat(metrics): add reconcile-loop metrics for Engine, RuleSet, RuleSource, and RuleData

### DIFF
--- a/internal/controller/engine_controller.go
+++ b/internal/controller/engine_controller.go
@@ -66,6 +66,7 @@ import (
 type EngineReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
+	Metrics  *CorazaMetrics
 
 	client.Client
 	kubeClient                kubernetes.Interface
@@ -167,6 +168,11 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, req.NamespacedName, &engine); err != nil {
 		if apierrors.IsNotFound(err) {
 			logDebug(log, req, "Engine", "Resource not found")
+			r.Metrics.ForgetEngine(req.Namespace, req.Name)
+			var list wafv1alpha1.EngineList
+			if listErr := r.List(ctx, &list, client.InNamespace(req.Namespace)); listErr == nil {
+				r.Metrics.SetEnginesTotal(req.Namespace, len(list.Items))
+			}
 			// Best-effort cleanup: remove any orphaned NetworkPolicy that may
 			// remain if the Engine was deleted before the finalizer was added
 			// (e.g., race during upgrade or legacy Engine without finalizer).
@@ -179,6 +185,17 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		logAPIError(log, req, "Engine", err, "Failed to get", nil)
 		return ctrl.Result{}, err
 	}
+
+	defer func() {
+		if r.Metrics == nil {
+			return
+		}
+		r.Metrics.RecordEngine(&engine)
+		var list wafv1alpha1.EngineList
+		if err := r.List(ctx, &list, client.InNamespace(req.Namespace)); err == nil {
+			r.Metrics.SetEnginesTotal(req.Namespace, len(list.Items))
+		}
+	}()
 
 	// Handle deletion: clean up cross-namespace NetworkPolicy before removing
 	// the finalizer so the Engine can be garbage-collected.
@@ -256,7 +273,7 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	logInfo(log, req, "Engine", "Selecting driver and provisioning")
-	return r.selectDriver(ctx, log, req, engine)
+	return r.selectDriver(ctx, log, req, &engine)
 }
 
 // -----------------------------------------------------------------------------
@@ -283,7 +300,7 @@ func (r *EngineReconciler) handleInvalidDriverConfiguration(ctx context.Context,
 // EngineReconciler - Driver Provisioning
 // -----------------------------------------------------------------------------
 
-func (r *EngineReconciler) selectDriver(ctx context.Context, log logr.Logger, req ctrl.Request, engine wafv1alpha1.Engine) (ctrl.Result, error) {
+func (r *EngineReconciler) selectDriver(ctx context.Context, log logr.Logger, req ctrl.Request, engine *wafv1alpha1.Engine) (ctrl.Result, error) {
 	driverType := engine.Spec.Driver.Type
 	if driverType == "" {
 		driverType = defaultDriverTypeForProvider(engine.Spec.Target.Provider)
@@ -294,7 +311,7 @@ func (r *EngineReconciler) selectDriver(ctx context.Context, log logr.Logger, re
 		logDebug(log, req, "Engine", "Using WASM driver")
 		return r.provisionWasmDriver(ctx, log, req, engine)
 	default:
-		return ctrl.Result{}, r.handleInvalidDriverConfiguration(ctx, log, req, &engine)
+		return ctrl.Result{}, r.handleInvalidDriverConfiguration(ctx, log, req, engine)
 	}
 }
 

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -756,7 +758,7 @@ func TestEngineReconciler_SelectDriver_NilDriverDefaultsToWasm(t *testing.T) {
 			Name:      fetched.Name,
 			Namespace: fetched.Namespace,
 		},
-	}, fetched)
+	}, &fetched)
 	require.NoError(t, err)
 }
 
@@ -805,7 +807,7 @@ func TestEngineReconciler_NilTargetRef_MarksDegraded(t *testing.T) {
 	// Call provisionWasmDriver directly — it should detect the empty
 	// TargetRef and mark the Engine Degraded instead of creating a
 	// WasmPlugin that matches all workloads.
-	_, err := reconciler.provisionWasmDriver(ctx, ctrl.Log, engineReq, fetched)
+	_, err := reconciler.provisionWasmDriver(ctx, ctrl.Log, engineReq, &fetched)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "target is required")
 
@@ -2124,4 +2126,106 @@ func TestEngineReconciler_ReadyToTargetNotFound(t *testing.T) {
 	tokenKey := fmt.Sprintf("%s/%s/%s", engine.Namespace, engine.Name, engine.Spec.RuleSet.Name)
 	_, found := reconciler.tokenStore.Load(tokenKey)
 	assert.False(t, found, "token store entry should be removed when Engine is not accepted")
+}
+
+// -----------------------------------------------------------------------------
+// Engine reconciler — metrics integration tests
+// -----------------------------------------------------------------------------
+
+// TestEngineReconciler_MetricsRecordOnSuccess verifies that after a successful
+// reconcile the RecordEngine path fires and coraza_engine_info is emitted.
+// Because EngineReconciler uses a finalizer, two Reconcile calls are required:
+// the first adds the finalizer, the second does the actual work.
+func TestEngineReconciler_MetricsRecordOnSuccess(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	defer cleanup()
+
+	createTestGateway(t, ctx, k8sClient, "metrics-gw", testNamespace)
+
+	ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "metrics-engine-rs",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "non-existent-src"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleSet))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ruleSet) })
+
+	engine := utils.NewTestEngine(utils.EngineOptions{
+		Name:        "metrics-engine",
+		Namespace:   testNamespace,
+		GatewayName: "metrics-gw",
+		RuleSetName: "metrics-engine-rs",
+	})
+	require.NoError(t, k8sClient.Create(ctx, engine))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, engine) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &EngineReconciler{
+		Client:                    k8sClient,
+		Scheme:                    scheme,
+		Recorder:                  utils.NewTestRecorder(),
+		Metrics:                   m,
+		kubeClient:                testKubeClient,
+		ruleSetCacheServerCluster: "test-cluster",
+		defaultWasmImage:          defaults.DefaultCorazaWasmOCIReference,
+		operatorNamespace:         testNamespace,
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: engine.Name, Namespace: engine.Namespace}}
+
+	// First reconcile adds the finalizer.
+	result, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.NotZero(t, result.RequeueAfter, "first reconcile must requeue after finalizer add")
+
+	// Second reconcile performs the actual work and fires the defer RecordEngine.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// The defer in Reconcile fires RecordEngine: info gauge must be 1.
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_engine_info"),
+		"coraza_engine_info must be emitted after successful Engine reconcile")
+	// All engineConditionTypes must be emitted (Ready, Progressing, Degraded, Accepted).
+	assert.Equal(t, len(engineConditionTypes), testutil.CollectAndCount(reg, "coraza_engine_condition"),
+		"coraza_engine_condition must emit one series per engineConditionType")
+}
+
+// TestEngineReconciler_MetricsForgetOnNotFound verifies that a not-found
+// reconcile (simulating deletion) calls ForgetEngine and removes the info and
+// condition series from the registry.
+func TestEngineReconciler_MetricsForgetOnNotFound(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	defer cleanup()
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	// Pre-populate the series to simulate a previously-recorded Engine.
+	m.RecordEngine(minimalEngine(testNamespace, "engine-gone", "gw"))
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_engine_info"),
+		"pre-condition: info series must exist before reconcile")
+
+	reconciler := &EngineReconciler{
+		Client:                    k8sClient,
+		Scheme:                    scheme,
+		Recorder:                  utils.NewTestRecorder(),
+		Metrics:                   m,
+		ruleSetCacheServerCluster: "test-cluster",
+		defaultWasmImage:          defaults.DefaultCorazaWasmOCIReference,
+		operatorNamespace:         testNamespace,
+	}
+
+	// Resource does not exist — should trigger the ForgetEngine path.
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "engine-gone", Namespace: testNamespace},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_engine_info"),
+		"coraza_engine_info must be gone after not-found reconcile")
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_engine_condition"),
+		"coraza_engine_condition must be gone after not-found reconcile")
 }

--- a/internal/controller/engine_controller_wasm_driver.go
+++ b/internal/controller/engine_controller_wasm_driver.go
@@ -58,12 +58,13 @@ func wasmPluginName(engineName string) string {
 // -----------------------------------------------------------------------------
 
 // provisionWasmDriver provisions the Istio WasmPlugin resource for the Engine.
-func (r *EngineReconciler) provisionWasmDriver(ctx context.Context, log logr.Logger, req ctrl.Request, engine wafv1alpha1.Engine) (ctrl.Result, error) {
-	ws := targetLabelSelector(&engine)
+// engine is passed by pointer so that status patches are visible to the caller.
+func (r *EngineReconciler) provisionWasmDriver(ctx context.Context, log logr.Logger, req ctrl.Request, engine *wafv1alpha1.Engine) (ctrl.Result, error) {
+	ws := targetLabelSelector(engine)
 	if ws == nil {
 		err := fmt.Errorf("target is required: cannot derive workload selector")
 		logError(log, req, "Engine", err, "Invalid target configuration")
-		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "InvalidConfiguration", err.Error()); patchErr != nil {
+		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", engine, &engine.Status.Conditions, engine.Generation, "InvalidConfiguration", err.Error()); patchErr != nil {
 			return ctrl.Result{}, patchErr
 		}
 		return ctrl.Result{}, err
@@ -73,17 +74,17 @@ func (r *EngineReconciler) provisionWasmDriver(ctx context.Context, log logr.Log
 	// before the WasmPlugin starts running. This prevents a partially-provisioned
 	// state where the plugin is active without the intended cache-server network
 	// restrictions.
-	if err := r.applyNetworkPolicy(ctx, log, req, &engine); err != nil {
-		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "NetworkPolicyFailed", fmt.Sprintf("Failed to apply NetworkPolicy: %v", err)); patchErr != nil {
+	if err := r.applyNetworkPolicy(ctx, log, req, engine); err != nil {
+		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", engine, &engine.Status.Conditions, engine.Generation, "NetworkPolicyFailed", fmt.Sprintf("Failed to apply NetworkPolicy: %v", err)); patchErr != nil {
 			return ctrl.Result{}, patchErr
 		}
 		return ctrl.Result{}, err
 	}
 
 	logDebug(log, req, "Engine", "Ensuring cache client ServiceAccount")
-	saName, err := r.ensureCacheClientServiceAccount(ctx, log, req, &engine)
+	saName, err := r.ensureCacheClientServiceAccount(ctx, log, req, engine)
 	if err != nil {
-		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "ServiceAccountFailed", fmt.Sprintf("Failed to ensure cache client ServiceAccount: %v", err)); patchErr != nil {
+		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", engine, &engine.Status.Conditions, engine.Generation, "ServiceAccountFailed", fmt.Sprintf("Failed to ensure cache client ServiceAccount: %v", err)); patchErr != nil {
 			return ctrl.Result{}, patchErr
 		}
 		return ctrl.Result{}, err
@@ -94,25 +95,25 @@ func (r *EngineReconciler) provisionWasmDriver(ctx context.Context, log logr.Log
 	logDebug(log, req, "Engine", "Ensuring cache client token")
 	cacheToken, renewAt, err := r.ensureCacheToken(ctx, log, req, saName, engine.Spec.RuleSet.Name)
 	if err != nil {
-		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "TokenFailed", fmt.Sprintf("Failed to ensure cache client token: %v", err)); patchErr != nil {
+		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", engine, &engine.Status.Conditions, engine.Generation, "TokenFailed", fmt.Sprintf("Failed to ensure cache client token: %v", err)); patchErr != nil {
 			return ctrl.Result{}, patchErr
 		}
 		return ctrl.Result{}, err
 	}
 
-	wasmPlugin, err := r.applyWasmPlugin(ctx, log, req, &engine, cacheToken)
+	wasmPlugin, err := r.applyWasmPlugin(ctx, log, req, engine, cacheToken)
 	if err != nil {
-		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "ProvisioningFailed", fmt.Sprintf("Failed to create or update WasmPlugin: %v", err)); patchErr != nil {
+		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "Engine", engine, &engine.Status.Conditions, engine.Generation, "ProvisioningFailed", fmt.Sprintf("Failed to create or update WasmPlugin: %v", err)); patchErr != nil {
 			return ctrl.Result{}, patchErr
 		}
 		return ctrl.Result{}, err
 	}
 
 	logDebug(log, req, "Engine", "Updating status after successful provisioning")
-	if patchErr := patchReady(ctx, r.Status(), r.Recorder, log, req, "Engine", &engine, &engine.Status.Conditions, engine.Generation, "Configured", "WasmPlugin successfully created/updated"); patchErr != nil {
+	if patchErr := patchReady(ctx, r.Status(), r.Recorder, log, req, "Engine", engine, &engine.Status.Conditions, engine.Generation, "Configured", "WasmPlugin successfully created/updated"); patchErr != nil {
 		return ctrl.Result{}, patchErr
 	}
-	r.Recorder.Eventf(&engine, nil, "Normal", "WasmPluginCreated", "Provision", "Created WasmPlugin %s/%s", wasmPlugin.GetNamespace(), wasmPlugin.GetName())
+	r.Recorder.Eventf(engine, nil, "Normal", "WasmPluginCreated", "Provision", "Created WasmPlugin %s/%s", wasmPlugin.GetNamespace(), wasmPlugin.GetName())
 
 	// Schedule re-reconciliation at the token's renewal deadline. This is a
 	// single requeue that fires exactly when the token needs refreshing,

--- a/internal/controller/manager.go
+++ b/internal/controller/manager.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/networking-incubator/coraza-kubernetes-operator/internal/rulesets/cache"
 )
@@ -53,11 +54,17 @@ const DefaultRuleSetCacheServerPort = 18080
 
 // SetupControllers initializes all controllers
 func SetupControllers(mgr ctrl.Manager, rulesetCache *cache.RuleSetCache, envoyClusterName, istioRevision string, defaultWasmImage, operatorNamespace string, kubeClient kubernetes.Interface) error {
+	corazaMetrics, err := NewCorazaMetrics(metrics.Registry)
+	if err != nil {
+		return fmt.Errorf("register coraza metrics: %w", err)
+	}
+
 	if err := (&RuleSetReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorder("ruleset-controller"),
 		Cache:    rulesetCache,
+		Metrics:  corazaMetrics,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller RuleSet: %w", err)
 	}
@@ -65,6 +72,7 @@ func SetupControllers(mgr ctrl.Manager, rulesetCache *cache.RuleSetCache, envoyC
 	if err := (&RuleSourceReconciler{
 		Client:   mgr.GetClient(),
 		Recorder: mgr.GetEventRecorder("rulesource-controller"),
+		Metrics:  corazaMetrics,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller RuleSource: %w", err)
 	}
@@ -73,6 +81,7 @@ func SetupControllers(mgr ctrl.Manager, rulesetCache *cache.RuleSetCache, envoyC
 		Client:                    mgr.GetClient(),
 		Scheme:                    mgr.GetScheme(),
 		Recorder:                  mgr.GetEventRecorder("engine-controller"),
+		Metrics:                   corazaMetrics,
 		kubeClient:                kubeClient,
 		ruleSetCacheServerCluster: envoyClusterName,
 		istioRevision:             istioRevision,

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,354 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
+)
+
+// -----------------------------------------------------------------------------
+// Condition type lists
+// -----------------------------------------------------------------------------
+
+// Condition types tracked per resource kind. These must match the types
+// actually set by each reconciler so that ForgetXxx can clean up all series.
+var (
+	engineConditionTypes     = []string{conditionReady, conditionProgressing, conditionDegraded, conditionAccepted}
+	rulesetConditionTypes    = []string{conditionReady, conditionProgressing, conditionDegraded}
+	rulesourceConditionTypes = []string{conditionReady, conditionDegraded}
+	ruledataConditionTypes   = []string{conditionReady}
+)
+
+// -----------------------------------------------------------------------------
+// CorazaMetrics
+// -----------------------------------------------------------------------------
+
+// CorazaMetrics holds all Prometheus gauge metrics for the Coraza operator.
+// Gauges are updated during reconciliation rather than at scrape time, so
+// there are no live client.List calls on the Prometheus /metrics endpoint.
+//
+// All exported methods are nil-safe: calling them on a nil *CorazaMetrics is
+// a no-op. This lets reconcilers reference an uninitialized metrics instance
+// in tests without requiring a registry.
+type CorazaMetrics struct {
+	engineInfo      *prometheus.GaugeVec
+	engineCondition *prometheus.GaugeVec
+	engines         *prometheus.GaugeVec
+
+	rulesetInfo      *prometheus.GaugeVec
+	rulesetCondition *prometheus.GaugeVec
+	rulesets         *prometheus.GaugeVec
+	rulesetSources   *prometheus.GaugeVec
+	rulesetDataFiles *prometheus.GaugeVec
+
+	rulesourceInfo      *prometheus.GaugeVec
+	rulesourceCondition *prometheus.GaugeVec
+	rulesources         *prometheus.GaugeVec
+
+	ruledataInfo      *prometheus.GaugeVec
+	ruledataCondition *prometheus.GaugeVec
+	ruledatas         *prometheus.GaugeVec
+}
+
+// NewCorazaMetrics creates a CorazaMetrics and registers all gauges with reg.
+// Returns an error if any gauge conflicts with an already-registered metric.
+func NewCorazaMetrics(reg prometheus.Registerer) (*CorazaMetrics, error) {
+	m := &CorazaMetrics{
+		engineInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_engine_info",
+			Help: "Information about a Coraza Engine resource. Value is always 1.",
+		}, []string{"namespace", "name", "target_name", "target_type", "driver_type", "ruleset_name", "failure_policy"}),
+
+		engineCondition: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_engine_condition",
+			Help: "Current state of an Engine condition. 1=True 0=False -1=Unknown.",
+		}, []string{"namespace", "name", "condition"}),
+
+		engines: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_engines",
+			Help: "Total number of Engine resources per namespace.",
+		}, []string{"namespace"}),
+
+		rulesetInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_ruleset_info",
+			Help: "Information about a Coraza RuleSet resource. Value is always 1.",
+		}, []string{"namespace", "name"}),
+
+		rulesetCondition: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_ruleset_condition",
+			Help: "Current state of a RuleSet condition. 1=True 0=False -1=Unknown.",
+		}, []string{"namespace", "name", "condition"}),
+
+		rulesets: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_rulesets",
+			Help: "Total number of RuleSet resources per namespace.",
+		}, []string{"namespace"}),
+
+		rulesetSources: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_ruleset_sources",
+			Help: "Number of RuleSources referenced by the RuleSet.",
+		}, []string{"namespace", "name"}),
+
+		rulesetDataFiles: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_ruleset_data_files",
+			Help: "Number of RuleData resources referenced by the RuleSet.",
+		}, []string{"namespace", "name"}),
+
+		rulesourceInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_rulesource_info",
+			Help: "Information about a Coraza RuleSource resource. Value is always 1.",
+		}, []string{"namespace", "name"}),
+
+		rulesourceCondition: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_rulesource_condition",
+			Help: "Current state of a RuleSource condition. 1=True 0=False -1=Unknown.",
+		}, []string{"namespace", "name", "condition"}),
+
+		rulesources: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_rulesources",
+			Help: "Total number of RuleSource resources per namespace.",
+		}, []string{"namespace"}),
+
+		ruledataInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_ruledata_info",
+			Help: "Information about a Coraza RuleData resource. Value is always 1.",
+		}, []string{"namespace", "name"}),
+
+		ruledataCondition: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_ruledata_condition",
+			Help: "Current state of a RuleData condition. 1=True 0=False -1=Unknown.",
+		}, []string{"namespace", "name", "condition"}),
+
+		ruledatas: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "coraza_ruledatas",
+			Help: "Total number of RuleData resources per namespace.",
+		}, []string{"namespace"}),
+	}
+
+	for _, c := range []prometheus.Collector{
+		m.engineInfo, m.engineCondition, m.engines,
+		m.rulesetInfo, m.rulesetCondition, m.rulesets, m.rulesetSources, m.rulesetDataFiles,
+		m.rulesourceInfo, m.rulesourceCondition, m.rulesources,
+		m.ruledataInfo, m.ruledataCondition, m.ruledatas,
+	} {
+		if err := reg.Register(c); err != nil {
+			return nil, err
+		}
+	}
+
+	return m, nil
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+// conditionStatusToFloat converts a metav1.ConditionStatus to its numeric
+// representation: True=1, False=0, Unknown=-1.
+func conditionStatusToFloat(status metav1.ConditionStatus) float64 {
+	switch status {
+	case metav1.ConditionTrue:
+		return 1
+	case metav1.ConditionFalse:
+		return 0
+	default:
+		return -1
+	}
+}
+
+func setConditions(vec *prometheus.GaugeVec, ns, name string, conditions []metav1.Condition, types []string) {
+	for _, ct := range types {
+		val := float64(-1)
+		if cond := apimeta.FindStatusCondition(conditions, ct); cond != nil {
+			val = conditionStatusToFloat(cond.Status)
+		}
+		vec.WithLabelValues(ns, name, ct).Set(val)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Engine
+// -----------------------------------------------------------------------------
+
+// RecordEngine updates all Engine gauges for the given engine. It first
+// removes any stale info series (spec label values can change on spec updates)
+// then re-emits with current values. All condition types are always emitted;
+// absent conditions produce -1.
+func (m *CorazaMetrics) RecordEngine(e *wafv1alpha1.Engine) {
+	if m == nil {
+		return
+	}
+
+	// Delete old info series before re-emitting so spec-label changes
+	// (target, ruleset, failure_policy) do not leave stale series.
+	m.engineInfo.DeletePartialMatch(prometheus.Labels{"namespace": e.Namespace, "name": e.Name})
+
+	dt := string(e.Spec.Driver.Type)
+	if dt == "" {
+		dt = string(wafv1alpha1.DriverTypeWasm)
+	}
+	m.engineInfo.WithLabelValues(
+		e.Namespace, e.Name,
+		e.Spec.Target.Name, string(e.Spec.Target.Type),
+		dt, e.Spec.RuleSet.Name, string(e.Spec.FailurePolicy),
+	).Set(1)
+
+	var conds []metav1.Condition
+	if e.Status != nil {
+		conds = e.Status.Conditions
+	}
+	setConditions(m.engineCondition, e.Namespace, e.Name, conds, engineConditionTypes)
+}
+
+// ForgetEngine removes all gauge series for the given engine.
+func (m *CorazaMetrics) ForgetEngine(ns, name string) {
+	if m == nil {
+		return
+	}
+	m.engineInfo.DeletePartialMatch(prometheus.Labels{"namespace": ns, "name": name})
+	m.engineCondition.DeletePartialMatch(prometheus.Labels{"namespace": ns, "name": name})
+}
+
+// SetEnginesTotal sets the per-namespace Engine count gauge.
+// When count reaches zero the series is deleted entirely so that namespaces
+// with no resources do not accumulate stale zero-value series over the
+// operator's lifetime.
+func (m *CorazaMetrics) SetEnginesTotal(ns string, count int) {
+	if m == nil {
+		return
+	}
+	if count == 0 {
+		m.engines.DeleteLabelValues(ns)
+		return
+	}
+	m.engines.WithLabelValues(ns).Set(float64(count))
+}
+
+// -----------------------------------------------------------------------------
+// RuleSet
+// -----------------------------------------------------------------------------
+
+// RecordRuleSet updates all RuleSet gauges for the given ruleset.
+func (m *CorazaMetrics) RecordRuleSet(rs *wafv1alpha1.RuleSet) {
+	if m == nil {
+		return
+	}
+	m.rulesetInfo.WithLabelValues(rs.Namespace, rs.Name).Set(1)
+	m.rulesetSources.WithLabelValues(rs.Namespace, rs.Name).Set(float64(len(rs.Spec.Sources)))
+	m.rulesetDataFiles.WithLabelValues(rs.Namespace, rs.Name).Set(float64(len(rs.Spec.Data)))
+	setConditions(m.rulesetCondition, rs.Namespace, rs.Name, rs.Status.Conditions, rulesetConditionTypes)
+}
+
+// ForgetRuleSet removes all gauge series for the given ruleset.
+func (m *CorazaMetrics) ForgetRuleSet(ns, name string) {
+	if m == nil {
+		return
+	}
+	m.rulesetInfo.DeletePartialMatch(prometheus.Labels{"namespace": ns, "name": name})
+	m.rulesetCondition.DeletePartialMatch(prometheus.Labels{"namespace": ns, "name": name})
+	m.rulesetSources.DeleteLabelValues(ns, name)
+	m.rulesetDataFiles.DeleteLabelValues(ns, name)
+}
+
+// SetRuleSetsTotal sets the per-namespace RuleSet count gauge.
+// When count reaches zero the series is deleted to prevent stale accumulation.
+func (m *CorazaMetrics) SetRuleSetsTotal(ns string, count int) {
+	if m == nil {
+		return
+	}
+	if count == 0 {
+		m.rulesets.DeleteLabelValues(ns)
+		return
+	}
+	m.rulesets.WithLabelValues(ns).Set(float64(count))
+}
+
+// -----------------------------------------------------------------------------
+// RuleSource
+// -----------------------------------------------------------------------------
+
+// RecordRuleSource updates all RuleSource gauges for the given rulesource.
+func (m *CorazaMetrics) RecordRuleSource(rs *wafv1alpha1.RuleSource) {
+	if m == nil {
+		return
+	}
+	m.rulesourceInfo.WithLabelValues(rs.Namespace, rs.Name).Set(1)
+	setConditions(m.rulesourceCondition, rs.Namespace, rs.Name, rs.Status.Conditions, rulesourceConditionTypes)
+}
+
+// ForgetRuleSource removes all gauge series for the given rulesource.
+func (m *CorazaMetrics) ForgetRuleSource(ns, name string) {
+	if m == nil {
+		return
+	}
+	m.rulesourceInfo.DeletePartialMatch(prometheus.Labels{"namespace": ns, "name": name})
+	m.rulesourceCondition.DeletePartialMatch(prometheus.Labels{"namespace": ns, "name": name})
+}
+
+// SetRuleSourcesTotal sets the per-namespace RuleSource count gauge.
+// When count reaches zero the series is deleted to prevent stale accumulation.
+func (m *CorazaMetrics) SetRuleSourcesTotal(ns string, count int) {
+	if m == nil {
+		return
+	}
+	if count == 0 {
+		m.rulesources.DeleteLabelValues(ns)
+		return
+	}
+	m.rulesources.WithLabelValues(ns).Set(float64(count))
+}
+
+// -----------------------------------------------------------------------------
+// RuleData
+// -----------------------------------------------------------------------------
+
+// RecordRuleData updates all RuleData gauges for the given ruledata.
+// RuleData metrics are emitted only for objects referenced by at least one
+// RuleSet, since there is no dedicated RuleData reconciler.
+func (m *CorazaMetrics) RecordRuleData(rd *wafv1alpha1.RuleData) {
+	if m == nil {
+		return
+	}
+	m.ruledataInfo.WithLabelValues(rd.Namespace, rd.Name).Set(1)
+	setConditions(m.ruledataCondition, rd.Namespace, rd.Name, rd.Status.Conditions, ruledataConditionTypes)
+}
+
+// ForgetRuleData removes all gauge series for the given ruledata.
+func (m *CorazaMetrics) ForgetRuleData(ns, name string) {
+	if m == nil {
+		return
+	}
+	m.ruledataInfo.DeletePartialMatch(prometheus.Labels{"namespace": ns, "name": name})
+	m.ruledataCondition.DeletePartialMatch(prometheus.Labels{"namespace": ns, "name": name})
+}
+
+// SetRuleDatasTotal sets the per-namespace RuleData count gauge.
+// When count reaches zero the series is deleted to prevent stale accumulation.
+func (m *CorazaMetrics) SetRuleDatasTotal(ns string, count int) {
+	if m == nil {
+		return
+	}
+	if count == 0 {
+		m.ruledatas.DeleteLabelValues(ns)
+		return
+	}
+	m.ruledatas.WithLabelValues(ns).Set(float64(count))
+}

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -1,0 +1,658 @@
+/*
+Copyright Coraza Kubernetes Operator contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
+)
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+const (
+	labelCondition         = "condition"
+	metricRuleSetSources   = "coraza_ruleset_sources"
+	metricRuleSetDataFiles = "coraza_ruleset_data_files"
+)
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+func newTestRegistry() *prometheus.Registry {
+	return prometheus.NewPedanticRegistry()
+}
+
+func newTestMetrics(t *testing.T) (*CorazaMetrics, *prometheus.Registry) {
+	t.Helper()
+	reg := newTestRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+	return m, reg
+}
+
+// minimalEngine returns an Engine with the minimum valid fields set.
+func minimalEngine(ns, name, gatewayName string) *wafv1alpha1.Engine {
+	return &wafv1alpha1.Engine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: wafv1alpha1.EngineSpec{
+			Target: wafv1alpha1.EngineTarget{
+				Type: wafv1alpha1.EngineTargetTypeGateway,
+				Name: gatewayName,
+			},
+			RuleSet: wafv1alpha1.RuleSetReference{
+				Name: "rs",
+			},
+			FailurePolicy: wafv1alpha1.FailurePolicyFail,
+		},
+	}
+}
+
+// minimalRuleSet returns a RuleSet with the minimum valid fields set.
+func minimalRuleSet(ns, name string, sources int, data int) *wafv1alpha1.RuleSet {
+	rs := &wafv1alpha1.RuleSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: wafv1alpha1.RuleSetSpec{},
+	}
+	for i := 0; i < sources; i++ {
+		rs.Spec.Sources = append(rs.Spec.Sources, wafv1alpha1.SourceReference{Name: "src"})
+	}
+	for i := 0; i < data; i++ {
+		rs.Spec.Data = append(rs.Spec.Data, wafv1alpha1.DataReference{Name: "dat"})
+	}
+	return rs
+}
+
+// minimalRuleSource returns a RuleSource with the minimum valid fields set.
+func minimalRuleSource(ns, name string) *wafv1alpha1.RuleSource {
+	return &wafv1alpha1.RuleSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: wafv1alpha1.RuleSourceSpec{
+			Rules: "SecRule REQUEST_URI \"@streq /admin\" \"id:1,phase:1,deny\"",
+		},
+	}
+}
+
+// minimalRuleData returns a RuleData with the minimum valid fields set.
+func minimalRuleData(ns, name string) *wafv1alpha1.RuleData {
+	return &wafv1alpha1.RuleData{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: wafv1alpha1.RuleDataSpec{
+			Files: map[string]string{"words.txt": "foo\nbar\n"},
+		},
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Tests — NewCorazaMetrics
+// -----------------------------------------------------------------------------
+
+// TestNewCorazaMetricsRegistration verifies that NewCorazaMetrics succeeds on a
+// fresh registry and returns an error when called a second time (all 14
+// GaugeVecs conflict).
+func TestNewCorazaMetricsRegistration(t *testing.T) {
+	reg := newTestRegistry()
+
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+	assert.NotNil(t, m)
+
+	_, err = NewCorazaMetrics(reg)
+	require.Error(t, err, "second NewCorazaMetrics with the same registry must fail")
+}
+
+// TestNewCorazaMetricsGatherAndLint registers all 14 metrics, records one of
+// each resource type, and verifies that GatherAndLint finds no problems.
+func TestNewCorazaMetricsGatherAndLint(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.RecordEngine(minimalEngine("default", "my-engine", "gw"))
+	m.RecordRuleSet(minimalRuleSet("default", "my-rs", 1, 0))
+	m.RecordRuleSource(minimalRuleSource("default", "my-src"))
+	m.RecordRuleData(minimalRuleData("default", "my-rd"))
+	m.SetEnginesTotal("default", 1)
+	m.SetRuleSetsTotal("default", 1)
+	m.SetRuleSourcesTotal("default", 1)
+	m.SetRuleDatasTotal("default", 1)
+
+	problems, err := testutil.GatherAndLint(reg,
+		"coraza_engine_info", "coraza_engine_condition", "coraza_engines",
+		"coraza_ruleset_info", "coraza_ruleset_condition", "coraza_rulesets",
+		metricRuleSetSources, metricRuleSetDataFiles,
+		"coraza_rulesource_info", "coraza_rulesource_condition", "coraza_rulesources",
+		"coraza_ruledata_info", "coraza_ruledata_condition", "coraza_ruledatas",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, problems, "lint problems: %v", problems)
+}
+
+// -----------------------------------------------------------------------------
+// Tests — Engine
+// -----------------------------------------------------------------------------
+
+// TestCorazaMetricsRecordEngine verifies that RecordEngine emits info and
+// condition gauges with the expected label values and numeric encodings.
+func TestCorazaMetricsRecordEngine(t *testing.T) {
+	engine := &wafv1alpha1.Engine{
+		ObjectMeta: metav1.ObjectMeta{Name: "eng", Namespace: "ns"},
+		Spec: wafv1alpha1.EngineSpec{
+			Target:        wafv1alpha1.EngineTarget{Type: wafv1alpha1.EngineTargetTypeGateway, Name: "my-gw"},
+			RuleSet:       wafv1alpha1.RuleSetReference{Name: "my-rs"},
+			FailurePolicy: wafv1alpha1.FailurePolicyAllow,
+			Driver:        wafv1alpha1.DriverConfig{Type: wafv1alpha1.DriverTypeWasm},
+		},
+		Status: &wafv1alpha1.EngineStatus{
+			Conditions: []metav1.Condition{
+				{Type: conditionReady, Status: metav1.ConditionTrue, Reason: "r", LastTransitionTime: metav1.Now()},
+			},
+		},
+	}
+
+	m, reg := newTestMetrics(t)
+	m.RecordEngine(engine)
+
+	// info gauge
+	count := testutil.CollectAndCount(reg, "coraza_engine_info")
+	assert.Equal(t, 1, count)
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+
+	infoLabels := make(map[string]string)
+	condValues := make(map[string]float64)
+	for _, mf := range gathered {
+		switch mf.GetName() {
+		case "coraza_engine_info":
+			for _, lp := range mf.GetMetric()[0].GetLabel() {
+				infoLabels[lp.GetName()] = lp.GetValue()
+			}
+		case "coraza_engine_condition":
+			for _, m := range mf.GetMetric() {
+				var ct string
+				for _, lp := range m.GetLabel() {
+					if lp.GetName() == labelCondition {
+						ct = lp.GetValue()
+					}
+				}
+				condValues[ct] = m.GetGauge().GetValue()
+			}
+		}
+	}
+
+	assert.Equal(t, "my-gw", infoLabels["target_name"])
+	assert.Equal(t, "Gateway", infoLabels["target_type"])
+	assert.Equal(t, "wasm", infoLabels["driver_type"])
+	assert.Equal(t, "my-rs", infoLabels["ruleset_name"])
+	assert.Equal(t, "allow", infoLabels["failure_policy"])
+	assert.Equal(t, float64(1), condValues[conditionReady])
+	assert.Equal(t, float64(-1), condValues[conditionProgressing])
+	assert.Equal(t, float64(-1), condValues[conditionDegraded])
+	// engineConditionTypes includes conditionAccepted — must be emitted as -1 (unknown).
+	assert.Equal(t, float64(-1), condValues[conditionAccepted])
+}
+
+// TestCorazaMetricsForgetEngine verifies that ForgetEngine removes all series
+// for the named engine from the registry.
+func TestCorazaMetricsForgetEngine(t *testing.T) {
+	engine := minimalEngine("default", "eng", "gw")
+	m, reg := newTestMetrics(t)
+	m.RecordEngine(engine)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_engine_info"))
+
+	m.ForgetEngine("default", "eng")
+
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_engine_info"))
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_engine_condition"))
+}
+
+// TestCorazaMetricsEngineSpecChangeClearsStale verifies that RecordEngine with
+// new spec label values (e.g. different target) removes old info series and
+// creates a new one — no stale series remain.
+func TestCorazaMetricsEngineSpecChangeClearsStale(t *testing.T) {
+	engine := minimalEngine("default", "eng", "gw-old")
+	m, reg := newTestMetrics(t)
+	m.RecordEngine(engine)
+
+	// Simulate spec change: new target name.
+	engine.Spec.Target.Name = "gw-new"
+	m.RecordEngine(engine)
+
+	// Only one info series must exist — the old one must be gone.
+	count := testutil.CollectAndCount(reg, "coraza_engine_info")
+	assert.Equal(t, 1, count, "spec change must not leave stale info series")
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range gathered {
+		if mf.GetName() != "coraza_engine_info" {
+			continue
+		}
+		for _, lp := range mf.GetMetric()[0].GetLabel() {
+			if lp.GetName() == "target_name" {
+				assert.Equal(t, "gw-new", lp.GetValue(), "info series should have new target label")
+			}
+		}
+	}
+}
+
+// TestCorazaMetricsEngineNilStatus verifies that an Engine with nil Status
+// does not panic and emits -1.0 for all conditions.
+func TestCorazaMetricsEngineNilStatus(t *testing.T) {
+	engine := minimalEngine("default", "nil-engine", "gw")
+	assert.Nil(t, engine.Status)
+
+	m, reg := newTestMetrics(t)
+	m.RecordEngine(engine)
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range gathered {
+		if mf.GetName() != "coraza_engine_condition" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			assert.Equal(t, float64(-1), metric.GetGauge().GetValue(),
+				"nil Status should produce -1 for all conditions")
+		}
+	}
+}
+
+// TestCorazaMetricsSetEnginesTotal verifies per-namespace Engine count gauges.
+func TestCorazaMetricsSetEnginesTotal(t *testing.T) {
+	m, reg := newTestMetrics(t)
+	m.SetEnginesTotal("ns-a", 3)
+	m.SetEnginesTotal("ns-b", 1)
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+
+	totals := make(map[string]float64)
+	for _, mf := range gathered {
+		if mf.GetName() != "coraza_engines" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			var ns string
+			for _, lp := range metric.GetLabel() {
+				if lp.GetName() == "namespace" {
+					ns = lp.GetValue()
+				}
+			}
+			totals[ns] = metric.GetGauge().GetValue()
+		}
+	}
+
+	assert.Equal(t, float64(3), totals["ns-a"])
+	assert.Equal(t, float64(1), totals["ns-b"])
+}
+
+// -----------------------------------------------------------------------------
+// Tests — RuleSource
+// -----------------------------------------------------------------------------
+
+// TestCorazaMetricsRecordRuleSource verifies condition encoding for RuleSource.
+func TestCorazaMetricsRecordRuleSource(t *testing.T) {
+	rs := minimalRuleSource("default", "my-rs")
+	rs.Status = wafv1alpha1.RuleSourceStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:               conditionReady,
+				Status:             metav1.ConditionTrue,
+				Reason:             ruleSourceReadyReasonValidated,
+				LastTransitionTime: metav1.Now(),
+			},
+			{
+				Type:               conditionDegraded,
+				Status:             metav1.ConditionFalse,
+				Reason:             ruleSourceDegradedReasonInvalidRules,
+				LastTransitionTime: metav1.Now(),
+			},
+		},
+	}
+
+	m, reg := newTestMetrics(t)
+	m.RecordRuleSource(rs)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_rulesource_info"))
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+
+	condValues := make(map[string]float64)
+	for _, mf := range gathered {
+		if mf.GetName() != "coraza_rulesource_condition" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			var ct string
+			for _, lp := range metric.GetLabel() {
+				if lp.GetName() == labelCondition {
+					ct = lp.GetValue()
+				}
+			}
+			condValues[ct] = metric.GetGauge().GetValue()
+		}
+	}
+
+	assert.Equal(t, float64(1), condValues[conditionReady])
+	assert.Equal(t, float64(0), condValues[conditionDegraded])
+}
+
+// TestCorazaMetricsForgetRuleSource verifies that ForgetRuleSource removes all
+// series for the named rulesource.
+func TestCorazaMetricsForgetRuleSource(t *testing.T) {
+	rs := minimalRuleSource("ns", "src")
+	m, reg := newTestMetrics(t)
+	m.RecordRuleSource(rs)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_rulesource_info"))
+
+	m.ForgetRuleSource("ns", "src")
+
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_rulesource_info"))
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_rulesource_condition"))
+}
+
+// TestCorazaMetricsRuleSourcesTotal verifies per-namespace RuleSource counts.
+func TestCorazaMetricsRuleSourcesTotal(t *testing.T) {
+	m, reg := newTestMetrics(t)
+	m.SetRuleSourcesTotal("ns-a", 2)
+	m.SetRuleSourcesTotal("ns-b", 1)
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+
+	totals := make(map[string]float64)
+	for _, mf := range gathered {
+		if mf.GetName() != "coraza_rulesources" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			var ns string
+			for _, lp := range metric.GetLabel() {
+				if lp.GetName() == "namespace" {
+					ns = lp.GetValue()
+				}
+			}
+			totals[ns] = metric.GetGauge().GetValue()
+		}
+	}
+
+	assert.Equal(t, float64(2), totals["ns-a"])
+	assert.Equal(t, float64(1), totals["ns-b"])
+}
+
+// -----------------------------------------------------------------------------
+// Tests — RuleSet
+// -----------------------------------------------------------------------------
+
+// TestCorazaMetricsRecordRuleSet verifies source count, data count, and
+// condition gauges for a RuleSet.
+func TestCorazaMetricsRecordRuleSet(t *testing.T) {
+	rs := minimalRuleSet("default", "my-rs", 3, 2)
+	rs.Status.Conditions = []metav1.Condition{
+		{Type: conditionReady, Status: metav1.ConditionTrue, Reason: "r", LastTransitionTime: metav1.Now()},
+	}
+
+	m, reg := newTestMetrics(t)
+	m.RecordRuleSet(rs)
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+
+	metricValues := make(map[string]float64)
+	condValues := make(map[string]float64)
+	for _, mf := range gathered {
+		switch mf.GetName() {
+		case metricRuleSetSources, metricRuleSetDataFiles:
+			for _, metric := range mf.GetMetric() {
+				metricValues[mf.GetName()] = metric.GetGauge().GetValue()
+			}
+		case "coraza_ruleset_condition":
+			for _, metric := range mf.GetMetric() {
+				var ct string
+				for _, lp := range metric.GetLabel() {
+					if lp.GetName() == labelCondition {
+						ct = lp.GetValue()
+					}
+				}
+				condValues[ct] = metric.GetGauge().GetValue()
+			}
+		}
+	}
+
+	assert.Equal(t, float64(3), metricValues[metricRuleSetSources])
+	assert.Equal(t, float64(2), metricValues[metricRuleSetDataFiles])
+	assert.Equal(t, float64(1), condValues[conditionReady])
+	assert.Equal(t, float64(-1), condValues[conditionProgressing])
+}
+
+// TestCorazaMetricsRuleSetSpecChangeClearsStale verifies that when a RuleSet's
+// spec.sources or spec.data counts change, the gauges are updated to the new
+// values and no stale series remain.
+func TestCorazaMetricsRuleSetSpecChangeClearsStale(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	// Initial state: 3 sources, 2 data files.
+	rs := minimalRuleSet("default", "my-rs", 3, 2)
+	m.RecordRuleSet(rs)
+
+	gatherMetricValues := func() (sources, dataFiles float64) {
+		gathered, err := reg.Gather()
+		require.NoError(t, err)
+		for _, mf := range gathered {
+			switch mf.GetName() {
+			case metricRuleSetSources:
+				for _, metric := range mf.GetMetric() {
+					sources = metric.GetGauge().GetValue()
+				}
+			case metricRuleSetDataFiles:
+				for _, metric := range mf.GetMetric() {
+					dataFiles = metric.GetGauge().GetValue()
+				}
+			}
+		}
+		return
+	}
+
+	sources, dataFiles := gatherMetricValues()
+	assert.Equal(t, float64(3), sources, "initial sources count must be 3")
+	assert.Equal(t, float64(2), dataFiles, "initial data_files count must be 2")
+
+	// Simulate spec change: reduce to 1 source, 0 data files.
+	rs.Spec.Sources = rs.Spec.Sources[:1]
+	rs.Spec.Data = nil
+	m.RecordRuleSet(rs)
+
+	sources, dataFiles = gatherMetricValues()
+	assert.Equal(t, float64(1), sources, "after spec change sources count must be 1")
+	assert.Equal(t, float64(0), dataFiles, "after spec change data_files count must be 0")
+
+	// Only one info series must exist — no stale series from the first record.
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruleset_info"))
+}
+
+// TestCorazaMetricsForgetRuleSet verifies that ForgetRuleSet removes all
+// series for the named ruleset.
+func TestCorazaMetricsForgetRuleSet(t *testing.T) {
+	rs := minimalRuleSet("ns", "rs", 1, 0)
+	m, reg := newTestMetrics(t)
+	m.RecordRuleSet(rs)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruleset_info"))
+
+	m.ForgetRuleSet("ns", "rs")
+
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruleset_info"))
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruleset_condition"))
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, metricRuleSetSources))
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, metricRuleSetDataFiles))
+}
+
+// -----------------------------------------------------------------------------
+// Tests — RuleData
+// -----------------------------------------------------------------------------
+
+// TestCorazaMetricsRecordRuleData verifies that Ready condition is emitted for
+// a RuleData with a Ready=True status.
+func TestCorazaMetricsRecordRuleData(t *testing.T) {
+	rd := minimalRuleData("default", "my-rd")
+	rd.Status = wafv1alpha1.RuleDataStatus{
+		Conditions: []metav1.Condition{
+			{Type: conditionReady, Status: metav1.ConditionTrue, Reason: "Loaded", LastTransitionTime: metav1.Now()},
+		},
+	}
+
+	m, reg := newTestMetrics(t)
+	m.RecordRuleData(rd)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruledata_info"))
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+
+	var readyVal *float64
+	for _, mf := range gathered {
+		if mf.GetName() != "coraza_ruledata_condition" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			for _, lp := range metric.GetLabel() {
+				if lp.GetName() == labelCondition && lp.GetValue() == conditionReady {
+					v := metric.GetGauge().GetValue()
+					readyVal = &v
+				}
+			}
+		}
+	}
+
+	require.NotNil(t, readyVal, "coraza_ruledata_condition{condition=Ready} not found")
+	assert.Equal(t, float64(1), *readyVal)
+}
+
+// TestCorazaMetricsForgetRuleData verifies that ForgetRuleData removes all
+// series for the named ruledata.
+func TestCorazaMetricsForgetRuleData(t *testing.T) {
+	rd := minimalRuleData("ns", "rd")
+	m, reg := newTestMetrics(t)
+	m.RecordRuleData(rd)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruledata_info"))
+
+	m.ForgetRuleData("ns", "rd")
+
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledata_info"))
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledata_condition"))
+}
+
+// TestCorazaMetricsRuleDataDereferencedClearsStale verifies the "was referenced,
+// now removed from spec.data" scenario: after a RuleData is recorded and then
+// forgotten (simulating the reconciler detecting it is no longer in spec.data),
+// all its series must be absent from the registry.
+func TestCorazaMetricsRuleDataDereferencedClearsStale(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	rd := minimalRuleData("ns", "data-rd")
+	m.RecordRuleData(rd)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruledata_info"),
+		"series must be present after RecordRuleData")
+
+	// Simulate the RuleSet reconciler calling ForgetRuleData when the entry is
+	// no longer in spec.data.
+	m.ForgetRuleData("ns", "data-rd")
+
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledata_info"),
+		"info series must be gone after ForgetRuleData")
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledata_condition"),
+		"condition series must be gone after ForgetRuleData")
+}
+
+// TestCorazaMetricsSetTotalsDeleteSeriesOnZero verifies that SetXxxTotal removes
+// the namespace series entirely when count drops to zero rather than setting it
+// to 0 (preventing stale accumulation over the operator lifetime).
+func TestCorazaMetricsSetTotalsDeleteSeriesOnZero(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	// Set non-zero, then drop to zero: series must vanish.
+	m.SetEnginesTotal("ns-a", 2)
+	m.SetEnginesTotal("ns-a", 0)
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_engines"),
+		"coraza_engines series must be deleted when count drops to zero")
+
+	m.SetRuleSetsTotal("ns-b", 3)
+	m.SetRuleSetsTotal("ns-b", 0)
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_rulesets"),
+		"coraza_rulesets series must be deleted when count drops to zero")
+
+	m.SetRuleSourcesTotal("ns-c", 1)
+	m.SetRuleSourcesTotal("ns-c", 0)
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_rulesources"),
+		"coraza_rulesources series must be deleted when count drops to zero")
+
+	m.SetRuleDatasTotal("ns-d", 4)
+	m.SetRuleDatasTotal("ns-d", 0)
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledatas"),
+		"coraza_ruledatas series must be deleted when count drops to zero")
+}
+
+// -----------------------------------------------------------------------------
+// Tests — nil-safety
+// -----------------------------------------------------------------------------
+
+// TestCorazaMetricsNilSafe verifies that calling any method on a nil
+// *CorazaMetrics does not panic.
+func TestCorazaMetricsNilSafe(t *testing.T) {
+	var m *CorazaMetrics
+	assert.NotPanics(t, func() {
+		m.RecordEngine(minimalEngine("ns", "eng", "gw"))
+		m.ForgetEngine("ns", "eng")
+		m.SetEnginesTotal("ns", 0)
+		m.RecordRuleSet(minimalRuleSet("ns", "rs", 1, 0))
+		m.ForgetRuleSet("ns", "rs")
+		m.SetRuleSetsTotal("ns", 0)
+		m.RecordRuleSource(minimalRuleSource("ns", "src"))
+		m.ForgetRuleSource("ns", "src")
+		m.SetRuleSourcesTotal("ns", 0)
+		m.RecordRuleData(minimalRuleData("ns", "rd"))
+		m.ForgetRuleData("ns", "rd")
+		m.SetRuleDatasTotal("ns", 0)
+	})
+}

--- a/internal/controller/ruleset_controller.go
+++ b/internal/controller/ruleset_controller.go
@@ -65,6 +65,7 @@ type RuleSetReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder events.EventRecorder
 	Cache    *cache.RuleSetCache
+	Metrics  *CorazaMetrics
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -134,11 +135,21 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			} else {
 				logDebug(log, req, "RuleSet", "Resource not found, no cache entry to remove")
 			}
+			r.Metrics.ForgetRuleSet(req.Namespace, req.Name)
+			r.reconcileRuleDataMetrics(ctx, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		logAPIError(log, req, "RuleSet", err, "Failed to GET", nil)
 		return ctrl.Result{}, err
 	}
+
+	defer func() {
+		if r.Metrics == nil {
+			return
+		}
+		r.Metrics.RecordRuleSet(&ruleset)
+		r.reconcileRuleDataMetrics(ctx, req.Namespace)
+	}()
 
 	logDebug(log, req, "RuleSet", "Initializing status")
 	if err := r.initializeStatus(ctx, log, req, &ruleset); err != nil {
@@ -195,7 +206,56 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	logInfo(log, req, "RuleSet", "Caching rules")
-	return r.cacheRules(ctx, log, req, &ruleset, aggregatedRules, dataFiles, unsupportedMsg)
+	if err := r.cacheRules(ctx, log, req, &ruleset, aggregatedRules, dataFiles, unsupportedMsg); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// -----------------------------------------------------------------------------
+// RuleSetReconciler - Metrics Helpers
+// -----------------------------------------------------------------------------
+
+// reconcileRuleDataMetrics updates namespace-level RuleData metrics: the total
+// count of all RuleData objects, and cleanup of per-object series for RuleData
+// not referenced by any RuleSet. Called from both the not-found path (RuleSet
+// deleted) and the defer block (normal reconcile).
+//
+// Because there is no dedicated RuleData reconciler, these counts only refresh
+// when a RuleSet in the same namespace reconciles. Orphaned RuleData created or
+// deleted without a corresponding RuleSet change will appear stale until the
+// next RuleSet reconciliation in that namespace.
+func (r *RuleSetReconciler) reconcileRuleDataMetrics(ctx context.Context, ns string) {
+	if r.Metrics == nil {
+		return
+	}
+	var rsList wafv1alpha1.RuleSetList
+	if err := r.List(ctx, &rsList, client.InNamespace(ns)); err != nil {
+		return
+	}
+	r.Metrics.SetRuleSetsTotal(ns, len(rsList.Items))
+
+	referencedData := make(map[string]struct{})
+	for i := range rsList.Items {
+		for _, d := range rsList.Items[i].Spec.Data {
+			referencedData[d.Name] = struct{}{}
+		}
+	}
+
+	// coraza_ruledatas = raw count of ALL RuleData objects in the namespace.
+	// This intentionally differs from coraza_ruledata_info, which only covers
+	// RuleData objects referenced by at least one RuleSet. The raw total is
+	// useful for detecting unreferenced (orphaned) RuleData objects.
+	var rdList wafv1alpha1.RuleDataList
+	if err := r.List(ctx, &rdList, client.InNamespace(ns)); err != nil {
+		return
+	}
+	r.Metrics.SetRuleDatasTotal(ns, len(rdList.Items))
+	for i := range rdList.Items {
+		if _, referenced := referencedData[rdList.Items[i].Name]; !referenced {
+			r.Metrics.ForgetRuleData(ns, rdList.Items[i].Name)
+		}
+	}
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/controller/ruleset_controller_cache.go
+++ b/internal/controller/ruleset_controller_cache.go
@@ -24,15 +24,11 @@ func (r *RuleSetReconciler) cacheRules(
 	aggregatedRules string,
 	dataFiles map[string][]byte,
 	unsupportedMsg string,
-) (ctrl.Result, error) {
+) error {
 	cacheKey := fmt.Sprintf("%s/%s", ruleset.Namespace, ruleset.Name)
 	r.Cache.Put(cacheKey, aggregatedRules, dataFiles)
 	logInfo(log, req, "RuleSet", "Stored rules in cache", "cacheKey", cacheKey)
 
 	statusMsg := buildCacheReadyMessage(ruleset.Namespace, ruleset.Name, unsupportedMsg)
-	if err := patchReady(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "RulesCached", statusMsg); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	return patchReady(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "RulesCached", statusMsg)
 }

--- a/internal/controller/ruleset_controller_rule_aggregation.go
+++ b/internal/controller/ruleset_controller_rule_aggregation.go
@@ -80,6 +80,7 @@ func (r *RuleSetReconciler) loadData(
 		}, &rd); err != nil {
 			if apierrors.IsNotFound(err) {
 				logInfo(log, req, "RuleSet", "Referenced RuleData not found; waiting for it to appear", "ruleDataName", ref.Name)
+				r.Metrics.ForgetRuleData(ruleset.Namespace, ref.Name)
 				msg := fmt.Sprintf("Referenced RuleData %s does not exist", ref.Name)
 				if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "RuleDataNotFound", msg); patchErr != nil {
 					return nil, true, patchErr
@@ -100,6 +101,7 @@ func (r *RuleSetReconciler) loadData(
 				return nil, true, patchErr
 			}
 		}
+		r.Metrics.RecordRuleData(&rd)
 
 		for k, v := range rd.Spec.Files {
 			dataFiles[k] = []byte(v)

--- a/internal/controller/ruleset_controller_test.go
+++ b/internal/controller/ruleset_controller_test.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -164,14 +166,14 @@ func TestRuleSetReconciler_ReconcileRuleSources(t *testing.T) {
 			ruleSetCache := cache.NewRuleSetCache()
 
 			t.Logf("Creating %d RuleSource(s)", len(tt.ruleSources))
-			var refs []wafv1alpha1.SourceReference
-			var names []string
+			names := make([]string, 0, len(tt.ruleSources))
 			for name := range tt.ruleSources {
 				names = append(names, name)
 			}
 			sort.Strings(names)
 
 			t.Logf("Creating RuleSources: %v", names)
+			refs := make([]wafv1alpha1.SourceReference, 0, len(names))
 			for _, name := range names {
 				data := tt.ruleSources[name]
 				rs := utils.NewTestRuleSource(name, testNamespace, data)
@@ -1487,4 +1489,381 @@ func TestRuleSetReconciler_RuleDataStatusRefreshesAfterSpecUpdate(t *testing.T) 
 	assert.Equal(t, gen2, ready2.ObservedGeneration)
 	assert.Equal(t, metav1.ConditionTrue, ready2.Status)
 	assert.Equal(t, "Loaded", ready2.Reason)
+}
+
+// -----------------------------------------------------------------------------
+// RuleSet reconciler — metrics integration tests
+// -----------------------------------------------------------------------------
+
+// TestRuleSetReconciler_MetricsRecordOnSuccess verifies that after a successful
+// reconcile the RecordRuleSet path fires and coraza_ruleset_info is set to 1.
+func TestRuleSetReconciler_MetricsRecordOnSuccess(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	// Create a RuleSource that the RuleSet references.
+	src := utils.NewTestRuleSource("metrics-src", testNamespace,
+		`SecRule REQUEST_URI "@contains /m" "id:900,phase:1,pass,nolog"`)
+	require.NoError(t, k8sClient.Create(ctx, src))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, src) })
+
+	ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "metrics-rs",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "metrics-src"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleSet))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ruleSet) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    cache.NewRuleSetCache(),
+		Metrics:  m,
+	}
+
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}, reconciler)
+	require.NoError(t, err)
+
+	// The defer in Reconcile fires RecordRuleSet: info gauge must be 1.
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruleset_info"),
+		"coraza_ruleset_info must be emitted after successful RuleSet reconcile")
+}
+
+// TestRuleSetReconciler_MetricsForgetOnNotFound verifies that a not-found
+// reconcile calls ForgetRuleSet and removes all series from the registry.
+func TestRuleSetReconciler_MetricsForgetOnNotFound(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	// Pre-populate the series to simulate a previously-recorded RuleSet.
+	m.RecordRuleSet(minimalRuleSet(testNamespace, "rs-metrics-gone", 1, 0))
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruleset_info"),
+		"pre-condition: info series must exist before reconcile")
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    cache.NewRuleSetCache(),
+		Metrics:  m,
+	}
+
+	// Reconcile a resource that does not exist in the cluster.
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "rs-metrics-gone", Namespace: testNamespace},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruleset_info"),
+		"coraza_ruleset_info must be gone after not-found reconcile")
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruleset_condition"),
+		"coraza_ruleset_condition must be gone after not-found reconcile")
+}
+
+// TestRuleSetReconciler_MetricsSourceDataCountsUpdateOnSpecChange verifies that
+// coraza_ruleset_sources and coraza_ruleset_data_files update when the RuleSet
+// spec.sources or spec.data counts change between reconciles. This exercises the
+// RecordRuleSet path in the reconciler defer for spec mutations.
+func TestRuleSetReconciler_MetricsSourceDataCountsUpdateOnSpecChange(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	src := utils.NewTestRuleSource("spec-change-src", testNamespace,
+		`SecRule REQUEST_URI "@contains /x" "id:11,phase:1,pass,nolog"`)
+	require.NoError(t, k8sClient.Create(ctx, src))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, src) })
+
+	rd := utils.NewTestRuleData("spec-change-rd", testNamespace, map[string]string{"x.data": "a"})
+	require.NoError(t, k8sClient.Create(ctx, rd))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rd) })
+
+	// Initial RuleSet: 1 source, 1 data file.
+	ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "spec-change-ruleset",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "spec-change-src"}},
+		Data:      []wafv1alpha1.DataReference{{Name: "spec-change-rd"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleSet))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ruleSet) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    cache.NewRuleSetCache(),
+		Metrics:  m,
+	}
+	nn := types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}
+
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nn, reconciler)
+	require.NoError(t, err)
+
+	gatherCounts := func() (sources, dataFiles float64) {
+		gathered, gErr := reg.Gather()
+		require.NoError(t, gErr)
+		for _, mf := range gathered {
+			switch mf.GetName() {
+			case "coraza_ruleset_sources":
+				for _, metric := range mf.GetMetric() {
+					sources = metric.GetGauge().GetValue()
+				}
+			case "coraza_ruleset_data_files":
+				for _, metric := range mf.GetMetric() {
+					dataFiles = metric.GetGauge().GetValue()
+				}
+			}
+		}
+		return
+	}
+
+	sources, dataFiles := gatherCounts()
+	assert.Equal(t, float64(1), sources, "initial sources count must be 1")
+	assert.Equal(t, float64(1), dataFiles, "initial data_files count must be 1")
+
+	// Remove spec.data from the RuleSet — this requires a spec update.
+	var updated wafv1alpha1.RuleSet
+	require.NoError(t, k8sClient.Get(ctx, nn, &updated))
+	updated.Spec.Data = nil
+	require.NoError(t, k8sClient.Update(ctx, &updated))
+
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nn, reconciler)
+	require.NoError(t, err)
+
+	sources, dataFiles = gatherCounts()
+	assert.Equal(t, float64(1), sources, "sources count must remain 1 after data removal")
+	assert.Equal(t, float64(0), dataFiles, "data_files count must drop to 0 after spec.data cleared")
+}
+
+// TestRuleSetReconciler_MetricsForgetRuleDataOnSpecRemoval verifies the
+// reconciler-level "stale RuleData series cleanup" path (Finding 1): when a
+// RuleData is removed from spec.data, the reconciler's defer block calls
+// ForgetRuleData so the coraza_ruledata_info series disappears.
+func TestRuleSetReconciler_MetricsForgetRuleDataOnSpecRemoval(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	// Use a rule that references the data file only while the RuleData is in
+	// spec.data. When we remove it from spec.data we also change the rule so
+	// the RuleSet can still reconcile successfully.
+	srcWithData := utils.NewTestRuleSource("forget-rd-src-data", testNamespace,
+		`SecRule ARGS "@pmFromFile forget-rd.data" "id:33,phase:1,pass,nolog"`)
+	require.NoError(t, k8sClient.Create(ctx, srcWithData))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, srcWithData) })
+
+	srcNoData := utils.NewTestRuleSource("forget-rd-src-nodata", testNamespace,
+		`SecCollectionTimeout 1`)
+	require.NoError(t, k8sClient.Create(ctx, srcNoData))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, srcNoData) })
+
+	rd := utils.NewTestRuleData("forget-rd", testNamespace, map[string]string{"forget-rd.data": "alpha"})
+	require.NoError(t, k8sClient.Create(ctx, rd))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rd) })
+
+	// Initial: RuleSet references the RuleData and the rule that uses it.
+	ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "forget-rd-ruleset",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "forget-rd-src-data"}},
+		Data:      []wafv1alpha1.DataReference{{Name: "forget-rd"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleSet))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ruleSet) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    cache.NewRuleSetCache(),
+		Metrics:  m,
+	}
+	nn := types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}
+
+	// First reconcile: RuleData is referenced, so RecordRuleData must fire via
+	// the cache path in ruleset_controller_cache.go.
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nn, reconciler)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruledata_info"),
+		"pre-condition: coraza_ruledata_info must be set while RuleData is in spec.data")
+
+	// Swap the source to one that does not use the data file, then remove
+	// spec.data so the RuleSet can reconcile cleanly without the RuleData.
+	var updated wafv1alpha1.RuleSet
+	require.NoError(t, k8sClient.Get(ctx, nn, &updated))
+	updated.Spec.Sources = []wafv1alpha1.SourceReference{{Name: "forget-rd-src-nodata"}}
+	updated.Spec.Data = nil
+	require.NoError(t, k8sClient.Update(ctx, &updated))
+
+	// Second reconcile: the defer block must call ForgetRuleData for "forget-rd"
+	// because it is present in the namespace but absent from spec.data.
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nn, reconciler)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledata_info"),
+		"coraza_ruledata_info must be cleared when RuleData is removed from spec.data")
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledata_condition"),
+		"coraza_ruledata_condition must be cleared when RuleData is removed from spec.data")
+}
+
+// TestRuleSetReconciler_MetricsMultiRuleSetRuleDataIsolation verifies that
+// reconciling one RuleSet does NOT wipe RuleData metrics belonging to another
+// RuleSet in the same namespace. The ForgetRuleData logic must build a union
+// of spec.data across ALL RuleSets before deciding what to forget.
+func TestRuleSetReconciler_MetricsMultiRuleSetRuleDataIsolation(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	// Two distinct RuleSources with simple, valid rules.
+	srcA := utils.NewTestRuleSource("multi-src-a", testNamespace,
+		`SecRule REQUEST_URI "@contains /a" "id:50,phase:1,pass,nolog"`)
+	srcB := utils.NewTestRuleSource("multi-src-b", testNamespace,
+		`SecRule REQUEST_URI "@contains /b" "id:51,phase:1,pass,nolog"`)
+	require.NoError(t, k8sClient.Create(ctx, srcA))
+	require.NoError(t, k8sClient.Create(ctx, srcB))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, srcA) })
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, srcB) })
+
+	// Two distinct RuleData objects, each referenced by a different RuleSet.
+	rdA := utils.NewTestRuleData("multi-rd-a", testNamespace, map[string]string{"a.data": "alpha"})
+	rdB := utils.NewTestRuleData("multi-rd-b", testNamespace, map[string]string{"b.data": "beta"})
+	require.NoError(t, k8sClient.Create(ctx, rdA))
+	require.NoError(t, k8sClient.Create(ctx, rdB))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rdA) })
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rdB) })
+
+	rsA := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "multi-rs-a",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "multi-src-a"}},
+		Data:      []wafv1alpha1.DataReference{{Name: "multi-rd-a"}},
+	})
+	rsB := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "multi-rs-b",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "multi-src-b"}},
+		Data:      []wafv1alpha1.DataReference{{Name: "multi-rd-b"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, rsA))
+	require.NoError(t, k8sClient.Create(ctx, rsB))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rsA) })
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rsB) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    cache.NewRuleSetCache(),
+		Metrics:  m,
+	}
+
+	nnA := types.NamespacedName{Name: rsA.Name, Namespace: rsA.Namespace}
+	nnB := types.NamespacedName{Name: rsB.Name, Namespace: rsB.Namespace}
+
+	// Reconcile both RuleSets — both RuleData should have metrics.
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nnA, reconciler)
+	require.NoError(t, err)
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nnB, reconciler)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, testutil.CollectAndCount(reg, "coraza_ruledata_info"),
+		"both RuleData must have info series after initial reconcile")
+
+	// Re-reconcile RuleSet A — must NOT wipe RuleData B's series.
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nnA, reconciler)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, testutil.CollectAndCount(reg, "coraza_ruledata_info"),
+		"reconciling RuleSet A must not forget RuleData B's series")
+
+	// Re-reconcile RuleSet B — must NOT wipe RuleData A's series.
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nnB, reconciler)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, testutil.CollectAndCount(reg, "coraza_ruledata_info"),
+		"reconciling RuleSet B must not forget RuleData A's series")
+}
+
+// TestRuleSetReconciler_MetricsRuleSetDeletionCleansUpRuleData verifies that
+// when a RuleSet is deleted (not-found path), the orphaned RuleData metrics are
+// cleaned up via reconcileRuleDataMetrics — not left stale.
+func TestRuleSetReconciler_MetricsRuleSetDeletionCleansUpRuleData(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	src := utils.NewTestRuleSource("del-cleanup-src", testNamespace,
+		`SecRule REQUEST_URI "@contains /d" "id:60,phase:1,pass,nolog"`)
+	require.NoError(t, k8sClient.Create(ctx, src))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, src) })
+
+	rd := utils.NewTestRuleData("del-cleanup-rd", testNamespace, map[string]string{"d.data": "value"})
+	require.NoError(t, k8sClient.Create(ctx, rd))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rd) })
+
+	ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "del-cleanup-rs",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "del-cleanup-src"}},
+		Data:      []wafv1alpha1.DataReference{{Name: "del-cleanup-rd"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleSet))
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    cache.NewRuleSetCache(),
+		Metrics:  m,
+	}
+	nn := types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}
+
+	// First reconcile: both RuleSet and RuleData series should be recorded.
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nn, reconciler)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruleset_info"),
+		"pre-condition: ruleset info must exist")
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruledata_info"),
+		"pre-condition: ruledata info must exist")
+
+	// Delete the RuleSet from the cluster.
+	require.NoError(t, k8sClient.Delete(ctx, ruleSet))
+
+	// Reconcile the deleted RuleSet — not-found path should clean up both
+	// the RuleSet series and the orphaned RuleData series.
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruleset_info"),
+		"coraza_ruleset_info must be cleared after RuleSet deletion")
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledata_info"),
+		"coraza_ruledata_info must be cleared when the only referencing RuleSet is deleted")
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledata_condition"),
+		"coraza_ruledata_condition must be cleared when the only referencing RuleSet is deleted")
 }

--- a/internal/controller/rulesource_controller.go
+++ b/internal/controller/rulesource_controller.go
@@ -51,6 +51,7 @@ import (
 type RuleSourceReconciler struct {
 	client.Client
 	Recorder events.EventRecorder
+	Metrics  *CorazaMetrics
 }
 
 // SetupWithManager sets up the RuleSource controller.
@@ -77,11 +78,27 @@ func (r *RuleSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	var rs wafv1alpha1.RuleSource
 	if err := r.Get(ctx, req.NamespacedName, &rs); err != nil {
 		if apierrors.IsNotFound(err) {
+			r.Metrics.ForgetRuleSource(req.Namespace, req.Name)
+			var list wafv1alpha1.RuleSourceList
+			if listErr := r.List(ctx, &list, client.InNamespace(req.Namespace)); listErr == nil {
+				r.Metrics.SetRuleSourcesTotal(req.Namespace, len(list.Items))
+			}
 			return ctrl.Result{}, nil
 		}
 		logAPIError(log, req, "RuleSource", err, "Failed to GET", nil)
 		return ctrl.Result{}, err
 	}
+
+	defer func() {
+		if r.Metrics == nil {
+			return
+		}
+		r.Metrics.RecordRuleSource(&rs)
+		var list wafv1alpha1.RuleSourceList
+		if err := r.List(ctx, &list, client.InNamespace(req.Namespace)); err == nil {
+			r.Metrics.SetRuleSourcesTotal(req.Namespace, len(list.Items))
+		}
+	}()
 
 	skipValidation := rs.Annotations[wafv1alpha1.AnnotationSkipValidation] == "false"
 	if skipValidation {

--- a/internal/controller/rulesource_controller_test.go
+++ b/internal/controller/rulesource_controller_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -85,6 +87,65 @@ func TestRuleSourceReconciler_PatchOnlyFragment(t *testing.T) {
 
 	deg := apimeta.FindStatusCondition(rs.Status.Conditions, conditionDegraded)
 	assert.Nil(t, deg)
+}
+
+// TestRuleSourceReconciler_MetricsRecordOnSuccess verifies that after a
+// successful reconcile the RecordRuleSource path fires and coraza_rulesource_info
+// is set to 1 for the resource.
+func TestRuleSourceReconciler_MetricsRecordOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	rs := utils.NewTestRuleSource("rs-metrics-ok", testNamespace,
+		`SecRule REQUEST_URI "@contains /test" "id:10,phase:1,pass,nolog"`)
+	require.NoError(t, k8sClient.Create(ctx, rs))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rs) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	rec := &RuleSourceReconciler{
+		Client:   k8sClient,
+		Recorder: utils.NewTestRecorder(),
+		Metrics:  m,
+	}
+	_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}})
+	require.NoError(t, err)
+
+	// The defer in Reconcile fires RecordRuleSource: info gauge must be 1.
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_rulesource_info"),
+		"coraza_rulesource_info must be emitted after successful reconcile")
+}
+
+// TestRuleSourceReconciler_MetricsForgetOnNotFound verifies that reconciling a
+// deleted RuleSource calls ForgetRuleSource and the info series is cleared.
+func TestRuleSourceReconciler_MetricsForgetOnNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	// Pre-populate the series to simulate a previously-recorded RuleSource.
+	m.RecordRuleSource(minimalRuleSource(testNamespace, "rs-metrics-gone"))
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_rulesource_info"),
+		"pre-condition: info series must exist before reconcile")
+
+	rec := &RuleSourceReconciler{
+		Client:   k8sClient,
+		Recorder: utils.NewTestRecorder(),
+		Metrics:  m,
+	}
+	// Reconcile a resource that does not exist in the cluster.
+	_, err = rec.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "rs-metrics-gone", Namespace: testNamespace},
+	})
+	require.NoError(t, err)
+
+	// ForgetRuleSource must have deleted the series.
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_rulesource_info"),
+		"coraza_rulesource_info must be gone after not-found reconcile")
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_rulesource_condition"),
+		"coraza_rulesource_condition must be gone after not-found reconcile")
 }
 
 func TestRuleSourceReconciler_ValidationSkipped(t *testing.T) {


### PR DESCRIPTION
## What

Add a `CorazaMetrics` struct with 14 `GaugeVec` instances updated during reconciliation, providing per-resource metrics for Engine, RuleSet, RuleSource, and RuleData objects.

## Why

Observability into the operator's control plane is essential for alerting and dashboards. Rather than implementing a `prometheus.Collector` that calls `client.List()` on every Prometheus scrape (adding API load proportional to scrape frequency), metrics are updated as a side effect of reconciliation — where the state is already known. This means metrics reflect the latest reconciled state immediately (zero lag for conditions patched during reconcile) and add no load to the `/metrics` endpoint.

## Changes

### Core metrics library (`metrics.go`)
- `CorazaMetrics` struct with 14 `*prometheus.GaugeVec` fields: info, condition, and total gauges per resource type, plus `coraza_ruleset_sources` and `coraza_ruleset_data_files`
- `NewCorazaMetrics(reg)` registers all gauges; `RecordXxx` / `ForgetXxx` / `SetXxxTotal` methods per resource
- All methods are nil-safe (no-op on nil receiver) so reconcilers work without metrics in tests
- `DeletePartialMatch` clears stale info series when spec labels change (e.g. Engine target rename)
- `SetXxxTotal(ns, 0)` deletes the series entirely to prevent zero-value accumulation
- Condition encoding: `True=1, False=0, absent=-1`

### Reconciler integration
- All three reconcilers gain a `Metrics *CorazaMetrics` field, wired in `manager.go`
- **IsNotFound path**: calls `ForgetXxx` + `SetXxxTotal` to clean up deleted resources
- **Deferred `RecordXxx`**: runs on every reconcile exit to capture the final state including any status patches
- **Engine**: `selectDriver` / `provisionWasmDriver` changed from value to pointer receiver (`*Engine`) so status patches inside are immediately visible to the deferred `RecordEngine`
- **RuleData** (no dedicated reconciler): `RecordRuleData` hooked into `loadData()` in `RuleSetReconciler`; `reconcileRuleDataMetrics` helper builds a union of `spec.data` across all RuleSets before forgetting unreferenced series, called from both the not-found and defer paths

### Tests
- 18 unit tests for `CorazaMetrics` API: record/forget/spec-change/nil-status/nil-safety/registration/GatherAndLint/totals
- Reconciler integration tests: metrics emitted on successful reconcile, cleared on not-found, source/data counts update on spec change, stale RuleData cleanup on spec removal, multi-RuleSet isolation (no ping-pong), RuleSet deletion cleans up orphaned RuleData series

🤖 Generated with [Claude Code](https://claude.com/claude-code)