### PR TITLE
fix(metrics): resync guards, cache improvements, and alert tuning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,19 +142,14 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: "v4.2.0"
+      - name: set up go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
       - name: install promtool
         run: |
-          PROM_VERSION="3.12.0"
-          PROM_SHA256="20da47f8e5303f74aecb78edd7f7e39041dac08ac4939dba75efd7a900ae8867"
-          PROM_ARCHIVE="prometheus-${PROM_VERSION}.linux-amd64.tar.gz"
-          curl -fsSLo "${PROM_ARCHIVE}" \
-            "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/${PROM_ARCHIVE}"
-          echo "${PROM_SHA256}  ${PROM_ARCHIVE}" | sha256sum -c -
-          tar -xzf "${PROM_ARCHIVE}" --strip-components=1 \
-            "prometheus-${PROM_VERSION}.linux-amd64/promtool"
-          install promtool "${RUNNER_TEMP}/promtool"
+          make observability.promtool.install INSTALL_DIR="${RUNNER_TEMP}"
           echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
-          rm -f "${PROM_ARCHIVE}" promtool
       - name: validate helm templates
         run: make helm.validate
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ KIND_CLUSTER_NAME ?= coraza-kubernetes-operator-integration
 # use openshift-gateway (match operator istio.revision) or empty for default-revision Istio.
 ISTIO_GATEWAY_REVISION ?= coraza
 ISTIO_VERSION ?= 1.28.2
+# Used by promtool in CI: make observability.promtool.install
+PROM_VERSION ?= 3.12.0
+PROM_SHA256_LINUX_AMD64 ?= 20da47f8e5303f74aecb78edd7f7e39041dac08ac4939dba75efd7a900ae8867
 METALLB_VERSION ?= 0.15.3
 METALLB_POOL_SIZE ?= 128 # Defines the size of MetalLB pool, when being used
 
@@ -471,6 +474,12 @@ helm.sync: helm.sync-crds helm.sync-rbac ## Sync all generated resources into th
 .PHONY: helm.validate
 helm.validate: ## Validate Helm templates render correctly for key flag combinations
 	hack/test-helm-manifests.sh
+
+.PHONY: observability.promtool.install
+observability.promtool.install: ## Install promtool (PROM_VERSION) to INSTALL_DIR (default: GOBIN)
+	PROM_VERSION=$(PROM_VERSION) PROM_SHA256=$(PROM_SHA256_LINUX_AMD64) \
+		INSTALL_DIR=$(or $(INSTALL_DIR),$(GOBIN)) \
+		hack/observability/install-promtool.sh
 
 .PHONY: test.metrics
 test.metrics: ## Run metrics integration tests (requires KIND cluster)

--- a/charts/coraza-kubernetes-operator/templates/prometheusrule.yaml
+++ b/charts/coraza-kubernetes-operator/templates/prometheusrule.yaml
@@ -13,13 +13,19 @@ spec:
   groups:
     - name: coraza-operator.alerts
       rules:
-        # Reconcile error ratio above 10% over 5m window (errors / total reconciles)
+        # Reconcile error ratio above 10% over 5m window (errors / total reconciles).
+        # Guard: when reconcile_total rate is 0 the division is NaN and the alert
+        # does not fire (same pattern as CorazaCacheHitRateLow traffic guard).
         - alert: CorazaReconcileErrorRateHigh
           expr: >-
-            sum by (controller) (rate(controller_runtime_reconcile_errors_total{controller=~"ruleset|engine|rulesource"}[5m]))
-            /
-            sum by (controller) (rate(controller_runtime_reconcile_total{controller=~"ruleset|engine|rulesource"}[5m]))
-            > 0.1
+            (
+              sum by (controller) (rate(controller_runtime_reconcile_errors_total{controller=~"ruleset|engine|rulesource"}[5m]))
+              /
+              sum by (controller) (rate(controller_runtime_reconcile_total{controller=~"ruleset|engine|rulesource"}[5m]))
+              > 0.1
+            )
+            and
+            sum by (controller) (rate(controller_runtime_reconcile_total{controller=~"ruleset|engine|rulesource"}[5m])) > 0
           for: 10m
           labels:
             severity: warning
@@ -72,18 +78,15 @@ spec:
             summary: "Coraza ruleset cache is near capacity"
             description: 'Cache utilization is {{ "{{" }} $value | humanizePercentage {{ "}}" }} of the configured maximum.'
 
-        # GC pruning more than 10 entries per second — indicates cache pressure.
-        # rate() returns per-second values, so > 10 means more than 10 entries/sec
-        # (i.e. 600 per minute, ~9000 per 15m). To alert on 10 entries per 15m instead,
-        # use threshold > 0.011 (10/900).
+        # More than 10 entries pruned in 15 minutes — indicates sustained cache pressure.
         - alert: CorazaCacheGCFrequencyHigh
-          expr: rate(coraza_cache_gc_pruned_entries_total[15m]) > 10
+          expr: increase(coraza_cache_gc_pruned_entries_total[15m]) > 10
           for: 15m
           labels:
             severity: warning
           annotations:
             summary: "Coraza cache GC is pruning entries at a high rate"
-            description: 'Cache GC is pruning {{ "{{" }} $value | humanize {{ "}}" }} entries/sec — consider increasing cache size limits.'
+            description: 'Cache GC pruned more than 10 entries in the last 15 minutes — consider increasing cache size limits.'
 
         # Workqueue depth above 100 for 10 minutes
         - alert: CorazaWorkqueueDepthHigh
@@ -141,9 +144,10 @@ spec:
             summary: "Cache hit ratio is low"
             description: 'Cache hit ratio is {{ "{{" }} $value | humanizePercentage {{ "}}" }} — most cache requests are returning 404 (cache miss).'
 
-        # Sustained authentication failures on the cache HTTP server
+        # Sustained authentication failures on the cache HTTP server.
+        # Require multiple failures in 15m to ignore brief token refresh on pod restart.
         - alert: CorazaCacheServerAuthFailures
-          expr: rate(coraza_cache_server_auth_failures_total[5m]) > 0
+          expr: increase(coraza_cache_server_auth_failures_total[15m]) >= 3
           for: 5m
           labels:
             severity: warning

--- a/charts/coraza-kubernetes-operator/templates/servicemonitor.yaml
+++ b/charts/coraza-kubernetes-operator/templates/servicemonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "coraza-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -15,6 +18,11 @@ spec:
       interval: 30s
       scrapeTimeout: 10s
       scheme: https
+      # Coraza CR metrics use a `namespace` label for the resource namespace. Without
+      # honorLabels, Prometheus overwrites it with the operator pod namespace.
+      # Operator metrics must not emit `job` or `instance` labels; the guard below
+      # drops them if they ever appear so scrape-target identity stays authoritative.
+      honorLabels: true
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         {{- if and .Values.metrics.certSecret .Values.metrics.caName }}
@@ -27,9 +35,11 @@ spec:
         # self-signed or unverifiable metrics certificate.
         insecureSkipVerify: true
         {{- end }}
-      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings:
-        {{- toYaml . | nindent 8 }}
+        - action: labeldrop
+          regex: ^(job|instance)$
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.metrics.serviceMonitor.relabelings }}
       relabelings:

--- a/docs/content/reference/metrics-cardinality.md
+++ b/docs/content/reference/metrics-cardinality.md
@@ -48,12 +48,12 @@ for counters by Prometheus convention).
 | `coraza_rulesources` | gauge | `namespace` | 1 per namespace | |
 | `coraza_ruledata_info` | gauge=1 | `namespace`, `name` | 1 per referenced RuleData | Only RuleDatas referenced by a RuleSet |
 | `coraza_ruledata_condition` | gauge | `namespace`, `name`, `condition` | 1 per referenced RuleData (Ready) | |
-| `coraza_ruledatas` | gauge | `namespace` | 1 per namespace | Refreshed on RuleSet reconciliation |
-| `coraza_rulesource_validations_total` | counter | `namespace`, `outcome` | 3 per namespace (valid/invalid/skipped) | `skipped` = annotation bypass or patch-only fragment |
-| `coraza_ruleset_validations_total` | counter | `namespace`, `outcome` | 2 per namespace (valid/invalid) | `valid` = Coraza parse succeeded, not necessarily Ready |
+| `coraza_ruledatas` | gauge | `namespace` | 1 per namespace | Refreshed on RuleSet reconcile and RuleData watch events |
+| `coraza_rulesource_validations_total` | counter | `namespace`, `outcome` | 3 per namespace (valid/invalid/skipped) | Incremented once per status transition, not per informer resync |
+| `coraza_ruleset_validations_total` | counter | `namespace`, `outcome` | 2 per namespace (valid/invalid) | `valid` recorded after successful cache; `invalid` on degrade transition |
 | `coraza_rulesource_validation_duration_seconds` | histogram | `namespace`, `outcome` | 2 × 13 per namespace (valid/invalid) | `skipped` increments the counter only; 11 buckets + sum + count |
-| `coraza_ruleset_validation_duration_seconds` | histogram | `namespace`, `outcome` | 2 × 13 per namespace | 11 buckets + sum + count |
-| `coraza_cache_set_duration_seconds` | histogram | `namespace` | 1 × 10 per namespace | 8 buckets + sum + count |
+| `coraza_ruleset_validation_duration_seconds` | histogram | `namespace`, `outcome` | 2 × 13 per namespace | PMFromFile + Coraza parse only; excludes status patches and cache |
+| `coraza_cache_set_duration_seconds` | histogram | `namespace` | 1 × 10 per namespace | Recorded once per cache transition; excludes resync and unchanged content |
 
 ### Controller-Runtime Built-ins (not `coraza_` prefixed)
 
@@ -134,6 +134,21 @@ constraints (including the top-N rule limit that bounds per-rule series), see
 | Scrape target | ServiceMonitor on operator pod | PodMonitor on Gateway pods |
 | Per-rule detail | No — operator never sees rule decisions | Yes — bounded by top-N limit |
 | Worst-case (10-engine cluster) | ~585 series | ~7,000 series |
+
+## ServiceMonitor label handling
+
+The Helm chart enables `honorLabels: true` on the operator ServiceMonitor so the
+`namespace` label on `coraza_*` metrics reflects the **CR namespace**, not the
+operator pod namespace. Prometheus normally overwrites `namespace` with the scrape
+target namespace when `honorLabels` is false.
+
+`honorLabels` also preserves any `job` or `instance` labels emitted by the
+operator. Those labels are reserved for scrape-target identity; if the operator
+ever emitted them, aggregation would silently break. The chart therefore applies a
+built-in `metricRelabelings` rule to drop `job` and `instance` before user-supplied
+`metrics.serviceMonitor.metricRelabelings` are applied.
+
+**Contract:** operator metrics must not emit `job` or `instance` labels.
 
 ## Reducing Cardinality with metricRelabelings
 

--- a/hack/observability/install-promtool.sh
+++ b/hack/observability/install-promtool.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install promtool for local dev and CI (make observability.promtool.install).
+# Version is pinned in the Makefile (PROM_VERSION); keep SHA256 in sync when bumping.
+set -euo pipefail
+
+: "${PROM_VERSION:?PROM_VERSION must be set}"
+
+INSTALL_DIR="${INSTALL_DIR:-${GOBIN:-${HOME}/.local/bin}}"
+mkdir -p "${INSTALL_DIR}"
+
+OS="$(go env GOOS)"
+ARCH="$(go env GOARCH)"
+PROM_ARCHIVE="prometheus-${PROM_VERSION}.${OS}-${ARCH}.tar.gz"
+PROM_URL="https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/${PROM_ARCHIVE}"
+
+curl -fsSLo "${PROM_ARCHIVE}" "${PROM_URL}"
+
+# PROM_SHA256 is verified only on linux/amd64 (CI pin). Other platforms skip checksum.
+if [ -n "${PROM_SHA256:-}" ] && [ "${OS}" = "linux" ] && [ "${ARCH}" = "amd64" ]; then
+  echo "${PROM_SHA256}  ${PROM_ARCHIVE}" | sha256sum -c -
+fi
+
+tar -xzf "${PROM_ARCHIVE}" --strip-components=1 "prometheus-${PROM_VERSION}.${OS}-${ARCH}/promtool"
+install promtool "${INSTALL_DIR}/promtool"
+rm -f "${PROM_ARCHIVE}" promtool
+
+echo "promtool ${PROM_VERSION} (${OS}/${ARCH}) installed to ${INSTALL_DIR}/promtool"

--- a/hack/test-helm-manifests.sh
+++ b/hack/test-helm-manifests.sh
@@ -36,6 +36,8 @@ echo "$out" | grep -q "kind: ServiceMonitor" && fail "ServiceMonitor should not 
 section "ServiceMonitor enabled"
 out=$(render --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true)
 echo "$out" | grep -q "kind: ServiceMonitor" && pass "ServiceMonitor rendered" || fail "ServiceMonitor missing"
+echo "$out" | grep -q "honorLabels: true" && pass "ServiceMonitor honorLabels enabled" || fail "ServiceMonitor honorLabels missing"
+echo "$out" | grep -q 'action: labeldrop' && echo "$out" | grep -qF '^(job|instance)$' && pass "ServiceMonitor drops reserved scrape labels" || fail "ServiceMonitor labeldrop guard missing"
 echo "$out" | grep -q "monitoring.coreos.com" && pass "monitoring.coreos.com API group" || fail "Wrong API group"
 
 # ── Test 3: PrometheusRule enabled ───────────────────────────────────────────
@@ -78,8 +80,8 @@ echo "$out" | grep -q "kind: PodMonitor" && fail "PodMonitor should be gated on 
 # ── Test 8: additionalLabels merged into PrometheusRule ──────────────────────
 section "PrometheusRule additionalLabels"
 out=$(render --set metrics.enabled=true --set metrics.prometheusRule.enabled=true \
-  --set 'metrics.prometheusRule.additionalLabels.release=prometheus')
-echo "$out" | grep -q "release: prometheus" && pass "additionalLabels merged" || fail "additionalLabels not merged"
+  --set 'metrics.prometheusRule.additionalLabels.release=kube-prometheus-stack')
+echo "$out" | grep -q "release: kube-prometheus-stack" && pass "additionalLabels merged" || fail "additionalLabels not merged"
 
 # ── Test 9: PodMonitor port name override ────────────────────────────────────
 section "PodMonitor portName override"
@@ -98,8 +100,8 @@ echo "$out" | grep -q "CustomAlert" && pass "Custom alert rule injected" || fail
 section "PodMonitor additionalLabels"
 out=$(render --set metrics.podMonitor.enabled=true \
   --set 'metrics.podMonitor.gatewaySelector.app=my-gateway' \
-  --set 'metrics.podMonitor.additionalLabels.release=prometheus')
-echo "$out" | grep -q "release: prometheus" && pass "PodMonitor additionalLabels merged" || fail "PodMonitor additionalLabels not merged"
+  --set 'metrics.podMonitor.additionalLabels.release=kube-prometheus-stack')
+echo "$out" | grep -q "release: kube-prometheus-stack" && pass "PodMonitor additionalLabels merged" || fail "PodMonitor additionalLabels not merged"
 
 # ── Test 12: PodMonitor metricRelabelings injection ──────────────────────────
 section "PodMonitor metricRelabelings"
@@ -109,7 +111,13 @@ out=$(render --set metrics.podMonitor.enabled=true \
 echo "$out" | grep -q "coraza_waf_requests_total" && pass "User metricRelabelings injected" || fail "User metricRelabelings missing"
 echo "$out" | grep -qF 'coraza_waf_.*' && pass "Mandatory cardinality guard still present" || fail "Mandatory cardinality guard missing"
 
-# ── Test 13: promtool check rules (optional) ─────────────────────────────────
+# ── Test 13: ServiceMonitor additionalLabels ─────────────────────────────────
+section "ServiceMonitor additionalLabels"
+out=$(render --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true \
+  --set 'metrics.serviceMonitor.additionalLabels.release=kube-prometheus-stack')
+echo "$out" | grep -q "release: kube-prometheus-stack" && pass "ServiceMonitor additionalLabels merged" || fail "ServiceMonitor additionalLabels not merged"
+
+# ── Test 14: promtool check rules (optional) ─────────────────────────────────
 if command -v promtool &>/dev/null; then
   section "promtool check rules"
   tmpfile=$(mktemp /tmp/prometheusrule-XXXXXX.yaml)

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -152,12 +152,12 @@ func NewCorazaMetrics(reg prometheus.Registerer) (*CorazaMetrics, error) {
 
 		rulesourceValidations: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "coraza_rulesource_validations_total",
-			Help: "Total RuleSource validation attempts per reconcile by outcome (valid=Coraza parse succeeded, invalid=parse failed, skipped=annotation or patch-only fragment).",
+			Help: "RuleSource validation outcomes recorded once per status transition (valid=Coraza parse succeeded, invalid=parse failed, skipped=annotation or patch-only fragment).",
 		}, []string{"namespace", "outcome"}),
 
 		rulesetValidations: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "coraza_ruleset_validations_total",
-			Help: "Total RuleSet aggregate validation attempts per reconcile by outcome (valid=Coraza parse succeeded, invalid=parse failed; does not imply Ready — unsupported rules are checked afterward).",
+			Help: "RuleSet aggregate validation outcomes recorded once per status transition (valid=Coraza parse succeeded and rules cached, invalid=parse failed).",
 		}, []string{"namespace", "outcome"}),
 
 		rulesourceValidationDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -168,13 +168,13 @@ func NewCorazaMetrics(reg prometheus.Registerer) (*CorazaMetrics, error) {
 
 		rulesetValidationDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "coraza_ruleset_validation_duration_seconds",
-			Help:    "Duration of RuleSet aggregate Coraza validation by outcome.",
+			Help:    "Duration of RuleSet Coraza validation (PMFromFile + aggregate parse) by outcome; excludes status patches and cache writes.",
 			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5},
 		}, []string{"namespace", "outcome"}),
 
 		cacheSetDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "coraza_cache_set_duration_seconds",
-			Help:    "Duration of cache Put operations for validated RuleSets.",
+			Help:    "Duration of cache Put operations recorded once per RuleSet cache transition; excludes resync and content-unchanged reconciles.",
 			Buckets: []float64{.0001, .0005, .001, .005, .01, .025, .05, .1},
 		}, []string{"namespace"}),
 	}

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -714,6 +714,46 @@ func gatherRuleSetValidationCounter(t *testing.T, reg *prometheus.Registry, outc
 	return gatherCounterOutcome(t, reg, "coraza_ruleset_validations_total", outcome)
 }
 
+func gatherNamespaceGauge(t *testing.T, reg *prometheus.Registry, metricName, ns string) float64 {
+	t.Helper()
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range gathered {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			labels := make(map[string]string)
+			for _, lp := range metric.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["namespace"] == ns {
+				return metric.GetGauge().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func gatherCacheSetDurationSampleCount(t *testing.T, reg *prometheus.Registry) uint64 {
+	t.Helper()
+	gathered, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range gathered {
+		if mf.GetName() != "coraza_cache_set_duration_seconds" {
+			continue
+		}
+		var total uint64
+		for _, metric := range mf.GetMetric() {
+			if h := metric.GetHistogram(); h != nil {
+				total += h.GetSampleCount()
+			}
+		}
+		return total
+	}
+	return 0
+}
+
 func gatherCounterOutcome(t *testing.T, reg *prometheus.Registry, metricName, outcome string) float64 {
 	t.Helper()
 	gathered, err := reg.Gather()

--- a/internal/controller/ruleset_controller.go
+++ b/internal/controller/ruleset_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -104,8 +105,8 @@ func (r *RuleSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Watches(
 			&wafv1alpha1.RuleData{},
-			handler.EnqueueRequestsFromMapFunc(r.findRuleSetsForRuleData),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+			handler.EnqueueRequestsFromMapFunc(r.enqueueForRuleDataChange),
+			builder.WithPredicates(ruleDataWatchPredicate()),
 		).
 		WithOptions(controller.Options{
 			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[ctrl.Request](
@@ -179,32 +180,58 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
-	logInfo(log, req, "RuleSet", "Validating aggregated rules")
-	validationStart := time.Now()
-	if err := validation.ValidatePMFromFileData(aggregatedRules, dataFiles); err != nil {
-		vd := time.Since(validationStart)
-		r.Metrics.IncRuleSetValidation(req.Namespace, "invalid")
-		r.Metrics.ObserveRuleSetValidation(req.Namespace, "invalid", vd)
-		msg := fmt.Sprintf("Ruleset is invalid\n%v", err)
-		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", &ruleset, &ruleset.Status.Conditions, ruleset.Generation, "InvalidRuleSet", msg); patchErr != nil {
-			return ctrl.Result{}, patchErr
+	alreadyInvalid := isConditionCurrent(ruleset.Status.Conditions, conditionDegraded, ruleSetDegradedReasonInvalidRuleSet, ruleset.Generation)
+	alreadyCached := isConditionCurrent(ruleset.Status.Conditions, conditionReady, ruleSetReadyReasonRulesCached, ruleset.Generation)
+	cacheKey := fmt.Sprintf("%s/%s", ruleset.Namespace, ruleset.Name)
+	if alreadyCached && r.Cache.EntryMatches(cacheKey, aggregatedRules, dataFiles) {
+		// Annotation-only reconciles (e.g. removing skip-unsupported-rules-check) do not
+		// bump generation; still re-run unsupported-rule policy before skipping work.
+		if ruleset.Annotations[wafv1alpha1.AnnotationSkipUnsupportedRulesCheck] != "true" {
+			foundUnsupportedRules, _, err := r.rejectUnsupportedRules(ctx, log, req, &ruleset, aggregatedRules)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if foundUnsupportedRules {
+				return ctrl.Result{}, nil
+			}
 		}
 		return ctrl.Result{}, nil
 	}
+
+	logInfo(log, req, "RuleSet", "Validating aggregated rules")
+
+	pmStart := time.Now()
+	if err := validation.ValidatePMFromFileData(aggregatedRules, dataFiles); err != nil {
+		pmDur := time.Since(pmStart)
+		if !alreadyInvalid {
+			msg := fmt.Sprintf("Ruleset is invalid\n%v", err)
+			if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", &ruleset, &ruleset.Status.Conditions, ruleset.Generation, ruleSetDegradedReasonInvalidRuleSet, msg); patchErr != nil {
+				return ctrl.Result{}, patchErr
+			}
+			r.Metrics.IncRuleSetValidation(req.Namespace, "invalid")
+			r.Metrics.ObserveRuleSetValidation(req.Namespace, "invalid", pmDur)
+		}
+		return ctrl.Result{}, nil
+	}
+	pmDur := time.Since(pmStart)
+
 	fsRules := getDataFilesystem(dataFiles)
 	conf := coraza.NewWAFConfig().WithDirectives(aggregatedRules)
 	if fsRules != nil {
 		conf = conf.WithRootFS(fsRules)
 	}
-	if err := r.validateAggregatedRules(ctx, log, req, &ruleset, conf); err != nil {
-		vd := time.Since(validationStart)
-		r.Metrics.IncRuleSetValidation(req.Namespace, "invalid")
-		r.Metrics.ObserveRuleSetValidation(req.Namespace, "invalid", vd)
+	corazaDur, err := r.validateAggregatedRules(ctx, log, req, &ruleset, conf)
+	if err != nil {
+		if errors.Is(err, errRuleSetRulesInvalid) {
+			if !alreadyInvalid {
+				r.Metrics.IncRuleSetValidation(req.Namespace, "invalid")
+				r.Metrics.ObserveRuleSetValidation(req.Namespace, "invalid", pmDur+corazaDur)
+			}
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
-	vd := time.Since(validationStart)
-	r.Metrics.IncRuleSetValidation(req.Namespace, "valid")
-	r.Metrics.ObserveRuleSetValidation(req.Namespace, "valid", vd)
+	validationDur := pmDur + corazaDur
 
 	logDebug(log, req, "RuleSet", "Checking for unsupported rules")
 	foundUnsupportedRules, unsupportedMsg, err := r.rejectUnsupportedRules(ctx, log, req, &ruleset, aggregatedRules)
@@ -219,6 +246,10 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.cacheRules(ctx, log, req, &ruleset, aggregatedRules, dataFiles, unsupportedMsg); err != nil {
 		return ctrl.Result{}, err
 	}
+	if !alreadyCached {
+		r.Metrics.IncRuleSetValidation(req.Namespace, "valid")
+		r.Metrics.ObserveRuleSetValidation(req.Namespace, "valid", validationDur)
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -231,10 +262,9 @@ func (r *RuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 // not referenced by any RuleSet. Called from both the not-found path (RuleSet
 // deleted) and the defer block (normal reconcile).
 //
-// Because there is no dedicated RuleData reconciler, these counts only refresh
-// when a RuleSet in the same namespace reconciles. Orphaned RuleData created or
-// deleted without a corresponding RuleSet change will appear stale until the
-// next RuleSet reconciliation in that namespace.
+// Because there is no dedicated RuleData reconciler, namespace totals refresh when
+// a RuleSet in the same namespace reconciles, or when a RuleData watch event has
+// no referencing RuleSet (enqueueForRuleDataChange).
 func (r *RuleSetReconciler) reconcileRuleDataMetrics(ctx context.Context, ns string) {
 	if r.Metrics == nil {
 		return

--- a/internal/controller/ruleset_controller_cache.go
+++ b/internal/controller/ruleset_controller_cache.go
@@ -16,7 +16,8 @@ import (
 // -----------------------------------------------------------------------------
 
 // cacheRules stores the aggregated rules in the cache and patches the RuleSet
-// status to Ready.
+// status to Ready. Cache Put duration is observed only when the cache content
+// was updated (not when status is patched for content already in the cache).
 func (r *RuleSetReconciler) cacheRules(
 	ctx context.Context,
 	log logr.Logger,
@@ -27,11 +28,28 @@ func (r *RuleSetReconciler) cacheRules(
 	unsupportedMsg string,
 ) error {
 	cacheKey := fmt.Sprintf("%s/%s", ruleset.Namespace, ruleset.Name)
-	cacheStart := time.Now()
-	r.Cache.Put(cacheKey, aggregatedRules, dataFiles)
-	r.Metrics.ObserveCacheSet(ruleset.Namespace, time.Since(cacheStart))
-	logInfo(log, req, "RuleSet", "Stored rules in cache", "cacheKey", cacheKey)
+	alreadyReady := isConditionCurrent(ruleset.Status.Conditions, conditionReady, ruleSetReadyReasonRulesCached, ruleset.Generation)
+
+	cacheUpdated := false
+	var cacheDur time.Duration
+	if !r.Cache.EntryMatches(cacheKey, aggregatedRules, dataFiles) {
+		cacheStart := time.Now()
+		r.Cache.Put(cacheKey, aggregatedRules, dataFiles)
+		cacheDur = time.Since(cacheStart)
+		cacheUpdated = true
+		logInfo(log, req, "RuleSet", "Stored rules in cache", "cacheKey", cacheKey)
+	}
+
+	if alreadyReady {
+		return nil
+	}
 
 	statusMsg := buildCacheReadyMessage(ruleset.Namespace, ruleset.Name, unsupportedMsg)
-	return patchReady(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "RulesCached", statusMsg)
+	if err := patchReady(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, ruleSetReadyReasonRulesCached, statusMsg); err != nil {
+		return err
+	}
+	if cacheUpdated {
+		r.Metrics.ObserveCacheSet(ruleset.Namespace, cacheDur)
+	}
+	return nil
 }

--- a/internal/controller/ruleset_controller_test.go
+++ b/internal/controller/ruleset_controller_test.go
@@ -21,16 +21,19 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
@@ -1086,6 +1089,64 @@ func TestRuleSetReconciler_UnsupportedRules(t *testing.T) {
 		assert.True(t, recorder.HasEvent("Warning", "UnsupportedRules"),
 			"expected Warning/UnsupportedRules event even with annotation override; got: %v", recorder.Events)
 	})
+
+	t.Run("removing skip annotation degrades cached ruleset with unsupported rules", func(t *testing.T) {
+		ruleSetCache := cache.NewRuleSetCache()
+
+		const unsupportedRule = `SecRule ARGS "@rx error" "id:922110,phase:2,deny,status:403,msg:'Multipart charset'"`
+		rs := utils.NewTestRuleSource("remove-skip-rules-src", testNamespace, unsupportedRule)
+		require.NoError(t, k8sClient.Create(ctx, rs))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, rs); err != nil {
+				t.Logf("Failed to delete RuleSource: %v", err)
+			}
+		})
+
+		ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+			Name:      "remove-skip-ruleset",
+			Namespace: testNamespace,
+			Sources:   []wafv1alpha1.SourceReference{{Name: "remove-skip-rules-src"}},
+		})
+		ruleSet.Annotations = map[string]string{
+			wafv1alpha1.AnnotationSkipUnsupportedRulesCheck: "true",
+		}
+		require.NoError(t, k8sClient.Create(ctx, ruleSet))
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(ctx, ruleSet); err != nil {
+				t.Logf("Failed to delete RuleSet: %v", err)
+			}
+		})
+
+		reconciler := &RuleSetReconciler{
+			Client:   k8sClient,
+			Scheme:   scheme,
+			Recorder: utils.NewFakeRecorder(),
+			Cache:    ruleSetCache,
+		}
+		nn := types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}
+
+		_, err := reconcileRuleSetWithRuleSources(ctx, t, nn, reconciler)
+		require.NoError(t, err)
+
+		require.NoError(t, k8sClient.Get(ctx, nn, ruleSet))
+		ready := apimeta.FindStatusCondition(ruleSet.Status.Conditions, conditionReady)
+		require.NotNil(t, ready)
+		assert.Equal(t, metav1.ConditionTrue, ready.Status)
+
+		patch := client.MergeFrom(ruleSet.DeepCopy())
+		delete(ruleSet.Annotations, wafv1alpha1.AnnotationSkipUnsupportedRulesCheck)
+		require.NoError(t, k8sClient.Patch(ctx, ruleSet, patch))
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn})
+		require.NoError(t, err)
+
+		require.NoError(t, k8sClient.Get(ctx, nn, ruleSet))
+		degraded := apimeta.FindStatusCondition(ruleSet.Status.Conditions, conditionDegraded)
+		require.NotNil(t, degraded, "RuleSet must degrade when skip-unsupported annotation is removed")
+		assert.Equal(t, metav1.ConditionTrue, degraded.Status)
+		assert.Equal(t, "UnsupportedRules", degraded.Reason)
+		assert.Contains(t, degraded.Message, "922110")
+	})
 }
 
 func TestRuleSetReconciler_DuplicateSourceReferences(t *testing.T) {
@@ -1578,6 +1639,150 @@ func TestRuleSetReconciler_MetricsValidationInvalid(t *testing.T) {
 	assert.Equal(t, float64(0), gatherRuleSetValidationCounter(t, reg, "valid"))
 }
 
+// TestRuleSetReconciler_MetricsCorazaAggregateInvalid verifies Coraza parse
+// failure in validateAggregatedRules records outcome=invalid, not valid.
+func TestRuleSetReconciler_MetricsCorazaAggregateInvalid(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	src := utils.NewTestRuleSource("metrics-coraza-invalid-src", testNamespace,
+		`SecDefaultActionXPTO "INVALID"`)
+	src.Annotations = map[string]string{wafv1alpha1.AnnotationSkipValidation: "false"}
+	require.NoError(t, k8sClient.Create(ctx, src))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, src) })
+
+	rsRec := &RuleSourceReconciler{Client: k8sClient, Recorder: utils.NewTestRecorder()}
+	_, err := rsRec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: src.Name, Namespace: src.Namespace}})
+	require.NoError(t, err)
+
+	ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "metrics-coraza-invalid-rs",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "metrics-coraza-invalid-src"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleSet))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ruleSet) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    cache.NewRuleSetCache(),
+		Metrics:  m,
+	}
+
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}, reconciler)
+	require.NoError(t, err)
+
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}, ruleSet))
+	ready := apimeta.FindStatusCondition(ruleSet.Status.Conditions, "Ready")
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, "InvalidRuleSet", ready.Reason)
+	assert.Equal(t, float64(1), gatherRuleSetValidationCounter(t, reg, "invalid"))
+	assert.Equal(t, float64(0), gatherRuleSetValidationCounter(t, reg, "valid"))
+}
+
+func TestRuleSetReconciler_MetricsNotIncrementedOnResync(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	src := utils.NewTestRuleSource("metrics-resync-src", testNamespace,
+		`SecRule REQUEST_URI "@contains /r" "id:901,phase:1,pass,nolog"`)
+	require.NoError(t, k8sClient.Create(ctx, src))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, src) })
+
+	ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "metrics-resync-rs",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "metrics-resync-src"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleSet))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ruleSet) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    cache.NewRuleSetCache(),
+		Metrics:  m,
+	}
+
+	nn := types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nn, reconciler)
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), gatherRuleSetValidationCounter(t, reg, "valid"))
+	assert.Equal(t, uint64(1), gatherCacheSetDurationSampleCount(t, reg))
+
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nn})
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), gatherRuleSetValidationCounter(t, reg, "valid"),
+		"second reconcile with unchanged cached content must not increment validation counter")
+	assert.Equal(t, uint64(1), gatherCacheSetDurationSampleCount(t, reg),
+		"second reconcile with unchanged cached content must not observe cache duration")
+}
+
+func TestRuleSetReconciler_MetricsCacheDurationOnlyOnPut(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	src := utils.NewTestRuleSource("cache-dur-src", testNamespace,
+		`SecRule REQUEST_URI "@contains /r" "id:901,phase:1,pass,nolog"`)
+	require.NoError(t, k8sClient.Create(ctx, src))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, src) })
+
+	ruleSet := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      "cache-dur-rs",
+		Namespace: testNamespace,
+		Sources:   []wafv1alpha1.SourceReference{{Name: "cache-dur-src"}},
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleSet))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ruleSet) })
+
+	ruleSetCache := cache.NewRuleSetCache()
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:   k8sClient,
+		Scheme:   scheme,
+		Recorder: utils.NewTestRecorder(),
+		Cache:    ruleSetCache,
+		Metrics:  m,
+	}
+
+	nn := types.NamespacedName{Name: ruleSet.Name, Namespace: ruleSet.Namespace}
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nn, reconciler)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), gatherCacheSetDurationSampleCount(t, reg))
+
+	require.NoError(t, k8sClient.Get(ctx, nn, ruleSet))
+	patch := client.MergeFrom(ruleSet.DeepCopy())
+	setConditionFalse(&ruleSet.Status.Conditions, ruleSet.Generation, conditionReady, "StatusReset", "test reset")
+	require.NoError(t, k8sClient.Status().Patch(ctx, ruleSet, patch))
+
+	reg2 := prometheus.NewRegistry()
+	m2, err := NewCorazaMetrics(reg2)
+	require.NoError(t, err)
+	reconciler.Metrics = m2
+
+	_, err = reconcileRuleSetWithRuleSources(ctx, t, nn, reconciler)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), gatherCacheSetDurationSampleCount(t, reg2),
+		"status-only reconcile with unchanged cache must not observe cache Put duration")
+	assert.Equal(t, uint64(1), gatherCacheSetDurationSampleCount(t, reg),
+		"original cache Put observation must be unchanged")
+}
+
 // TestRuleSetReconciler_MetricsForgetOnNotFound verifies that a not-found
 // reconcile calls ForgetRuleSet and removes all series from the registry.
 func TestRuleSetReconciler_MetricsForgetOnNotFound(t *testing.T) {
@@ -1909,4 +2114,45 @@ func TestRuleSetReconciler_MetricsRuleSetDeletionCleansUpRuleData(t *testing.T) 
 		"coraza_ruledata_info must be cleared when the only referencing RuleSet is deleted")
 	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledata_condition"),
 		"coraza_ruledata_condition must be cleared when the only referencing RuleSet is deleted")
+}
+
+// TestRuleSetReconciler_MetricsRuleDataDeleteRefreshesNamespaceTotal verifies that
+// deleting an unreferenced RuleData refreshes coraza_ruledatas even when no
+// RuleSet exists to reconcile.
+func TestRuleSetReconciler_MetricsRuleDataDeleteRefreshesNamespaceTotal(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	t.Cleanup(cleanup)
+
+	const ns = "ruledata-metrics-delete"
+	require.NoError(t, k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}) })
+
+	rd := utils.NewTestRuleData("orphan-rd", ns, map[string]string{"orphan.data": "x"})
+	require.NoError(t, k8sClient.Create(ctx, rd))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rd) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &RuleSetReconciler{
+		Client:  k8sClient,
+		Scheme:  scheme,
+		Metrics: m,
+	}
+
+	reconciler.enqueueForRuleDataChange(ctx, rd)
+	assert.Equal(t, float64(1), gatherNamespaceGauge(t, reg, "coraza_ruledatas", ns))
+
+	require.NoError(t, k8sClient.Delete(ctx, rd))
+	require.Eventually(t, func() bool {
+		var list wafv1alpha1.RuleDataList
+		if err := k8sClient.List(ctx, &list, client.InNamespace(ns)); err != nil {
+			return false
+		}
+		return len(list.Items) == 0
+	}, 5*time.Second, 50*time.Millisecond, "RuleData should disappear from the test cache after delete")
+	reconciler.enqueueForRuleDataChange(ctx, rd)
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_ruledatas"),
+		"coraza_ruledatas series must be removed when the last RuleData in a namespace is deleted")
 }

--- a/internal/controller/ruleset_controller_validation.go
+++ b/internal/controller/ruleset_controller_validation.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/corazawaf/coraza/v3"
 	"github.com/go-logr/logr"
@@ -17,23 +19,38 @@ import (
 // RuleSet Validation
 // -----------------------------------------------------------------------------
 
+const (
+	ruleSetDegradedReasonInvalidRuleSet = "InvalidRuleSet"
+	ruleSetReadyReasonRulesCached       = "RulesCached"
+)
+
+// errRuleSetRulesInvalid indicates aggregate Coraza validation failed and the
+// RuleSet status was patched to Degraded. Reconcile should stop without error.
+var errRuleSetRulesInvalid = errors.New("aggregated rules failed Coraza validation")
+
 // validateAggregatedRules validates the aggregated rule set via Coraza.
 // Sets Degraded status and emits Warning events on failure.
+// The returned duration covers Coraza parsing only (not status patches).
 func (r *RuleSetReconciler) validateAggregatedRules(
 	ctx context.Context,
 	log logr.Logger,
 	req ctrl.Request,
 	ruleset *wafv1alpha1.RuleSet,
 	conf coraza.WAFConfig,
-) error {
+) (time.Duration, error) {
+	start := time.Now()
 	if _, err := coraza.NewWAF(conf); err != nil {
-		msg := fmt.Sprintf("Ruleset is invalid\n%v", validation.SanitizeErrorMessage(err))
-		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, "InvalidRuleSet", msg); patchErr != nil {
-			return patchErr
+		d := time.Since(start)
+		if isConditionCurrent(ruleset.Status.Conditions, conditionDegraded, ruleSetDegradedReasonInvalidRuleSet, ruleset.Generation) {
+			return d, errRuleSetRulesInvalid
 		}
-		return nil
+		msg := fmt.Sprintf("Ruleset is invalid\n%v", validation.SanitizeErrorMessage(err))
+		if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSet", ruleset, &ruleset.Status.Conditions, ruleset.Generation, ruleSetDegradedReasonInvalidRuleSet, msg); patchErr != nil {
+			return d, patchErr
+		}
+		return d, errRuleSetRulesInvalid
 	}
-	return nil
+	return time.Since(start), nil
 }
 
 // rejectUnsupportedRules checks rules for IDs unsupported in WASM mode.

--- a/internal/controller/ruleset_controller_validation_test.go
+++ b/internal/controller/ruleset_controller_validation_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	wafv1alpha1 "github.com/networking-incubator/coraza-kubernetes-operator/api/v1alpha1"
 )
@@ -82,4 +87,40 @@ func TestFindDuplicateReferences(t *testing.T) {
 		rs := &wafv1alpha1.RuleSet{}
 		assert.Empty(t, findDuplicateReferences(rs))
 	})
+}
+
+// TestRuleSetValidationErrorClassification documents metrics behavior: only
+// errRuleSetRulesInvalid (Coraza rejected rules, status patched) records
+// outcome=invalid. API errors from patchDegraded must not increment counters.
+func TestRuleSetValidationErrorClassification(t *testing.T) {
+	patchErr := apierrors.NewConflict(
+		schema.GroupResource{Group: "waf.k8s.coraza.io", Resource: "rulesets"},
+		"rs",
+		errors.New("conflict"),
+	)
+
+	assert.True(t, errors.Is(errRuleSetRulesInvalid, errRuleSetRulesInvalid))
+	assert.False(t, errors.Is(patchErr, errRuleSetRulesInvalid))
+}
+
+func TestRuleSetValidationMetricsOnlyOnSentinel(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	patchErr := apierrors.NewConflict(
+		schema.GroupResource{Group: "waf.k8s.coraza.io", Resource: "rulesets"},
+		"rs",
+		errors.New("conflict"),
+	)
+	if errors.Is(patchErr, errRuleSetRulesInvalid) {
+		m.IncRuleSetValidation("default", "invalid")
+	}
+
+	assert.Equal(t, float64(0), gatherRuleSetValidationCounter(t, reg, "invalid"))
+
+	if errors.Is(errRuleSetRulesInvalid, errRuleSetRulesInvalid) {
+		m.IncRuleSetValidation("default", "invalid")
+	}
+	assert.Equal(t, float64(1), gatherRuleSetValidationCounter(t, reg, "invalid"))
 }

--- a/internal/controller/ruleset_controller_watch_predicates.go
+++ b/internal/controller/ruleset_controller_watch_predicates.go
@@ -45,6 +45,17 @@ func (r *RuleSetReconciler) findRuleSetsForRuleData(ctx context.Context, ruleDat
 	return r.findRuleSetsBy(ctx, ruleData.GetNamespace(), "spec.data.name", ruleData.GetName())
 }
 
+// enqueueForRuleDataChange maps RuleData events to RuleSet reconciles when
+// referenced, and refreshes namespace-level ruledata totals when not.
+func (r *RuleSetReconciler) enqueueForRuleDataChange(ctx context.Context, ruleData client.Object) []reconcile.Request {
+	reqs := r.findRuleSetsForRuleData(ctx, ruleData)
+	if len(reqs) > 0 {
+		return reqs
+	}
+	r.reconcileRuleDataMetrics(ctx, ruleData.GetNamespace())
+	return nil
+}
+
 // findRuleSetsBy lists RuleSets matching a field index value and returns
 // reconcile requests for each.
 func (r *RuleSetReconciler) findRuleSetsBy(ctx context.Context, namespace, indexKey, indexValue string) []reconcile.Request {
@@ -83,5 +94,19 @@ func ruleSourceWatchPredicate() predicate.Predicate {
 		predicate.GenerationChangedPredicate{},
 		annotationChangedPredicate(wafv1alpha1.AnnotationSkipValidation),
 		statusChanged,
+	)
+}
+
+// ruleDataWatchPredicate enqueues referencing RuleSets (or refreshes namespace
+// ruledata totals) when RuleData is created, updated, or deleted.
+func ruleDataWatchPredicate() predicate.Predicate {
+	return predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		predicate.Funcs{
+			CreateFunc:  func(event.CreateEvent) bool { return true },
+			DeleteFunc:  func(event.DeleteEvent) bool { return true },
+			UpdateFunc:  func(event.UpdateEvent) bool { return false },
+			GenericFunc: func(event.GenericEvent) bool { return false },
+		},
 	)
 }

--- a/internal/controller/rulesource_controller.go
+++ b/internal/controller/rulesource_controller.go
@@ -100,36 +100,39 @@ func (r *RuleSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}()
 
+	// Validation metrics are recorded only after a successful status transition
+	// (not on informer resync when the condition is already current).
 	skipValidation := rs.Annotations[wafv1alpha1.AnnotationSkipValidation] == "false"
 	if skipValidation {
-		r.Metrics.IncRuleSourceValidation(req.Namespace, "skipped")
 		if isConditionCurrent(rs.Status.Conditions, conditionReady, ruleSourceReadyReasonValidationSkipped, rs.Generation) {
 			return ctrl.Result{}, nil
 		}
 		if patchErr := patchReady(ctx, r.Status(), r.Recorder, log, req, "RuleSource", &rs, &rs.Status.Conditions, rs.Generation, ruleSourceReadyReasonValidationSkipped, "Per-fragment validation skipped by annotation"); patchErr != nil {
 			return ctrl.Result{}, patchErr
 		}
+		r.Metrics.IncRuleSourceValidation(req.Namespace, "skipped")
 		return ctrl.Result{}, nil
 	}
 
-	if validation.IsPatchOnlyFragment(rs.Spec.Rules) {
-		r.Metrics.IncRuleSourceValidation(req.Namespace, "skipped")
-	} else {
+	patchOnly := validation.IsPatchOnlyFragment(rs.Spec.Rules)
+	// Patch-only fragments skip Coraza; aggregate RuleSet validation is authoritative.
+	var validationDuration time.Duration
+
+	if !patchOnly {
 		validationStart := time.Now()
 		if err := validation.ValidateRuleSourceRules(rs.Spec.Rules, rs.Name, nil); err != nil {
-			d := time.Since(validationStart)
-			r.Metrics.IncRuleSourceValidation(req.Namespace, "invalid")
-			r.Metrics.ObserveRuleSourceValidation(req.Namespace, "invalid", d)
-			if !isConditionCurrent(rs.Status.Conditions, conditionDegraded, ruleSourceDegradedReasonInvalidRules, rs.Generation) {
-				if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSource", &rs, &rs.Status.Conditions, rs.Generation, ruleSourceDegradedReasonInvalidRules, err.Error()); patchErr != nil {
-					return ctrl.Result{}, patchErr
-				}
+			validationDuration = time.Since(validationStart)
+			if isConditionCurrent(rs.Status.Conditions, conditionDegraded, ruleSourceDegradedReasonInvalidRules, rs.Generation) {
+				return ctrl.Result{}, nil
 			}
+			if patchErr := patchDegraded(ctx, r.Status(), r.Recorder, log, req, "RuleSource", &rs, &rs.Status.Conditions, rs.Generation, ruleSourceDegradedReasonInvalidRules, err.Error()); patchErr != nil {
+				return ctrl.Result{}, patchErr
+			}
+			r.Metrics.IncRuleSourceValidation(req.Namespace, "invalid")
+			r.Metrics.ObserveRuleSourceValidation(req.Namespace, "invalid", validationDuration)
 			return ctrl.Result{}, nil
 		}
-		d := time.Since(validationStart)
-		r.Metrics.IncRuleSourceValidation(req.Namespace, "valid")
-		r.Metrics.ObserveRuleSourceValidation(req.Namespace, "valid", d)
+		validationDuration = time.Since(validationStart)
 	}
 
 	if isConditionCurrent(rs.Status.Conditions, conditionReady, ruleSourceReadyReasonValidated, rs.Generation) {
@@ -137,6 +140,12 @@ func (r *RuleSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	if patchErr := patchReady(ctx, r.Status(), r.Recorder, log, req, "RuleSource", &rs, &rs.Status.Conditions, rs.Generation, ruleSourceReadyReasonValidated, "Rules validated successfully"); patchErr != nil {
 		return ctrl.Result{}, patchErr
+	}
+	if patchOnly {
+		r.Metrics.IncRuleSourceValidation(req.Namespace, "skipped")
+	} else {
+		r.Metrics.IncRuleSourceValidation(req.Namespace, "valid")
+		r.Metrics.ObserveRuleSourceValidation(req.Namespace, "valid", validationDuration)
 	}
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/rulesource_controller_test.go
+++ b/internal/controller/rulesource_controller_test.go
@@ -98,6 +98,60 @@ func TestRuleSourceReconciler_PatchOnlyFragment(t *testing.T) {
 	assert.Nil(t, deg)
 	assert.Equal(t, float64(1), gatherValidationCounter(t, reg, "skipped"))
 	assert.Equal(t, float64(0), gatherValidationCounter(t, reg, "valid"))
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_rulesource_validation_duration_seconds"),
+		"skipped outcomes must not emit validation duration histograms")
+}
+
+func TestRuleSourceReconciler_MalformedPatchOnlyFragment(t *testing.T) {
+	// Patch-only classification is syntactic; Coraza cannot validate patches in isolation.
+	// Malformed patch text still reaches Ready here; RuleSet aggregate validation is authoritative.
+	ctx := context.Background()
+	rs := utils.NewTestRuleSource("rs-ctrl-patch-bad", testNamespace,
+		`SecRuleUpdateTargetById 999999 "this is not valid patch syntax"`)
+	require.NoError(t, k8sClient.Create(ctx, rs))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rs) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	rec := &RuleSourceReconciler{Client: k8sClient, Recorder: utils.NewTestRecorder(), Metrics: m}
+	_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}})
+	require.NoError(t, err)
+
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}, rs))
+	ready := apimeta.FindStatusCondition(rs.Status.Conditions, conditionReady)
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionTrue, ready.Status)
+	assert.Equal(t, ruleSourceReadyReasonValidated, ready.Reason)
+	assert.Equal(t, float64(1), gatherValidationCounter(t, reg, "skipped"))
+	assert.Equal(t, float64(0), gatherValidationCounter(t, reg, "valid"))
+	assert.Equal(t, 0, testutil.CollectAndCount(reg, "coraza_rulesource_validation_duration_seconds"),
+		"skipped outcomes must not emit validation duration histograms")
+}
+
+func TestRuleSourceReconciler_MetricsNotIncrementedOnResync(t *testing.T) {
+	ctx := context.Background()
+	rs := utils.NewTestRuleSource("rs-ctrl-resync", testNamespace,
+		`SecRule REQUEST_URI "@contains /x" "id:1,phase:1,pass,nolog"`)
+	require.NoError(t, k8sClient.Create(ctx, rs))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, rs) })
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	rec := &RuleSourceReconciler{Client: k8sClient, Recorder: utils.NewTestRecorder(), Metrics: m}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}}
+
+	_, err = rec.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), gatherValidationCounter(t, reg, "valid"))
+
+	_, err = rec.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), gatherValidationCounter(t, reg, "valid"),
+		"second reconcile with unchanged Ready condition must not increment validation counter")
 }
 
 // TestRuleSourceReconciler_MetricsRecordOnSuccess verifies that after a

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -160,6 +160,30 @@ func TestMain(m *testing.M) {
 		_ = testEnv.Stop()
 		os.Exit(1)
 	}
+	if err := testCache.(client.FieldIndexer).IndexField(context.Background(), &wafv1alpha1.RuleSet{}, "spec.sources.name", func(obj client.Object) []string {
+		rs := obj.(*wafv1alpha1.RuleSet)
+		names := make([]string, len(rs.Spec.Sources))
+		for i, src := range rs.Spec.Sources {
+			names[i] = src.Name
+		}
+		return names
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to register RuleSet spec.sources.name index: %v\n", err)
+		_ = testEnv.Stop()
+		os.Exit(1)
+	}
+	if err := testCache.(client.FieldIndexer).IndexField(context.Background(), &wafv1alpha1.RuleSet{}, "spec.data.name", func(obj client.Object) []string {
+		rs := obj.(*wafv1alpha1.RuleSet)
+		names := make([]string, len(rs.Spec.Data))
+		for i, d := range rs.Spec.Data {
+			names[i] = d.Name
+		}
+		return names
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to register RuleSet spec.data.name index: %v\n", err)
+		_ = testEnv.Stop()
+		os.Exit(1)
+	}
 	cacheCtx, cacheCancel := context.WithCancel(context.Background())
 	cacheErrCh := make(chan error, 1)
 	go func() {

--- a/internal/rulesets/cache/auth_test.go
+++ b/internal/rulesets/cache/auth_test.go
@@ -346,10 +346,12 @@ func TestServer_HandleRules_Authentication(t *testing.T) {
 	server := NewServer(c, testServerAddr, logger, nil, fake)
 
 	t.Run("missing authorization header", func(t *testing.T) {
+		before := testutil.ToFloat64(authFailuresTotal)
 		req := httptest.NewRequest(http.MethodGet, "/rules/test-ns/my-ruleset", nil)
 		w := httptest.NewRecorder()
 		server.handleRules(w, req)
 		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Equal(t, before+1, testutil.ToFloat64(authFailuresTotal))
 	})
 
 	t.Run("invalid bearer token", func(t *testing.T) {

--- a/internal/rulesets/cache/cache.go
+++ b/internal/rulesets/cache/cache.go
@@ -78,34 +78,25 @@ func (c *RuleSetCache) SetLogger(l logr.Logger) {
 func (c *RuleSetCache) Get(instance string) (*RuleSetEntry, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	entries, ok := c.entries[instance]
-	if ok && len(entries.Entries) > 0 {
-		for _, entry := range entries.Entries {
-			if entry.UUID == entries.Latest {
-				var copiedDataFiles map[string][]byte
-				if entry.DataFiles != nil {
-					copiedDataFiles = make(map[string][]byte, len(entry.DataFiles))
-					for name, contents := range entry.DataFiles {
-						copiedDataFiles[name] = bytes.Clone(contents)
-					}
-				}
-				copiedEntry := &RuleSetEntry{
-					UUID:      entry.UUID,
-					Timestamp: entry.Timestamp,
-					Rules:     entry.Rules,
-					DataFiles: copiedDataFiles,
-				}
-				return copiedEntry, true
-			}
-		}
-		c.logger.Info("cache invariant violation: Latest UUID not found among entries",
-			"instance", instance,
-			"latestUUID", entries.Latest,
-			"entryCount", len(entries.Entries),
-		)
+
+	entry, ok := c.latestEntryLocked(instance)
+	if !ok {
+		return nil, false
 	}
 
-	return nil, false
+	var copiedDataFiles map[string][]byte
+	if entry.DataFiles != nil {
+		copiedDataFiles = make(map[string][]byte, len(entry.DataFiles))
+		for name, contents := range entry.DataFiles {
+			copiedDataFiles[name] = bytes.Clone(contents)
+		}
+	}
+	return &RuleSetEntry{
+		UUID:      entry.UUID,
+		Timestamp: entry.Timestamp,
+		Rules:     entry.Rules,
+		DataFiles: copiedDataFiles,
+	}, true
 }
 
 // Put stores rules for the given instance with a new UUID and timestamp.
@@ -193,6 +184,55 @@ func (c *RuleSetCache) TotalEntries() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.totalEntries
+}
+
+// EntryMatches reports whether the latest cached entry for instance has the same
+// rules text and data files as the candidate content. Comparison is done under
+// the read lock against immutable stored entries without copying data file bytes.
+func (c *RuleSetCache) EntryMatches(instance, rules string, dataFiles map[string][]byte) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.latestEntryLocked(instance)
+	if !ok {
+		return false
+	}
+	if entry.Rules != rules {
+		return false
+	}
+	return dataFilesEqual(entry.DataFiles, dataFiles)
+}
+
+// latestEntryLocked returns the latest revision for instance. Caller must hold c.mu.
+func (c *RuleSetCache) latestEntryLocked(instance string) (*RuleSetEntry, bool) {
+	entries, ok := c.entries[instance]
+	if !ok || len(entries.Entries) == 0 {
+		return nil, false
+	}
+	for _, entry := range entries.Entries {
+		if entry.UUID == entries.Latest {
+			return entry, true
+		}
+	}
+	c.logger.Info("cache invariant violation: Latest UUID not found among entries",
+		"instance", instance,
+		"latestUUID", entries.Latest,
+		"entryCount", len(entries.Entries),
+	)
+	return nil, false
+}
+
+func dataFilesEqual(a, b map[string][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, aData := range a {
+		bData, ok := b[name]
+		if !ok || !bytes.Equal(aData, bData) {
+			return false
+		}
+	}
+	return true
 }
 
 // CountEntries returns the number of entries for an instance.

--- a/internal/rulesets/cache/cache_test.go
+++ b/internal/rulesets/cache/cache_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -88,6 +89,39 @@ func TestRuleSetCache_PutAndGet(t *testing.T) {
 			assert.False(t, entry.Timestamp.IsZero(), "Timestamp should be set")
 		})
 	}
+}
+
+func TestRuleSetCache_EntryMatches(t *testing.T) {
+	c := NewRuleSetCache()
+	rules := `SecRule REQUEST_URI "@contains /admin" "id:1,deny"`
+	data := map[string][]byte{"words.data": []byte("admin\nroot")}
+
+	assert.False(t, c.EntryMatches("ns/rs", rules, data))
+
+	c.Put("ns/rs", rules, data)
+	assert.True(t, c.EntryMatches("ns/rs", rules, data))
+	assert.False(t, c.EntryMatches("ns/rs", rules+"\n", data))
+	assert.False(t, c.EntryMatches("ns/rs", rules, map[string][]byte{"words.data": []byte("other")}))
+	assert.False(t, c.EntryMatches("ns/other", rules, data))
+}
+
+func TestRuleSetCache_EntryMatchesNoAllocOnLargeData(t *testing.T) {
+	c := NewRuleSetCache()
+	large := make([]byte, 1<<20) // 1 MiB
+	for i := range large {
+		large[i] = byte(i)
+	}
+	data := map[string][]byte{"big.data": large}
+	rules := `SecRule ARGS "@rx ." "id:1,pass,nolog"`
+	c.Put("ns/rs", rules, data)
+
+	candidate := map[string][]byte{"big.data": bytes.Clone(large)}
+	allocs := testing.AllocsPerRun(10, func() {
+		if !c.EntryMatches("ns/rs", rules, candidate) {
+			panic("expected match")
+		}
+	})
+	assert.Zero(t, allocs, "EntryMatches must not allocate when comparing large RuleData")
 }
 
 func TestRuleSetCache_Pruning(t *testing.T) {

--- a/internal/rulesets/cache/metrics_use.go
+++ b/internal/rulesets/cache/metrics_use.go
@@ -128,6 +128,11 @@ func RegisterUSEMetrics(reg prometheus.Registerer, c *RuleSetCache, gc GarbageCo
 				return err
 			}
 		}
+		// Expose GC counters at 0 before the first prune cycle so Prometheus/Grafana
+		// can graph a zero baseline instead of "no data".
+		gcPrunedEntriesTotal.WithLabelValues(PruneReasonAge)
+		gcPrunedEntriesTotal.WithLabelValues(PruneReasonSize)
+		gcSizeLimitExceededTotal.WithLabelValues()
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Follow-up metrics fixes on top of **already-merged** #404 and #412. This PR does **not** re-land validation instrumentation — only the delta from the observability branch:

- Validation/resync guards; cache Put duration only on actual updates
- Allocation-free `EntryMatches`; RuleData watch metrics refresh
- Unsupported-rules check on annotation-only reconciles
- ServiceMonitor `honorLabels`/labeldrop; PrometheusRule alert tuning
- `hack/observability/install-promtool.sh` + CI simplification

## Follow-ups

#419, #420, #421, #422

## Test plan

- [x] `make test`
- [ ] CI green

## Note

Replaces the metrics portion of #405. Merge before #424.