### PR TITLE
feat(metrics): add validation instrumentation, cache auth counter, and alerts

### DIFF
--- a/charts/coraza-kubernetes-operator/templates/prometheusrule.yaml
+++ b/charts/coraza-kubernetes-operator/templates/prometheusrule.yaml
@@ -95,6 +95,72 @@ spec:
             summary: "Coraza operator workqueue depth is high"
             description: 'Workqueue {{ "{{" }} $labels.name {{ "}}" }} has {{ "{{" }} $value {{ "}}" }} items pending — reconciliation may be lagging.'
 
+        # RuleSource validation failure rate above 20% over 5m (per namespace).
+        # Requires sustained validation traffic to avoid firing on a single failure.
+        - alert: CorazaRuleSourceValidationFailureRate
+          expr: >-
+            (sum by (namespace) (rate(coraza_rulesource_validations_total{outcome="invalid"}[5m]))
+            /
+            sum by (namespace) (rate(coraza_rulesource_validations_total[5m])))
+            > 0.2
+            and
+            sum by (namespace) (rate(coraza_rulesource_validations_total[5m])) > 0.01
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RuleSource validation failure rate is high"
+            description: 'Namespace {{ "{{" }} $labels.namespace {{ "}}" }} has {{ "{{" }} $value | humanizePercentage {{ "}}" }} RuleSource validation failure rate over the last 5 minutes.'
+
+        # RuleSet aggregate validation failure rate above 20% over 5m (per namespace).
+        - alert: CorazaRuleSetValidationFailureRate
+          expr: >-
+            (sum by (namespace) (rate(coraza_ruleset_validations_total{outcome="invalid"}[5m]))
+            /
+            sum by (namespace) (rate(coraza_ruleset_validations_total[5m])))
+            > 0.2
+            and
+            sum by (namespace) (rate(coraza_ruleset_validations_total[5m])) > 0.01
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RuleSet validation failure rate is high"
+            description: 'Namespace {{ "{{" }} $labels.namespace {{ "}}" }} has {{ "{{" }} $value | humanizePercentage {{ "}}" }} RuleSet aggregate validation failure rate over the last 5 minutes.'
+
+        # Cache hit ratio below 50% with active traffic
+        - alert: CorazaCacheHitRateLow
+          expr: >-
+            (coraza:cache_hit_ratio:rate5m < 0.5)
+            and
+            (sum(rate(coraza_cache_server_requests_total{code=~"200|404"}[5m])) > 0)
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cache hit ratio is low"
+            description: 'Cache hit ratio is {{ "{{" }} $value | humanizePercentage {{ "}}" }} — most cache requests are returning 404 (cache miss).'
+
+        # Sustained authentication failures on the cache HTTP server
+        - alert: CorazaCacheServerAuthFailures
+          expr: rate(coraza_cache_server_auth_failures_total[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cache server authentication failures detected"
+            description: 'The RuleSet cache server is rejecting authenticated requests — verify ServiceAccount tokens and RBAC for WASM plugin polling.'
+
+        # RuleSources in Degraded state
+        - alert: CorazaRuleSourcesDegraded
+          expr: coraza:rulesources_degraded:count > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "One or more RuleSources are degraded"
+            description: '{{ "{{" }} $value {{ "}}" }} RuleSource(s) have been in Degraded state for more than 5 minutes.'
+
         {{- with .Values.metrics.prometheusRule.rules }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -117,4 +183,16 @@ spec:
 
         - record: coraza:rulesets_not_ready:count
           expr: count(coraza_ruleset_condition{condition="Ready"} != 1) or vector(0)
+
+        - record: coraza:rulesources_degraded:count
+          expr: count(coraza_rulesource_condition{condition="Degraded"} == 1) or vector(0)
+
+        # Produces NaN when there is no cache traffic (0/0). This is correct:
+        # the dependent CorazaCacheHitRateLow alert has a traffic-presence
+        # guard (sum(rate(...)) > 0) so it never fires on NaN/idle.
+        - record: coraza:cache_hit_ratio:rate5m
+          expr: >-
+            sum(rate(coraza_cache_server_requests_total{code="200"}[5m]))
+            /
+            sum(rate(coraza_cache_server_requests_total{code=~"200|404"}[5m]))
 {{- end }}

--- a/docs/content/howto/monitoring-prometheus.md
+++ b/docs/content/howto/monitoring-prometheus.md
@@ -85,15 +85,37 @@ By default, the operator generates a self-signed certificate for the metrics end
 
 ## Available Metrics
 
-The operator exposes RED (Rate, Errors, Duration) metrics for the RuleSet cache server:
+### RuleSet cache server (RED)
 
 | Metric | Type | Description |
 |--------|------|-------------|
 | `coraza_cache_server_requests_total` | Counter | Total number of requests. Labels: `handler`, `method`, `code`. |
 | `coraza_cache_server_request_duration_seconds` | Histogram | Request duration in seconds. Labels: `handler`, `method`, `code`. |
 | `coraza_cache_server_in_flight_requests` | Gauge | Number of in-flight requests. Labels: `handler`. |
+| `coraza_cache_server_auth_failures_total` | Counter | Authentication failures on the cache HTTP server (invalid or missing bearer token). |
 
 The `handler` label has two values:
 
 - `rules` -- requests for the full compiled ruleset
 - `latest` -- requests for the latest ruleset metadata
+
+### Rule validation
+
+Counters and histograms are emitted during Coraza validation in the RuleSource and RuleSet reconcilers. The `outcome` label is `valid`, `invalid`, or (RuleSource only) `skipped`. A `valid` outcome means Coraza parsing succeeded — it does not imply the resource is Ready.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `coraza_rulesource_validations_total` | Counter | RuleSource validation outcomes. Labels: `namespace`, `outcome`. |
+| `coraza_rulesource_validation_duration_seconds` | Histogram | RuleSource validation latency. Labels: `namespace`, `outcome` (`valid` or `invalid` only). |
+| `coraza_ruleset_validations_total` | Counter | RuleSet aggregate validation outcomes. Labels: `namespace`, `outcome`. |
+| `coraza_ruleset_validation_duration_seconds` | Histogram | RuleSet aggregate validation latency. Labels: `namespace`, `outcome`. |
+
+### Cache storage
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `coraza_cache_set_duration_seconds` | Histogram | Time to store a compiled RuleSet in the in-memory cache. Labels: `namespace`. |
+
+For controller resource gauges, condition metrics, and cardinality guidance, see [Metrics cardinality reference]({{< relref "../reference/metrics-cardinality" >}}).
+
+When the Helm chart's `metrics.prometheusRule.enabled` value is true, bundled alerts cover validation failure rates, cache hit ratio, and authentication failures on the cache server.

--- a/docs/content/reference/metrics-cardinality.md
+++ b/docs/content/reference/metrics-cardinality.md
@@ -27,6 +27,7 @@ for counters by Prometheus convention).
 | `coraza_cache_config_max_size_bytes` | gauge | (none) | 1 | |
 | `coraza_cache_gc_pruned_entries_total` | counter | `reason` | 2 | `reason` ∈ {`age`, `size`} |
 | `coraza_cache_gc_size_limit_exceeded_total` | counter | (none) | 1 | |
+| `coraza_cache_server_auth_failures_total` | counter | (none) | 1 | Authentication failures on cache server |
 
 ### Controller Observability (PR #397 — `internal/controller/metrics.go`)
 
@@ -48,6 +49,11 @@ for counters by Prometheus convention).
 | `coraza_ruledata_info` | gauge=1 | `namespace`, `name` | 1 per referenced RuleData | Only RuleDatas referenced by a RuleSet |
 | `coraza_ruledata_condition` | gauge | `namespace`, `name`, `condition` | 1 per referenced RuleData (Ready) | |
 | `coraza_ruledatas` | gauge | `namespace` | 1 per namespace | Refreshed on RuleSet reconciliation |
+| `coraza_rulesource_validations_total` | counter | `namespace`, `outcome` | 3 per namespace (valid/invalid/skipped) | `skipped` = annotation bypass or patch-only fragment |
+| `coraza_ruleset_validations_total` | counter | `namespace`, `outcome` | 2 per namespace (valid/invalid) | `valid` = Coraza parse succeeded, not necessarily Ready |
+| `coraza_rulesource_validation_duration_seconds` | histogram | `namespace`, `outcome` | 2 × 13 per namespace (valid/invalid) | `skipped` increments the counter only; 11 buckets + sum + count |
+| `coraza_ruleset_validation_duration_seconds` | histogram | `namespace`, `outcome` | 2 × 13 per namespace | 11 buckets + sum + count |
+| `coraza_cache_set_duration_seconds` | histogram | `namespace` | 1 × 10 per namespace | 8 buckets + sum + count |
 
 ### Controller-Runtime Built-ins (not `coraza_` prefixed)
 
@@ -75,9 +81,11 @@ for the full list.
 200 RuleSources in 5 namespaces: 5 namespace aggregates            =    5 series
 50 referenced RuleData × (1 info + 1 condition)                    =  100 RuleData series
 50 RuleData in 5 namespaces: 5 namespace aggregates                =    5 series
-Cache server: ~98 series
+Validation counters: 5 ns × (3 rulesource + 2 ruleset outcomes)    =   25 series
+Validation histograms: 5 ns × (2×13 rulesource + 2×13 ruleset + 10 cache) =  310 series
+Cache server: ~99 series (incl. auth failures counter)
                                                                    ─────────────────
-Total coraza_* operator series:                                   ~1368
+Total coraza_* operator series:                                   ~1704
 ```
 
 Well within the 5,000 series budget.

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,6 +68,12 @@ type CorazaMetrics struct {
 	ruledataInfo      *prometheus.GaugeVec
 	ruledataCondition *prometheus.GaugeVec
 	ruledatas         *prometheus.GaugeVec
+
+	rulesourceValidations        *prometheus.CounterVec
+	rulesetValidations           *prometheus.CounterVec
+	rulesourceValidationDuration *prometheus.HistogramVec
+	rulesetValidationDuration    *prometheus.HistogramVec
+	cacheSetDuration             *prometheus.HistogramVec
 }
 
 // NewCorazaMetrics creates a CorazaMetrics and registers all gauges with reg.
@@ -141,6 +149,34 @@ func NewCorazaMetrics(reg prometheus.Registerer) (*CorazaMetrics, error) {
 			Name: "coraza_ruledatas",
 			Help: "Total number of RuleData resources per namespace.",
 		}, []string{"namespace"}),
+
+		rulesourceValidations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "coraza_rulesource_validations_total",
+			Help: "Total RuleSource validation attempts per reconcile by outcome (valid=Coraza parse succeeded, invalid=parse failed, skipped=annotation or patch-only fragment).",
+		}, []string{"namespace", "outcome"}),
+
+		rulesetValidations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "coraza_ruleset_validations_total",
+			Help: "Total RuleSet aggregate validation attempts per reconcile by outcome (valid=Coraza parse succeeded, invalid=parse failed; does not imply Ready — unsupported rules are checked afterward).",
+		}, []string{"namespace", "outcome"}),
+
+		rulesourceValidationDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "coraza_rulesource_validation_duration_seconds",
+			Help:    "Duration of RuleSource Coraza validation by outcome (skipped outcomes are not recorded).",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5},
+		}, []string{"namespace", "outcome"}),
+
+		rulesetValidationDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "coraza_ruleset_validation_duration_seconds",
+			Help:    "Duration of RuleSet aggregate Coraza validation by outcome.",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5},
+		}, []string{"namespace", "outcome"}),
+
+		cacheSetDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "coraza_cache_set_duration_seconds",
+			Help:    "Duration of cache Put operations for validated RuleSets.",
+			Buckets: []float64{.0001, .0005, .001, .005, .01, .025, .05, .1},
+		}, []string{"namespace"}),
 	}
 
 	for _, c := range []prometheus.Collector{
@@ -148,6 +184,8 @@ func NewCorazaMetrics(reg prometheus.Registerer) (*CorazaMetrics, error) {
 		m.rulesetInfo, m.rulesetCondition, m.rulesets, m.rulesetSources, m.rulesetDataFiles,
 		m.rulesourceInfo, m.rulesourceCondition, m.rulesources,
 		m.ruledataInfo, m.ruledataCondition, m.ruledatas,
+		m.rulesourceValidations, m.rulesetValidations,
+		m.rulesourceValidationDuration, m.rulesetValidationDuration, m.cacheSetDuration,
 	} {
 		if err := reg.Register(c); err != nil {
 			return nil, err
@@ -351,4 +389,50 @@ func (m *CorazaMetrics) SetRuleDatasTotal(ns string, count int) {
 		return
 	}
 	m.ruledatas.WithLabelValues(ns).Set(float64(count))
+}
+
+// -----------------------------------------------------------------------------
+// Validation counters and duration histograms
+// -----------------------------------------------------------------------------
+
+// IncRuleSourceValidation increments the RuleSource validation counter.
+// Outcome must be one of "valid", "invalid", or "skipped" (annotation bypass or patch-only fragment).
+func (m *CorazaMetrics) IncRuleSourceValidation(ns, outcome string) {
+	if m == nil {
+		return
+	}
+	m.rulesourceValidations.WithLabelValues(ns, outcome).Inc()
+}
+
+// IncRuleSetValidation increments the RuleSet validation counter.
+// Outcome must be one of "valid" (Coraza parse succeeded) or "invalid".
+func (m *CorazaMetrics) IncRuleSetValidation(ns, outcome string) {
+	if m == nil {
+		return
+	}
+	m.rulesetValidations.WithLabelValues(ns, outcome).Inc()
+}
+
+// ObserveRuleSourceValidation records a RuleSource validation duration.
+func (m *CorazaMetrics) ObserveRuleSourceValidation(ns, outcome string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.rulesourceValidationDuration.WithLabelValues(ns, outcome).Observe(d.Seconds())
+}
+
+// ObserveRuleSetValidation records a RuleSet aggregate validation duration.
+func (m *CorazaMetrics) ObserveRuleSetValidation(ns, outcome string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.rulesetValidationDuration.WithLabelValues(ns, outcome).Observe(d.Seconds())
+}
+
+// ObserveCacheSet records a cache Put duration.
+func (m *CorazaMetrics) ObserveCacheSet(ns string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.cacheSetDuration.WithLabelValues(ns).Observe(d.Seconds())
 }

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -654,5 +655,82 @@ func TestCorazaMetricsNilSafe(t *testing.T) {
 		m.RecordRuleData(minimalRuleData("ns", "rd"))
 		m.ForgetRuleData("ns", "rd")
 		m.SetRuleDatasTotal("ns", 0)
+		m.IncRuleSourceValidation("ns", "valid")
+		m.IncRuleSetValidation("ns", "invalid")
+		m.ObserveRuleSourceValidation("ns", "valid", time.Millisecond)
+		m.ObserveRuleSetValidation("ns", "invalid", 2*time.Millisecond)
+		m.ObserveCacheSet("ns", time.Microsecond)
 	})
+}
+
+// TestCorazaMetricsValidationMetrics verifies validation counters and histograms.
+func TestCorazaMetricsValidationMetrics(t *testing.T) {
+	m, reg := newTestMetrics(t)
+
+	m.IncRuleSourceValidation("default", "valid")
+	m.IncRuleSourceValidation("default", "invalid")
+	m.IncRuleSourceValidation("default", "skipped")
+	m.IncRuleSetValidation("default", "valid")
+	m.IncRuleSetValidation("default", "invalid")
+	m.ObserveRuleSourceValidation("default", "valid", 10*time.Millisecond)
+	m.ObserveRuleSetValidation("default", "valid", 20*time.Millisecond)
+	m.ObserveCacheSet("default", 5*time.Millisecond)
+
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+
+	counterValues := make(map[string]float64)
+	for _, mf := range gathered {
+		if mf.GetName() != "coraza_rulesource_validations_total" && mf.GetName() != "coraza_ruleset_validations_total" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			var outcome string
+			for _, lp := range metric.GetLabel() {
+				if lp.GetName() == "outcome" {
+					outcome = lp.GetValue()
+				}
+			}
+			counterValues[mf.GetName()+"/"+outcome] = metric.GetCounter().GetValue()
+		}
+	}
+
+	assert.Equal(t, float64(1), counterValues["coraza_rulesource_validations_total/valid"])
+	assert.Equal(t, float64(1), counterValues["coraza_rulesource_validations_total/invalid"])
+	assert.Equal(t, float64(1), counterValues["coraza_rulesource_validations_total/skipped"])
+	assert.Equal(t, float64(1), counterValues["coraza_ruleset_validations_total/valid"])
+	assert.Equal(t, float64(1), counterValues["coraza_ruleset_validations_total/invalid"])
+
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_rulesource_validation_duration_seconds"))
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_ruleset_validation_duration_seconds"))
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_cache_set_duration_seconds"))
+}
+
+func gatherValidationCounter(t *testing.T, reg *prometheus.Registry, outcome string) float64 {
+	return gatherCounterOutcome(t, reg, "coraza_rulesource_validations_total", outcome)
+}
+
+func gatherRuleSetValidationCounter(t *testing.T, reg *prometheus.Registry, outcome string) float64 {
+	return gatherCounterOutcome(t, reg, "coraza_ruleset_validations_total", outcome)
+}
+
+func gatherCounterOutcome(t *testing.T, reg *prometheus.Registry, metricName, outcome string) float64 {
+	t.Helper()
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range gathered {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			labels := make(map[string]string)
+			for _, lp := range metric.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["outcome"] == outcome {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
 }

--- a/internal/controller/ruleset_controller.go
+++ b/internal/controller/ruleset_controller.go
@@ -180,7 +180,11 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	logInfo(log, req, "RuleSet", "Validating aggregated rules")
+	validationStart := time.Now()
 	if err := validation.ValidatePMFromFileData(aggregatedRules, dataFiles); err != nil {
+		vd := time.Since(validationStart)
+		r.Metrics.IncRuleSetValidation(req.Namespace, "invalid")
+		r.Metrics.ObserveRuleSetValidation(req.Namespace, "invalid", vd)
 		msg := fmt.Sprintf("Ruleset is invalid\n%v", err)
 		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", &ruleset, &ruleset.Status.Conditions, ruleset.Generation, "InvalidRuleSet", msg); patchErr != nil {
 			return ctrl.Result{}, patchErr
@@ -193,8 +197,14 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		conf = conf.WithRootFS(fsRules)
 	}
 	if err := r.validateAggregatedRules(ctx, log, req, &ruleset, conf); err != nil {
+		vd := time.Since(validationStart)
+		r.Metrics.IncRuleSetValidation(req.Namespace, "invalid")
+		r.Metrics.ObserveRuleSetValidation(req.Namespace, "invalid", vd)
 		return ctrl.Result{}, err
 	}
+	vd := time.Since(validationStart)
+	r.Metrics.IncRuleSetValidation(req.Namespace, "valid")
+	r.Metrics.ObserveRuleSetValidation(req.Namespace, "valid", vd)
 
 	logDebug(log, req, "RuleSet", "Checking for unsupported rules")
 	foundUnsupportedRules, unsupportedMsg, err := r.rejectUnsupportedRules(ctx, log, req, &ruleset, aggregatedRules)

--- a/internal/controller/ruleset_controller_cache.go
+++ b/internal/controller/ruleset_controller_cache.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -26,7 +27,9 @@ func (r *RuleSetReconciler) cacheRules(
 	unsupportedMsg string,
 ) error {
 	cacheKey := fmt.Sprintf("%s/%s", ruleset.Namespace, ruleset.Name)
+	cacheStart := time.Now()
 	r.Cache.Put(cacheKey, aggregatedRules, dataFiles)
+	r.Metrics.ObserveCacheSet(ruleset.Namespace, time.Since(cacheStart))
 	logInfo(log, req, "RuleSet", "Stored rules in cache", "cacheKey", cacheKey)
 
 	statusMsg := buildCacheReadyMessage(ruleset.Namespace, ruleset.Name, unsupportedMsg)

--- a/internal/controller/ruleset_controller_test.go
+++ b/internal/controller/ruleset_controller_test.go
@@ -1535,6 +1535,49 @@ func TestRuleSetReconciler_MetricsRecordOnSuccess(t *testing.T) {
 		"coraza_ruleset_info must be emitted after successful RuleSet reconcile")
 }
 
+// TestRuleSetReconciler_MetricsValidationInvalid verifies that aggregate
+// validation failure increments coraza_ruleset_validations_total{outcome="invalid"}.
+func TestRuleSetReconciler_MetricsValidationInvalid(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	src := utils.NewTestRuleSource("metrics-invalid-src", testNamespace,
+		`SecRule REQUEST_URI "@pmFromFile rule1.data" "id:55555,phase:1,deny,status:403,msg:'File Match'"`)
+	require.NoError(t, k8sClient.Create(ctx, src))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, src) })
+
+	ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "metrics-invalid-rs",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "metrics-invalid-src"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleSet))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ruleSet) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    cache.NewRuleSetCache(),
+		Metrics:  m,
+	}
+
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}, reconciler)
+	require.NoError(t, err)
+
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}, ruleSet))
+	ready := apimeta.FindStatusCondition(ruleSet.Status.Conditions, "Ready")
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, "InvalidRuleSet", ready.Reason)
+	assert.Equal(t, float64(1), gatherRuleSetValidationCounter(t, reg, "invalid"))
+	assert.Equal(t, float64(0), gatherRuleSetValidationCounter(t, reg, "valid"))
+}
+
 // TestRuleSetReconciler_MetricsForgetOnNotFound verifies that a not-found
 // reconcile calls ForgetRuleSet and removes all series from the registry.
 func TestRuleSetReconciler_MetricsForgetOnNotFound(t *testing.T) {

--- a/internal/controller/rulesource_controller.go
+++ b/internal/controller/rulesource_controller.go
@@ -102,6 +102,7 @@ func (r *RuleSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	skipValidation := rs.Annotations[wafv1alpha1.AnnotationSkipValidation] == "false"
 	if skipValidation {
+		r.Metrics.IncRuleSourceValidation(req.Namespace, "skipped")
 		if isConditionCurrent(rs.Status.Conditions, conditionReady, ruleSourceReadyReasonValidationSkipped, rs.Generation) {
 			return ctrl.Result{}, nil
 		}
@@ -111,13 +112,24 @@ func (r *RuleSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	if err := validation.ValidateRuleSourceRules(rs.Spec.Rules, rs.Name, nil); err != nil {
-		if !isConditionCurrent(rs.Status.Conditions, conditionDegraded, ruleSourceDegradedReasonInvalidRules, rs.Generation) {
-			if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSource", &rs, &rs.Status.Conditions, rs.Generation, ruleSourceDegradedReasonInvalidRules, err.Error()); patchErr != nil {
-				return ctrl.Result{}, patchErr
+	if validation.IsPatchOnlyFragment(rs.Spec.Rules) {
+		r.Metrics.IncRuleSourceValidation(req.Namespace, "skipped")
+	} else {
+		validationStart := time.Now()
+		if err := validation.ValidateRuleSourceRules(rs.Spec.Rules, rs.Name, nil); err != nil {
+			d := time.Since(validationStart)
+			r.Metrics.IncRuleSourceValidation(req.Namespace, "invalid")
+			r.Metrics.ObserveRuleSourceValidation(req.Namespace, "invalid", d)
+			if !isConditionCurrent(rs.Status.Conditions, conditionDegraded, ruleSourceDegradedReasonInvalidRules, rs.Generation) {
+				if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSource", &rs, &rs.Status.Conditions, rs.Generation, ruleSourceDegradedReasonInvalidRules, err.Error()); patchErr != nil {
+					return ctrl.Result{}, patchErr
+				}
 			}
+			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, nil
+		d := time.Since(validationStart)
+		r.Metrics.IncRuleSourceValidation(req.Namespace, "valid")
+		r.Metrics.ObserveRuleSourceValidation(req.Namespace, "valid", d)
 	}
 
 	if isConditionCurrent(rs.Status.Conditions, conditionReady, ruleSourceReadyReasonValidated, rs.Generation) {

--- a/internal/controller/rulesource_controller_test.go
+++ b/internal/controller/rulesource_controller_test.go
@@ -57,8 +57,12 @@ func TestRuleSourceReconciler_InvalidRules(t *testing.T) {
 	require.NoError(t, k8sClient.Create(ctx, rs))
 	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rs) })
 
-	rec := &RuleSourceReconciler{Client: k8sClient, Recorder: utils.NewTestRecorder()}
-	_, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}})
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	rec := &RuleSourceReconciler{Client: k8sClient, Recorder: utils.NewTestRecorder(), Metrics: m}
+	_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}})
 	require.NoError(t, err)
 
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}, rs))
@@ -66,6 +70,7 @@ func TestRuleSourceReconciler_InvalidRules(t *testing.T) {
 	require.NotNil(t, deg)
 	assert.Equal(t, metav1.ConditionTrue, deg.Status)
 	assert.Equal(t, ruleSourceDegradedReasonInvalidRules, deg.Reason)
+	assert.Equal(t, float64(1), gatherValidationCounter(t, reg, "invalid"))
 }
 
 func TestRuleSourceReconciler_PatchOnlyFragment(t *testing.T) {
@@ -75,8 +80,12 @@ func TestRuleSourceReconciler_PatchOnlyFragment(t *testing.T) {
 	require.NoError(t, k8sClient.Create(ctx, rs))
 	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rs) })
 
-	rec := &RuleSourceReconciler{Client: k8sClient, Recorder: utils.NewTestRecorder()}
-	_, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}})
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	rec := &RuleSourceReconciler{Client: k8sClient, Recorder: utils.NewTestRecorder(), Metrics: m}
+	_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}})
 	require.NoError(t, err)
 
 	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}, rs))
@@ -87,6 +96,8 @@ func TestRuleSourceReconciler_PatchOnlyFragment(t *testing.T) {
 
 	deg := apimeta.FindStatusCondition(rs.Status.Conditions, conditionDegraded)
 	assert.Nil(t, deg)
+	assert.Equal(t, float64(1), gatherValidationCounter(t, reg, "skipped"))
+	assert.Equal(t, float64(0), gatherValidationCounter(t, reg, "valid"))
 }
 
 // TestRuleSourceReconciler_MetricsRecordOnSuccess verifies that after a
@@ -114,6 +125,7 @@ func TestRuleSourceReconciler_MetricsRecordOnSuccess(t *testing.T) {
 	// The defer in Reconcile fires RecordRuleSource: info gauge must be 1.
 	assert.Equal(t, 1, testutil.CollectAndCount(reg, "coraza_rulesource_info"),
 		"coraza_rulesource_info must be emitted after successful reconcile")
+	assert.Equal(t, float64(1), gatherValidationCounter(t, reg, "valid"))
 }
 
 // TestRuleSourceReconciler_MetricsForgetOnNotFound verifies that reconciling a

--- a/internal/rulesets/cache/auth_test.go
+++ b/internal/rulesets/cache/auth_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -352,11 +353,13 @@ func TestServer_HandleRules_Authentication(t *testing.T) {
 	})
 
 	t.Run("invalid bearer token", func(t *testing.T) {
+		before := testutil.ToFloat64(authFailuresTotal)
 		req := httptest.NewRequest(http.MethodGet, "/rules/test-ns/my-ruleset", nil)
 		req.Header.Set("Authorization", "Bearer invalid-token")
 		w := httptest.NewRecorder()
 		server.handleRules(w, req)
 		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Equal(t, before+1, testutil.ToFloat64(authFailuresTotal))
 	})
 
 	t.Run("valid token for correct ruleset", func(t *testing.T) {

--- a/internal/rulesets/cache/metrics.go
+++ b/internal/rulesets/cache/metrics.go
@@ -51,10 +51,17 @@ var (
 		},
 		[]string{"handler"},
 	)
+
+	authFailuresTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "coraza_cache_server_auth_failures_total",
+			Help: "Total number of authentication failures on the cache server.",
+		},
+	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(requestsTotal, requestDuration, inFlightRequests)
+	metrics.Registry.MustRegister(requestsTotal, requestDuration, inFlightRequests, authFailuresTotal)
 }
 
 // instrumentHandler wraps an http.Handler to record RED metrics.

--- a/internal/rulesets/cache/server.go
+++ b/internal/rulesets/cache/server.go
@@ -185,6 +185,7 @@ func (s *ruleSetCacheServer) handleRules(w http.ResponseWriter, r *http.Request)
 	// Authenticate: the token audience must match the requested RuleSet, and
 	// the SA namespace must match the cache key namespace.
 	if err := s.authenticateRequest(r, cacheKey); err != nil {
+		authFailuresTotal.Inc()
 		s.logger.Info("Authentication failed", "cacheKey", cacheKey, "error", err)
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return


### PR DESCRIPTION
## Summary

Adds control-plane validation and cache instrumentation so operators can observe Coraza parse outcomes, cache write latency, and cache server authentication failures. Extends bundled PrometheusRule alerts and documents the new metrics.

Part of the observability epic (#243 / #357), building on controller metrics (#397) and Helm alerting (#404).

## Why

After #397 and #404, the operator exposes CR condition gauges and cache RED metrics, but not:

- How often RuleSource/RuleSet Coraza validation runs and fails
- Validation latency on the reconciliation hot path
- Cache `Put` duration or auth failures on the RuleSet HTTP server

These gaps make it hard to detect bad rule edits, cache pressure, or WASM polling misconfiguration before CRs degrade.

## Changes

- **Validation metrics** — `coraza_rulesource_validations_total`, `coraza_ruleset_validations_total`, and matching duration histograms; patch-only fragments and annotation skips record `skipped` (counter only, no histogram)
- **Cache metrics** — `coraza_cache_set_duration_seconds` on RuleSet cache writes; `coraza_cache_server_auth_failures_total` on bearer token rejection
- **PrometheusRule** — recording rules for degraded RuleSources and cache hit ratio; alerts for validation failure rate, low cache hit ratio (with traffic guard), degraded RuleSources, and sustained auth failures
- **Docs** — extend `monitoring-prometheus.md`; update cardinality budget in `metrics-cardinality.md`
- **Tests** — unit and controller tests for validation counters, RuleSet invalid aggregate path, and auth failure counter

## Test plan

- [x] `ISTIO_VERSION=1.28.2 go test ./internal/controller/... ./internal/rulesets/cache/...`
- [ ] `make helm.validate` (PrometheusRule template renders with new alerts)
- [ ] Deploy with `metrics.prometheusRule.enabled: true` and confirm new series appear in `/metrics` after reconciling a RuleSource and RuleSet


Made with [Cursor](https://cursor.com)