### PR TITLE
feat(grafana): dashboard generator, Helm dashboards, and observability demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,19 @@ jobs:
       - name: set up go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: "tools/github_project_manager/go.mod"
+          go-version-file: "go.mod"
 
       - name: verify go module integrity
-        run: cd tools/github_project_manager && go mod verify
+        run: |
+          go mod verify
+          cd tools/github_project_manager && go mod verify
+          cd ../grafana-dashboards && go mod verify
 
       - name: run tools tests
         run: make test.tools
+
+      - name: validate grafana dashboards
+        run: make observability.dashboard.validate
 
   conformance-tests:
     name: Coreruleset conformance test

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,15 @@ KIND_CLUSTER_NAME ?= coraza-kubernetes-operator-integration
 # use openshift-gateway (match operator istio.revision) or empty for default-revision Istio.
 ISTIO_GATEWAY_REVISION ?= coraza
 ISTIO_VERSION ?= 1.28.2
-# Used by promtool in CI: make observability.promtool.install
+# Pin kube-prometheus-stack chart version (https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack).
+# Override at install time: make observability.prometheus.deploy KUBE_PROM_STACK_VERSION=x.y.z
+KUBE_PROM_STACK_VERSION ?= 86.2.3
+KUBE_PROM_STACK_RELEASE ?= kube-prometheus-stack
+MONITORING_NAMESPACE ?= monitoring
+DEMO_NAMESPACE ?= integration-tests
+GRAFANA_ADMIN_PASSWORD ?= coraza-demo
+# Matches Prometheus bundled in kube-prometheus-stack $(KUBE_PROM_STACK_VERSION).
+# Used by promtool in CI and: make observability.promtool.install
 PROM_VERSION ?= 3.12.0
 PROM_SHA256_LINUX_AMD64 ?= 20da47f8e5303f74aecb78edd7f7e39041dac08ac4939dba75efd7a900ae8867
 METALLB_VERSION ?= 0.15.3
@@ -286,6 +294,7 @@ test.e2e:
 .PHONY: test.tools
 test.tools:
 	cd tools/github_project_manager && go test -v ./...
+	cd tools/grafana-dashboards && go test -v ./...
 
 
 # -------------------------------------------------------------------------------
@@ -475,16 +484,140 @@ helm.sync: helm.sync-crds helm.sync-rbac ## Sync all generated resources into th
 helm.validate: ## Validate Helm templates render correctly for key flag combinations
 	hack/test-helm-manifests.sh
 
+.PHONY: test.metrics
+test.metrics: ## Run metrics integration tests (requires KIND cluster)
+	go clean -testcache
+	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) ISTIO_VERSION=${ISTIO_VERSION} go test -tags=integration -run TestCorazaControllerMetrics ./test/integration/... -v
+
+# -------------------------------------------------------------------------------
+# Observability demo (KIND + kube-prometheus-stack + Grafana dashboards)
+# -------------------------------------------------------------------------------
+
+.PHONY: observability.dashboard.generate
+observability.dashboard.generate: ## Regenerate Grafana dashboard JSON via Go Foundation SDK
+	cd tools/grafana-dashboards && go run ./cmd/generate
+
+.PHONY: observability.dashboard.test
+observability.dashboard.test: ## Run grafana-dashboards unit and golden tests
+	cd tools/grafana-dashboards && go test ./...
+
+.PHONY: observability.dashboard.validate
+observability.dashboard.validate: observability.dashboard.test ## Go tests + lint committed chart dashboard JSON
+	hack/observability/validate-dashboards.sh
+
 .PHONY: observability.promtool.install
 observability.promtool.install: ## Install promtool (PROM_VERSION) to INSTALL_DIR (default: GOBIN)
 	PROM_VERSION=$(PROM_VERSION) PROM_SHA256=$(PROM_SHA256_LINUX_AMD64) \
 		INSTALL_DIR=$(or $(INSTALL_DIR),$(GOBIN)) \
 		hack/observability/install-promtool.sh
 
-.PHONY: test.metrics
-test.metrics: ## Run metrics integration tests (requires KIND cluster)
-	go clean -testcache
-	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) ISTIO_VERSION=${ISTIO_VERSION} go test -tags=integration -run TestCorazaControllerMetrics ./test/integration/... -v
+.PHONY: observability.prometheus.deploy
+observability.prometheus.deploy: ## Install kube-prometheus-stack on the KIND cluster
+	@set -e; \
+	ctx="kind-$(KIND_CLUSTER_NAME)"; \
+	cfg="$(CURDIR)/config/observability"; \
+	kubectl --context "$$ctx" cluster-info >/dev/null; \
+	echo "=== Installing $(KUBE_PROM_STACK_RELEASE) ($(KUBE_PROM_STACK_VERSION)) ==="; \
+	helm --kube-context "$$ctx" repo add prometheus-community https://prometheus-community.github.io/helm-charts 2>/dev/null || true; \
+	helm --kube-context "$$ctx" repo update prometheus-community; \
+	kubectl --context "$$ctx" create namespace "$(MONITORING_NAMESPACE)" 2>/dev/null || true; \
+	helm --kube-context "$$ctx" upgrade --install "$(KUBE_PROM_STACK_RELEASE)" prometheus-community/kube-prometheus-stack \
+		--namespace "$(MONITORING_NAMESPACE)" \
+		--version "$(KUBE_PROM_STACK_VERSION)" \
+		--values "$$cfg/kube-prometheus-stack-values.yaml" \
+		--set-string grafana.adminPassword="$(GRAFANA_ADMIN_PASSWORD)" \
+		--wait --timeout 10m; \
+	kubectl --context "$$ctx" -n "$(MONITORING_NAMESPACE)" wait --for=condition=Available \
+		deployment/"$(KUBE_PROM_STACK_RELEASE)-operator" --timeout=300s; \
+	kubectl --context "$$ctx" -n "$(MONITORING_NAMESPACE)" wait --for=condition=Ready \
+		pod -l app.kubernetes.io/name=prometheus --timeout=300s; \
+	kubectl --context "$$ctx" -n "$(MONITORING_NAMESPACE)" wait --for=condition=Ready \
+		pod -l app.kubernetes.io/name=grafana --timeout=300s; \
+	sed -e "s/PLACEHOLDER_PROMETHEUS_SA/$(KUBE_PROM_STACK_RELEASE)-prometheus/g" \
+		-e "s/PLACEHOLDER_MONITORING_NS/$(MONITORING_NAMESPACE)/g" \
+		"$$cfg/prometheus-rbac.yaml" | kubectl --context "$$ctx" apply -f -
+
+.PHONY: observability.prometheus.undeploy
+observability.prometheus.undeploy: ## Remove kube-prometheus-stack from the KIND cluster
+	@set -e; \
+	ctx="kind-$(KIND_CLUSTER_NAME)"; \
+	if kubectl --context "$$ctx" cluster-info >/dev/null 2>&1; then \
+		helm --kube-context "$$ctx" uninstall "$(KUBE_PROM_STACK_RELEASE)" --namespace "$(MONITORING_NAMESPACE)" 2>/dev/null || true; \
+		kubectl --context "$$ctx" delete clusterrolebinding coraza-metrics-reader-prometheus --ignore-not-found; \
+		kubectl --context "$$ctx" delete clusterrole coraza-metrics-reader --ignore-not-found; \
+		kubectl --context "$$ctx" delete namespace "$(MONITORING_NAMESPACE)" --ignore-not-found --timeout=120s || true; \
+	fi
+
+.PHONY: observability.operator.monitoring
+observability.operator.monitoring: ## Enable ServiceMonitor, PrometheusRule, and Grafana dashboards on the operator
+	@set -e; \
+	ctx="kind-$(KIND_CLUSTER_NAME)"; \
+	kubectl --context "$$ctx" cluster-info >/dev/null; \
+	helm_extra="--reuse-values"; \
+	if ! helm --kube-context "$$ctx" status "$(HELM_RELEASE_NAME)" -n "$(HELM_RELEASE_NAMESPACE)" &>/dev/null; then \
+		helm_extra=""; \
+	fi; \
+	echo "=== Enabling operator monitoring ==="; \
+	helm --kube-context "$$ctx" upgrade --install "$(HELM_RELEASE_NAME)" "$(HELM_CHART_DIR)" \
+		--namespace "$(HELM_RELEASE_NAMESPACE)" \
+		--create-namespace \
+		$$helm_extra \
+		--set metrics.serviceMonitor.enabled=true \
+		--set metrics.serviceMonitor.additionalLabels.release="$(KUBE_PROM_STACK_RELEASE)" \
+		--set metrics.prometheusRule.enabled=true \
+		--set metrics.prometheusRule.additionalLabels.release="$(KUBE_PROM_STACK_RELEASE)" \
+		--set metrics.grafanaDashboard.enabled=true \
+		--wait --timeout 5m; \
+	kubectl --context "$$ctx" -n "$(HELM_RELEASE_NAMESPACE)" wait --for=condition=Available \
+		deployment/"$(HELM_RELEASE_NAME)" --timeout=300s
+
+.PHONY: observability.demo.workload
+observability.demo.workload: ## Apply demo CRs and seed traffic for dashboard metrics
+	@set -e; \
+	ctx="kind-$(KIND_CLUSTER_NAME)"; \
+	kubectl --context "$$ctx" cluster-info >/dev/null; \
+	echo "=== Applying demo workload (config/samples) to $(DEMO_NAMESPACE) ==="; \
+	kubectl --context "$$ctx" create namespace "$(DEMO_NAMESPACE)" 2>/dev/null || true; \
+	kubectl --context "$$ctx" apply -n "$(DEMO_NAMESPACE)" -k "$(CURDIR)/config/samples"; \
+	kubectl --context "$$ctx" -n "$(DEMO_NAMESPACE)" wait --for=condition=Available \
+		deployment/echo --timeout=300s; \
+	echo "=== Waiting for Engine Ready ==="; \
+	ready=""; \
+	deadline=$$(($$(date +%s) + 300)); \
+	while [ "$$(date +%s)" -lt "$$deadline" ]; do \
+		ready=$$(kubectl --context "$$ctx" -n "$(DEMO_NAMESPACE)" get engine coraza \
+			-o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true); \
+		if [ "$$ready" = "True" ]; then echo "Engine coraza is Ready"; break; fi; \
+		sleep 5; \
+	done; \
+	if [ "$$ready" != "True" ]; then echo "ERROR: Engine coraza not Ready within timeout" >&2; exit 1; fi; \
+	echo "=== Waiting for RuleSet Ready ==="; \
+	if ! kubectl --context "$$ctx" -n "$(DEMO_NAMESPACE)" wait --for=condition=Ready \
+		ruleset/default-ruleset --timeout=300s 2>/dev/null; then \
+		echo "ERROR: RuleSet default-ruleset not Ready within timeout" >&2; exit 1; \
+	fi
+	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) DEMO_NAMESPACE=$(DEMO_NAMESPACE) \
+		hack/observability/seed-traffic.sh
+
+.PHONY: observability.demo
+observability.demo: observability.prometheus.deploy observability.operator.monitoring observability.demo.workload observability.grafana.url ## Full observability demo on existing KIND cluster
+
+.PHONY: observability.grafana.port-forward
+observability.grafana.port-forward: ## Port-forward Grafana to http://localhost:3000
+	@echo "Grafana: http://localhost:3000 (admin / $(GRAFANA_ADMIN_PASSWORD))"
+	@echo "Press Ctrl+C to stop."
+	kubectl --context kind-$(KIND_CLUSTER_NAME) -n $(MONITORING_NAMESPACE) \
+		port-forward svc/$(KUBE_PROM_STACK_RELEASE)-grafana 3000:80
+
+.PHONY: observability.grafana.url
+observability.grafana.url: ## Print Grafana URL, credentials, and dashboard links
+	@echo "Grafana (port-forward):  make observability.grafana.port-forward"
+	@echo "URL:      http://localhost:3000"
+	@echo "User:     admin"
+	@echo "Password: $(GRAFANA_ADMIN_PASSWORD)"
+	@echo "Dashboards (folder: Coraza WAF):"
+	@echo "  - Coraza Operator — Overview:   /d/coraza-operator-overview"
+	@echo "  - Coraza Operator — Resources:  /d/coraza-operator-resources"
 
 # -------------------------------------------------------------------------------
 # Documentation

--- a/charts/coraza-kubernetes-operator/README.md
+++ b/charts/coraza-kubernetes-operator/README.md
@@ -61,6 +61,10 @@ When `openshift.enabled=true`, `runAsUser`, `fsGroup`, and `fsGroupChangePolicy`
 | `metrics.keyName`                                     | string | `tls.key`                                                 | Key name of the private key file inside `certSecret`                                                        |
 | `metrics.caName`                                      | string | `""`                                                      | Key name of a CA certificate inside `certSecret` for ServiceMonitor TLS verification                        |
 | `metrics.serviceMonitor.enabled`                      | bool   | `false`                                                   | Create a ServiceMonitor resource                                                                            |
+| `metrics.serviceMonitor.additionalLabels`             | object | `{}`                                                      | Extra labels on ServiceMonitor metadata (e.g. `release: kube-prometheus-stack`)                             |
+| `metrics.prometheusRule.enabled`                      | bool   | `false`                                                   | Create PrometheusRule alerting and recording rules                                                            |
+| `metrics.grafanaDashboard.enabled`                    | bool   | `false`                                                   | Create ConfigMap(s) with Grafana dashboard JSON for sidecar provisioning                                     |
+| `metrics.grafanaDashboard.folder`                     | string | `Coraza WAF`                                              | Grafana folder annotation on dashboard ConfigMaps                                                           |
 | `logging.development`                                 | bool   | `false`                                                   | Use console encoder with debug level (dev mode); when false, production flags below apply                   |
 | `logging.encoder`                                     | string | `json`                                                    | Log encoding format (`json` or `console`). Only used when `development=false`                               |
 | `logging.level`                                       | string | `info`                                                    | Minimum log level (`debug`, `info`, `error`). Only used when `development=false`                            |
@@ -123,3 +127,13 @@ subjects:
     name: prometheus  # adjust to your Prometheus SA
     namespace: monitoring
 ```
+
+### Grafana dashboards
+
+When `metrics.grafanaDashboard.enabled=true` **and** `metrics.prometheusRule.enabled=true`,
+the chart deploys ConfigMaps labeled `grafana_dashboard=1` containing **Coraza Operator —
+Overview** and **Coraza Operator — Resources** dashboards. Health summary panels query
+recording rules from the chart PrometheusRule; enabling dashboards without PrometheusRule
+is not supported. Compatible with the kube-prometheus-stack Grafana sidecar.
+
+See [Observability demo on KIND](https://github.com/networking-incubator/coraza-kubernetes-operator/blob/main/docs/content/howto/observability-demo.md) for a local walkthrough.

--- a/charts/coraza-kubernetes-operator/dashboards/coraza-operator-overview.json
+++ b/charts/coraza-kubernetes-operator/dashboards/coraza-operator-overview.json
@@ -1,0 +1,2313 @@
+{
+  "uid": "coraza-operator-overview",
+  "title": "Coraza Operator — Overview",
+  "tags": [
+    "coraza",
+    "operator",
+    "control-plane",
+    "waf"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "fiscalYearStartMonth": 0,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "version": 1,
+  "panels": [
+    {
+      "type": "text",
+      "id": 1,
+      "title": "",
+      "transparent": false,
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "repeatDirection": "h",
+      "options": {
+        "mode": "markdown",
+        "content": "Control-plane health for the Coraza Kubernetes Operator. Use **Resource drill-down** (top-right link) for per-CR troubleshooting. Alerts are defined in the Helm `PrometheusRule` when enabled."
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Health summary",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 3,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza:engines_not_ready:count",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Engines not ready",
+      "description": "Recording rule from PrometheusRule. Count of Engines where Ready != True.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": ""
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "id": 4,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza:rulesets_not_ready:count",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RuleSets not ready",
+      "description": "Recording rule from PrometheusRule.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 4
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": ""
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "id": 5,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza:rulesources_degraded:count",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RuleSources degraded",
+      "description": "Recording rule from PrometheusRule. RuleSources in Degraded condition.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 4
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": ""
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "yellow"
+              },
+              {
+                "value": 2,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "id": 6,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "(sum(rate(controller_runtime_reconcile_errors_total{controller=~\"ruleset|engine|rulesource\"}[5m])) / sum(rate(controller_runtime_reconcile_total{controller=~\"ruleset|engine|rulesource\"}[5m]))) and sum(rate(controller_runtime_reconcile_total{controller=~\"ruleset|engine|rulesource\"}[5m])) \u003e 0",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile error ratio",
+      "description": "Ratio of reconcile errors to total reconciles (5m rate).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 4
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": ""
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 0.01,
+                "color": "yellow"
+              },
+              {
+                "value": 0.1,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "id": 7,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "(coraza_cache_size_bytes / coraza_cache_config_max_size_bytes) and coraza_cache_config_max_size_bytes \u003e 0",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache utilization",
+      "description": "Cache size vs configured maximum.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 4
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": ""
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 0.7,
+                "color": "yellow"
+              },
+              {
+                "value": 0.9,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "id": 8,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza:cache_hit_ratio:rate5m",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache hit ratio",
+      "description": "Recording rule: 200s / (200s + 404s) over 5m. Shows no data when there is no cache traffic.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "repeatDirection": "h",
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "showPercentChange": false,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "percentChangeColorMode": "standard",
+        "orientation": ""
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "red"
+              },
+              {
+                "value": 0.5,
+                "color": "yellow"
+              },
+              {
+                "value": 0.8,
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Reconciliation",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 9,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 10,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (controller, result) (rate(controller_runtime_reconcile_total{controller=~\"ruleset|engine|rulesource\"}[5m]))",
+          "instant": false,
+          "legendFormat": "{{controller}} {{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile rate",
+      "description": "Reconciles per second by controller and result.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 11,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (controller) (rate(controller_runtime_reconcile_errors_total{controller=~\"ruleset|engine|rulesource\"}[5m]))",
+          "instant": false,
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile errors",
+      "description": "",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 12,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket{controller=~\"ruleset|engine|rulesource\"}[5m])))",
+          "instant": false,
+          "legendFormat": "{{controller}} p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket{controller=~\"ruleset|engine|rulesource\"}[5m])))",
+          "instant": false,
+          "legendFormat": "{{controller}} p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Reconcile duration p99",
+      "description": "",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 13,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "workqueue_depth{name=~\"ruleset|engine|rulesource\"}",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue depth",
+      "description": "",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Validation",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 14,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 15,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (outcome) (rate(coraza_rulesource_validations_total[5m]))",
+          "instant": false,
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RuleSource validation rate",
+      "description": "RuleSource validations per second by outcome (valid=Coraza parse succeeded, invalid=parse failed, skipped=annotation or patch-only).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 16,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (outcome) (rate(coraza_ruleset_validations_total[5m]))",
+          "instant": false,
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RuleSet validation rate",
+      "description": "RuleSet aggregate validations per second (valid=Coraza parse succeeded; does not imply Ready).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 17,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, outcome) (rate(coraza_rulesource_validation_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{outcome}} p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, outcome) (rate(coraza_rulesource_validation_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{outcome}} p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "RuleSource validation duration",
+      "description": "RuleSource validation latency by outcome.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 18,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, outcome) (rate(coraza_ruleset_validation_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{outcome}} p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, outcome) (rate(coraza_ruleset_validation_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{outcome}} p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "RuleSet validation duration",
+      "description": "RuleSet aggregate validation latency by outcome.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Cache server — RED",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 19,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 20,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (handler, code) (rate(coraza_cache_server_requests_total[5m]))",
+          "instant": false,
+          "legendFormat": "{{handler}} {{code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate",
+      "description": "",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 21,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(coraza_cache_server_requests_total{code=~\"5..\"}[5m]))",
+          "instant": false,
+          "legendFormat": "5xx",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(coraza_cache_server_auth_failures_total[5m])",
+          "instant": false,
+          "legendFormat": "auth failures",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Errors \u0026 auth failures",
+      "description": "Cache server 5xx error rate and authentication failure rate.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 22,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, handler) (rate(coraza_cache_server_request_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{handler}} p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, handler) (rate(coraza_cache_server_request_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{handler}} p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Request latency",
+      "description": "",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 23,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_cache_server_in_flight_requests",
+          "instant": false,
+          "legendFormat": "{{handler}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "In-flight requests",
+      "description": "",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Cache server — USE",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 24,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 25,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_cache_size_bytes",
+          "instant": false,
+          "legendFormat": "size",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_cache_config_max_size_bytes",
+          "instant": false,
+          "legendFormat": "max",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Cache size vs limit",
+      "description": "RuleSet cache payload size vs configured maximum (always emitted by the operator).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 26,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (reason) (rate(coraza_cache_gc_pruned_entries_total[15m]))",
+          "instant": false,
+          "legendFormat": "{{reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GC prune rate",
+      "description": "Entries pruned per second by reason (age/size). Flat at zero until GC runs.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 27,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_cache_instances",
+          "instant": false,
+          "legendFormat": "instances",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_cache_total_entries",
+          "instant": false,
+          "legendFormat": "entries",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Cache instances \u0026 entries",
+      "description": "Distinct cache keys and total stored revisions.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 28,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, namespace) (rate(coraza_cache_set_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{namespace}} p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, namespace) (rate(coraza_cache_set_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{namespace}} p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Cache Put duration",
+      "description": "Latency of RuleSet cache Put operations after successful validation.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 65
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Kubernetes API \u0026 workqueue",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 72
+      },
+      "id": 29,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 30,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (verb, resource) (rate(rest_client_requests_total[5m]))",
+          "instant": false,
+          "legendFormat": "{{verb}} {{resource}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "API request rate",
+      "description": "Kubernetes API request rate by verb and resource (from client-go).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 73
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 31,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (code) (rate(rest_client_requests_total{code!~\"2..\"}[5m]))",
+          "instant": false,
+          "legendFormat": "{{code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "API errors (non-2xx)",
+      "description": "Non-success API responses by status code.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 73
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 32,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, verb) (rate(rest_client_request_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{verb}} p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le, verb) (rate(rest_client_request_duration_seconds_bucket[5m])))",
+          "instant": false,
+          "legendFormat": "{{verb}} p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "API request latency p99",
+      "description": "Kubernetes API call latency by verb.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 81
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 33,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (name) (rate(workqueue_retries_total{name=~\"ruleset|engine|rulesource\"}[5m]))",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue retries",
+      "description": "Workqueue retry rate per controller.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 81
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 34,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "workqueue_longest_running_processor_seconds{name=~\"ruleset|engine|rulesource\"}",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Longest running processor",
+      "description": "Duration of the longest currently-running reconcile per controller.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 89
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 35,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "workqueue_unfinished_work_seconds{name=~\"ruleset|engine|rulesource\"}",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unfinished work",
+      "description": "Total seconds of unfinished work in the queue per controller.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 89
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Resource counts by namespace",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 96
+      },
+      "id": 36,
+      "panels": []
+    },
+    {
+      "type": "table",
+      "id": 37,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_engines",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Engines",
+      "description": "Current per-namespace engine count (instant; empty when zero).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 97
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "Value": 1,
+              "namespace": 0
+            },
+            "renameByName": {
+              "Value": "Count"
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "sortBy": [
+          {
+            "displayName": "namespace",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "table",
+      "id": 38,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_rulesets",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "RuleSets",
+      "description": "Current per-namespace ruleset count (instant; empty when zero).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 97
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "Value": 1,
+              "namespace": 0
+            },
+            "renameByName": {
+              "Value": "Count"
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "sortBy": [
+          {
+            "displayName": "namespace",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "table",
+      "id": 39,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_rulesources",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "RuleSources",
+      "description": "Current per-namespace rulesource count (instant; empty when zero).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 103
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "Value": 1,
+              "namespace": 0
+            },
+            "renameByName": {
+              "Value": "Count"
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "sortBy": [
+          {
+            "displayName": "namespace",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "table",
+      "id": 40,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_ruledatas",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "RuleData",
+      "description": "Current per-namespace ruledata count (instant; empty when zero).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 103
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {
+              "Value": 1,
+              "namespace": 0
+            },
+            "renameByName": {
+              "Value": "Count"
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "sortBy": [
+          {
+            "displayName": "namespace",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "type": "datasource",
+        "name": "DS_PROMETHEUS",
+        "label": "Datasource",
+        "skipUrlSync": false,
+        "query": "prometheus",
+        "multi": false,
+        "allowCustomValue": true,
+        "includeAll": false,
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "Annotations \u0026 Alerts",
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "type": "dashboard",
+        "builtIn": 1,
+        "placement": "inControlsMenu"
+      }
+    ]
+  },
+  "links": [
+    {
+      "title": "Resource drill-down",
+      "type": "link",
+      "icon": "external link",
+      "tooltip": "",
+      "url": "/d/coraza-operator-resources/coraza-operator-resources?${__url_time_range}",
+      "tags": [],
+      "asDropdown": false,
+      "placement": "inControlsMenu",
+      "targetBlank": false,
+      "includeVars": false,
+      "keepTime": false
+    }
+  ]
+}

--- a/charts/coraza-kubernetes-operator/dashboards/coraza-operator-resources.json
+++ b/charts/coraza-kubernetes-operator/dashboards/coraza-operator-resources.json
@@ -1,0 +1,1450 @@
+{
+  "uid": "coraza-operator-resources",
+  "title": "Coraza Operator — Resources",
+  "tags": [
+    "coraza",
+    "operator",
+    "control-plane",
+    "waf"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "fiscalYearStartMonth": 0,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "version": 1,
+  "panels": [
+    {
+      "type": "text",
+      "id": 1,
+      "title": "",
+      "transparent": false,
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "repeatDirection": "h",
+      "options": {
+        "mode": "markdown",
+        "content": "Drill-down for Coraza CRs. Pick **Namespace** to scope all tables below. Each table row is one resource (`namespace/name`). **Engine** / **RuleSet** dropdowns optionally narrow the **Engine details** panel only. Condition and composition tables always list every resource in the namespace."
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Selected Engine",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "panels": []
+    },
+    {
+      "type": "table",
+      "id": 3,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "label_join(coraza_engine_condition{namespace=~\"$namespace\", condition=~\"Ready|Progressing|Degraded|Accepted\"}, \"resource\", \"/\", \"namespace\", \"name\")",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Engine conditions",
+      "description": "One row per Engine in the selected namespace(s).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "condition",
+            "emptyValue": "null",
+            "rowField": "resource",
+            "valueField": "Value"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "resource\\\\condition",
+            "renamePattern": "Resource"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Accepted": 4,
+              "Degraded": 3,
+              "Progressing": 2,
+              "Ready": 1,
+              "Resource": 0
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "sortBy": [
+          {
+            "displayName": "Resource",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Ready"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "Absent",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Progressing"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "No",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Degraded"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "No",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accepted"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "Absent",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "table",
+      "id": 4,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_engine_info{namespace=~\"$namespace\", name=~\"$engine\", ruleset_name=~\"$ruleset\"}",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Engine details",
+      "description": "Engine metadata (filtered by Engine and RuleSet dropdowns; set All to list every engine).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "RuleSets in namespace",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "panels": []
+    },
+    {
+      "type": "table",
+      "id": 6,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "label_join(coraza_ruleset_condition{namespace=~\"$namespace\", condition=~\"Ready|Progressing|Degraded\"}, \"resource\", \"/\", \"namespace\", \"name\")",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "RuleSet conditions",
+      "description": "One row per RuleSet in the selected namespace(s).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "condition",
+            "emptyValue": "null",
+            "rowField": "resource",
+            "valueField": "Value"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "resource\\\\condition",
+            "renamePattern": "Resource"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Degraded": 3,
+              "Progressing": 2,
+              "Ready": 1,
+              "Resource": 0
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "sortBy": [
+          {
+            "displayName": "Resource",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Ready"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "Absent",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Progressing"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "No",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Degraded"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "No",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "table",
+      "id": 7,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_ruleset_sources{namespace=~\"$namespace\"}",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "coraza_ruleset_data_files{namespace=~\"$namespace\"}",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "RuleSet composition",
+      "description": "RuleSource and RuleData reference counts per RuleSet.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Value #A": 2,
+              "Value #B": 3,
+              "name": 1,
+              "namespace": 0
+            },
+            "renameByName": {
+              "Value #A": "Sources",
+              "Value #B": "Data files"
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "sortBy": [
+          {
+            "displayName": "namespace",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Namespace inventory — Engines",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 8,
+      "panels": []
+    },
+    {
+      "type": "table",
+      "id": 9,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "label_join(coraza_engine_condition{namespace=~\"$namespace\", condition=~\"Ready|Degraded\"}, \"resource\", \"/\", \"namespace\", \"name\")",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Engines in namespace",
+      "description": "Ready and Degraded condition values per engine (namespace/name).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "condition",
+            "emptyValue": "null",
+            "rowField": "resource",
+            "valueField": "Value"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "resource\\\\condition",
+            "renamePattern": "Resource"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Degraded": 2,
+              "Ready": 1,
+              "Resource": 0
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "sortBy": [
+          {
+            "displayName": "Resource",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Ready"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "Absent",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Degraded"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "No",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Namespace inventory — RuleSources",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 10,
+      "panels": []
+    },
+    {
+      "type": "table",
+      "id": 11,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "label_join(coraza_rulesource_condition{namespace=~\"$namespace\", condition=~\"Ready|Degraded\"}, \"resource\", \"/\", \"namespace\", \"name\")",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "RuleSources",
+      "description": "",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "repeatDirection": "h",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "condition",
+            "emptyValue": "null",
+            "rowField": "resource",
+            "valueField": "Value"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "resource\\\\condition",
+            "renamePattern": "Resource"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Degraded": 2,
+              "Ready": 1,
+              "Resource": 0
+            }
+          }
+        }
+      ],
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "showTypeIcons": false,
+        "sortBy": [
+          {
+            "displayName": "Resource",
+            "desc": false
+          }
+        ],
+        "footer": {
+          "show": false,
+          "reducer": []
+        },
+        "cellHeight": "sm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Ready"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "Absent",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Degraded"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": {
+                  "type": "value",
+                  "options": {
+                    "-1": {
+                      "text": "No",
+                      "index": 0
+                    },
+                    "0": {
+                      "text": "False",
+                      "index": 1
+                    },
+                    "1": {
+                      "text": "True",
+                      "index": 2
+                    }
+                  }
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "row",
+      "collapsed": false,
+      "title": "Operator-wide activity",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 12,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 13,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (controller, result) (rate(controller_runtime_reconcile_total{controller=~\"ruleset|engine|rulesource\"}[5m]))",
+          "instant": false,
+          "legendFormat": "{{controller}} {{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile rate (all controllers)",
+      "description": "Operator-wide; not filtered by namespace variable.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 14,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (handler) (rate(coraza_cache_server_requests_total[5m]))",
+          "instant": false,
+          "legendFormat": "{{handler}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache request rate",
+      "description": "Cache is operator-scoped; keys are ruleset namespace/name.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "axisSoftMin": 0,
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "type": "datasource",
+        "name": "DS_PROMETHEUS",
+        "label": "Datasource",
+        "skipUrlSync": false,
+        "query": "prometheus",
+        "multi": false,
+        "allowCustomValue": true,
+        "includeAll": false,
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30
+      },
+      {
+        "type": "query",
+        "name": "namespace",
+        "label": "Namespace",
+        "skipUrlSync": false,
+        "query": {
+          "query": "label_values({__name__=~\"coraza_(engines|rulesets|rulesources|ruledatas|engine_info|ruleset_info|rulesource_info|ruledata_info)\"}, namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "multi": true,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30,
+        "definition": "label_values({__name__=~\"coraza_(engines|rulesets|rulesources|ruledatas|engine_info|ruleset_info|rulesource_info|ruledata_info)\"}, namespace)"
+      },
+      {
+        "type": "query",
+        "name": "engine",
+        "label": "Engine",
+        "skipUrlSync": false,
+        "query": {
+          "query": "label_values(coraza_engine_info{namespace=~\"$namespace\"}, name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "multi": true,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30,
+        "definition": "label_values(coraza_engine_info{namespace=~\"$namespace\"}, name)"
+      },
+      {
+        "type": "query",
+        "name": "ruleset",
+        "label": "RuleSet",
+        "skipUrlSync": false,
+        "query": {
+          "query": "label_values(coraza_ruleset_info{namespace=~\"$namespace\"}, name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "multi": true,
+        "allowCustomValue": true,
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "auto": false,
+        "auto_min": "10s",
+        "auto_count": 30,
+        "definition": "label_values(coraza_ruleset_info{namespace=~\"$namespace\"}, name)"
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "Annotations \u0026 Alerts",
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "type": "dashboard",
+        "builtIn": 1,
+        "placement": "inControlsMenu"
+      }
+    ]
+  },
+  "links": [
+    {
+      "title": "Overview",
+      "type": "link",
+      "icon": "dashboard",
+      "tooltip": "",
+      "url": "/d/coraza-operator-overview/coraza-operator-overview?${__url_time_range}",
+      "tags": [],
+      "asDropdown": false,
+      "placement": "inControlsMenu",
+      "targetBlank": false,
+      "includeVars": false,
+      "keepTime": false
+    }
+  ]
+}

--- a/charts/coraza-kubernetes-operator/templates/grafana-dashboard-configmap.yaml
+++ b/charts/coraza-kubernetes-operator/templates/grafana-dashboard-configmap.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.metrics.enabled .Values.metrics.grafanaDashboard.enabled .Values.metrics.prometheusRule.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "coraza-operator.fullname" . }}-dashboards
+  namespace: {{ .Release.Namespace }}
+  labels:
+    grafana_dashboard: "1"
+    {{- include "coraza-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.grafanaDashboard.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    grafana_folder: {{ .Values.metrics.grafanaDashboard.folder | quote }}
+data:
+{{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+  {{ base $path }}: |
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/coraza-kubernetes-operator/values.yaml
+++ b/charts/coraza-kubernetes-operator/values.yaml
@@ -35,6 +35,10 @@ metrics:
   caName: ""
   serviceMonitor:
     enabled: false
+    # Labels merged into ServiceMonitor metadata.labels.
+    # Use this to match your Prometheus instance's serviceMonitorSelector.
+    # Example: additionalLabels: {release: kube-prometheus-stack}
+    additionalLabels: {}
     # Additional metric relabelings applied to scraped samples.
     # See docs/content/reference/metrics-cardinality.md for worked examples and a full
     # cardinality budget analysis.
@@ -53,7 +57,7 @@ metrics:
     enabled: false
     # Labels merged into PrometheusRule metadata.labels.
     # Use this to match your Prometheus instance's ruleSelector.
-    # Example: additionalLabels: {release: prometheus}
+    # Example: additionalLabels: {release: kube-prometheus-stack}
     additionalLabels: {}
     # Additional alerting rules appended after the default rules.
     rules: []
@@ -73,7 +77,7 @@ metrics:
     gatewaySelector: {}
     # Labels merged into PodMonitor metadata.labels.
     # Use this to match your Prometheus instance's podMonitorSelector.
-    # Example: additionalLabels: {release: prometheus}
+    # Example: additionalLabels: {release: kube-prometheus-stack}
     additionalLabels: {}
     # Port name on Gateway pods that exposes Envoy stats.
     # Default is the Istio convention; override for non-Istio service meshes.
@@ -81,6 +85,17 @@ metrics:
     # Additional metricRelabelings appended AFTER the mandatory cardinality guard.
     # The guard (keep only coraza_waf_.*) is always enforced first.
     metricRelabelings: []
+  grafanaDashboard:
+    # When true, deploys ConfigMap(s) containing Grafana dashboard JSON for the
+    # kube-prometheus-stack (or compatible) Grafana dashboard sidecar.
+    # Requires metrics.prometheusRule.enabled=true (health panels query recording
+    # rules from the chart PrometheusRule) and a Grafana instance watching
+    # ConfigMaps labeled grafana_dashboard=1.
+    enabled: false
+    # Folder name written to the grafana_folder ConfigMap annotation.
+    folder: "Coraza WAF"
+    # Labels merged into dashboard ConfigMap metadata.labels (in addition to grafana_dashboard).
+    additionalLabels: {}
 
 logging:
   # When true, uses console encoder with debug level (development mode).

--- a/config/observability/README.md
+++ b/config/observability/README.md
@@ -1,0 +1,10 @@
+# Local observability stack (KIND demo)
+
+Static config for the optional Prometheus/Grafana layer used by `make observability.demo`.
+
+| File | Purpose |
+|------|---------|
+| `kube-prometheus-stack-values.yaml` | Helm values for [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) |
+| `prometheus-rbac.yaml` | Lets Prometheus scrape the operator's authenticated `/metrics` endpoint |
+
+Orchestration: `make observability.demo` (all steps are Makefile targets; traffic seeding uses `hack/observability/seed-traffic.sh`).

--- a/config/observability/kube-prometheus-stack-values.yaml
+++ b/config/observability/kube-prometheus-stack-values.yaml
@@ -1,0 +1,53 @@
+# kube-prometheus-stack values tuned for local KIND demo clusters.
+# Chart version is pinned in the Makefile (KUBE_PROM_STACK_VERSION, default 86.2.3).
+# Installed by: make observability.prometheus.deploy
+
+prometheus:
+  prometheusSpec:
+    # Discover ServiceMonitors and PrometheusRules in all namespaces.
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorNamespaceSelector: {}
+    ruleSelectorNilUsesHelmValues: false
+    ruleNamespaceSelector: {}
+    retention: 2d
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 2Gi
+
+grafana:
+  # adminPassword is set by make observability.prometheus.deploy (GRAFANA_ADMIN_PASSWORD).
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      labelValue: "1"
+      searchNamespace: ALL
+      folderAnnotation: grafana_folder
+      provider:
+        foldersFromFilesStructure: true
+    datasources:
+      enabled: true
+      defaultDatasourceEnabled: true
+
+alertmanager:
+  enabled: true
+
+kubeStateMetrics:
+  enabled: true
+
+nodeExporter:
+  enabled: true
+
+# Reduce footprint on single-node KIND clusters.
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+defaultRules:
+  create: true

--- a/config/observability/prometheus-rbac.yaml
+++ b/config/observability/prometheus-rbac.yaml
@@ -1,0 +1,25 @@
+# Grants the kube-prometheus-stack Prometheus ServiceAccount permission to
+# scrape the Coraza operator's authenticated HTTPS /metrics endpoint.
+#
+# Applied by make observability.prometheus.deploy after the Helm release creates
+# the Prometheus ServiceAccount. Subject name/namespace are patched at apply time.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coraza-metrics-reader
+rules:
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coraza-metrics-reader-prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coraza-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: PLACEHOLDER_PROMETHEUS_SA
+    namespace: PLACEHOLDER_MONITORING_NS

--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -9,9 +9,10 @@ Kubernetes Gateway API and Istio.
 |------|-------------|
 | `ruleset.yaml` | `RuleSource` (SecLang rules), `RuleData` (`@pmFromFile` data files), and a `RuleSet` referencing them via `spec.sources` and `spec.data` |
 | `engine.yaml` | `Engine` CR that references the RuleSet and targets an Istio Gateway (`spec.driver.wasm.image` is optional) |
-| `gateway.yaml` | Kubernetes Gateway API `Gateway` using the Istio gateway class |
+| `gateway.yaml` | Kubernetes Gateway API `Gateway` using the Istio gateway class (**not** in `kustomization.yaml`; apply separately on generic clusters) |
 | `httproute.yaml` | `HTTPRoute` that sends all traffic through the gateway to the echo service |
 | `echo.yaml` | A simple echo Deployment and Service to act as the backend |
+| `kustomization.yaml` | Kustomize bundle of workload manifests (`ruleset`, `engine`, `echo`, `httproute`); excludes `gateway.yaml` |
 
 ## Prerequisites
 
@@ -22,9 +23,21 @@ Kubernetes Gateway API and Istio.
 
 All samples must be deployed to the same namespace.
 
+On a generic cluster, create the Gateway first, then apply the Kustomize bundle:
+
 ```bash
-kubectl apply -f config/samples/
+kubectl apply -f config/samples/gateway.yaml
+kubectl apply -k config/samples/
 ```
+
+For the KIND integration cluster (`make cluster.kind`), the Gateway is created automatically in `integration-tests`.
+Apply only the workload bundle:
+
+```bash
+kubectl apply -n integration-tests -k config/samples/
+```
+
+This is also what `make observability.demo.workload` uses.
 
 ## Test
 
@@ -48,5 +61,8 @@ kubectl logs deploy/coraza-gateway-istio
 ## Cleanup
 
 ```bash
-kubectl delete -f config/samples/
+kubectl delete -k config/samples/
+kubectl delete -f config/samples/gateway.yaml   # only if you applied gateway.yaml above
 ```
+
+On the KIND integration cluster, omit the `gateway.yaml` delete; the Gateway is owned by `make cluster.kind`.

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,0 +1,9 @@
+# Workload samples (excludes gateway.yaml — KIND creates coraza-gateway via make cluster.kind).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ruleset.yaml
+  - engine.yaml
+  - echo.yaml
+  - httproute.yaml

--- a/docs/content/howto/_index.md
+++ b/docs/content/howto/_index.md
@@ -26,4 +26,5 @@ How-to guides address specific tasks. Unlike tutorials, they assume you already 
 ## Operations
 
 - [Monitoring with Prometheus]({{< relref "monitoring-prometheus" >}})
+- [Observability demo on KIND]({{< relref "observability-demo" >}})
 - [Upgrading the Operator]({{< relref "upgrading" >}})

--- a/docs/content/howto/observability-demo.md
+++ b/docs/content/howto/observability-demo.md
@@ -1,0 +1,218 @@
+---
+title: "Observability demo on KIND"
+linkTitle: "Observability demo"
+weight: 46
+description: "Run Prometheus, Grafana, and Coraza control-plane dashboards on a local KIND cluster."
+---
+
+This guide walks through the local observability demo: Prometheus Operator, Grafana,
+Coraza operator metrics scraping, and the bundled control-plane dashboards.
+
+## Prerequisites
+
+- Docker (or Podman where supported by KIND)
+- `kubectl`, `helm`, `kind`, `curl`, `go`, `jq`
+- A completed [KIND cluster setup]({{< relref "install-kubernetes-helm" >}}) via `make cluster.kind`
+
+The observability demo **does not** recreate the KIND cluster. It layers monitoring on
+top of an existing cluster.
+
+## Quick start
+
+```bash
+# 1. Create the KIND cluster (Istio, Gateway, operator) — unchanged from other guides
+make cluster.kind
+
+# 2. Deploy Prometheus, enable operator monitoring, seed demo workload
+make observability.demo
+
+# 3. Open Grafana (port-forward)
+make observability.grafana.port-forward
+```
+
+Open [http://localhost:3000](http://localhost:3000):
+
+| Field | Value |
+|-------|-------|
+| User | `admin` |
+| Password | `coraza-demo` (demo only — change in production) |
+
+Dashboards appear under folder **Coraza WAF**:
+
+- **Coraza Operator — Overview** — health summary, validation rates/latency, reconciliation, cache RED/USE, Kubernetes API & workqueue
+- **Coraza Operator — Resources** — per-namespace CR drill-down with condition tables
+
+Run `make observability.grafana.url` to print credentials and dashboard UIDs.
+
+### Overview dashboard sections
+
+| Section | What to look for |
+|---------|------------------|
+| Health summary | Recording-rule stats (engines/rulesets not ready, cache hit ratio). **Cache hit ratio** shows no data when Envoy is not polling the cache (idle). |
+| Validation | `coraza_*_validations_total` rates and latency — spikes on bad rule edits |
+| Cache RED / USE | Request rates, auth failures, size vs limit, cache Put duration |
+| Kubernetes API & workqueue | `rest_client_*` pressure and controller queue retries |
+
+## What `make observability.demo` does
+
+1. **`observability.prometheus.deploy`** — installs [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) in `monitoring`, configures Grafana dashboard sidecar (`searchNamespace: ALL`), and grants Prometheus RBAC to scrape the operator's authenticated `/metrics` endpoint.
+2. **`observability.operator.monitoring`** — Helm upgrade enabling `metrics.serviceMonitor`, `metrics.prometheusRule`, and `metrics.grafanaDashboard` with labels matching the Prometheus release.
+3. **`observability.demo.workload`** — applies `config/samples` into `integration-tests` and sends HTTP traffic through `coraza-gateway` to populate cache and CR metrics.
+
+Prometheus/Grafana config: `config/observability/`. Demo orchestration is `make observability.*`; only traffic seeding uses `hack/observability/seed-traffic.sh`.
+
+## Production deployment
+
+For production clusters with an existing Prometheus Operator installation:
+
+```yaml
+metrics:
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      release: kube-prometheus-stack   # match your Prometheus release label
+  prometheusRule:
+    enabled: true
+    additionalLabels:
+      release: kube-prometheus-stack
+  grafanaDashboard:
+    enabled: true
+    folder: "Coraza WAF"
+```
+
+Ensure Prometheus can authenticate to `/metrics` — see [Monitoring with Prometheus]({{< relref "monitoring-prometheus" >}}).
+
+Import dashboards manually by copying JSON from
+`charts/coraza-kubernetes-operator/dashboards/` if you do not use the Grafana sidecar.
+
+## Simulating alerts (manual)
+
+The demo script does **not** intentionally degrade resources. To exercise
+`PrometheusRule` alerts, validation metrics, and red overview stats manually:
+
+### Validation metrics (Overview → Validation)
+
+Apply a RuleSource with invalid SecLang syntax:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: waf.k8s.coraza.io/v1alpha1
+kind: RuleSource
+metadata:
+  name: bad-rules
+  namespace: integration-tests
+spec:
+  rules: |
+    SecDefaultActionXPTO "INVALID"
+EOF
+```
+
+Within one or two scrape intervals, **RuleSource validation rate** should show an
+`invalid` series and **RuleSources degraded** in the health row should rise.
+Delete the object to clear the signal:
+
+```bash
+kubectl delete rulesource bad-rules -n integration-tests
+```
+
+### CorazaEngineNotReady
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: waf.k8s.coraza.io/v1alpha1
+kind: Engine
+metadata:
+  name: broken-engine
+  namespace: integration-tests
+spec:
+  ruleSet:
+    name: default-ruleset
+  target:
+    type: Gateway
+    name: nonexistent-gateway
+    provider: Istio
+  failurePolicy: fail
+  driver:
+    type: wasm
+    wasm: {}
+EOF
+```
+
+Wait ~5 minutes. The **Engines not ready** stat and `CorazaEngineNotReady` alert should fire.
+Cleanup:
+
+```bash
+kubectl delete engine broken-engine -n integration-tests
+```
+
+### CorazaRuleSetNotReady
+
+Create a RuleSet referencing a missing RuleSource:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: waf.k8s.coraza.io/v1alpha1
+kind: RuleSet
+metadata:
+  name: broken-ruleset
+  namespace: integration-tests
+spec:
+  sources:
+    - name: does-not-exist
+EOF
+```
+
+### CorazaReconcileErrorRateHigh
+
+Apply a RuleSource with invalid SecLang syntax (validation may mark it degraded and
+drive reconcile errors depending on timing).
+
+### CorazaCacheSizeHigh
+
+Populate the cache with many distinct RuleSets or temporarily reduce the operator
+`--cache-max-size` manager flag (not yet exposed as a Helm value) to approach the
+configured limit. Monitor `coraza_cache_size_bytes / coraza_cache_config_max_size_bytes`
+on the Overview dashboard.
+
+## Cleanup
+
+```bash
+make observability.prometheus.undeploy
+```
+
+This removes the `monitoring` namespace and Prometheus RBAC. The Coraza operator and
+KIND cluster remain (`make clean.cluster.kind` destroys the cluster).
+
+## Makefile reference
+
+| Target | Description |
+|--------|-------------|
+| `observability.demo` | Full demo orchestration |
+| `observability.prometheus.deploy` | Install kube-prometheus-stack only |
+| `observability.prometheus.undeploy` | Remove monitoring stack |
+| `observability.operator.monitoring` | Enable operator scrape + dashboards |
+| `observability.demo.workload` | Apply demo CRs and seed traffic |
+| `observability.grafana.port-forward` | Forward Grafana to localhost:3000 |
+| `observability.dashboard.generate` | Regenerate dashboard JSON (Go generator) |
+| `observability.dashboard.test` | Run generator unit and golden parity tests |
+| `observability.dashboard.validate` | Go tests + chart JSON lint (metric refs, size budget) |
+
+## Troubleshooting
+
+**Grafana shows empty panels**
+
+- Confirm Prometheus target `coraza-system/coraza-kubernetes-operator/0` is UP in
+  Prometheus → Status → Targets.
+- Verify the operator Helm release has `metrics.serviceMonitor.enabled=true`.
+- Wait 1–2 scrape intervals (30s) after seeding traffic.
+
+**Dashboards not in Grafana**
+
+- Check ConfigMap `coraza-kubernetes-operator-dashboards` exists in `coraza-system`
+  with label `grafana_dashboard=1`.
+- Confirm Grafana sidecar logs in the `monitoring` namespace.
+
+**401 on metrics scrape**
+
+- Apply `config/observability/prometheus-rbac.yaml` (done automatically by
+  `observability.prometheus.deploy`).

--- a/hack/observability/seed-traffic.sh
+++ b/hack/observability/seed-traffic.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Port-forward to coraza-gateway and send HTTP traffic for dashboard metrics.
+set -euo pipefail
+
+: "${KIND_CLUSTER_NAME:=coraza-kubernetes-operator-integration}"
+: "${DEMO_NAMESPACE:=integration-tests}"
+: "${GATEWAY_NAME:=coraza-gateway}"
+: "${GW_WAIT_TIMEOUT:=300s}"
+: "${HTTP_WAIT_TIMEOUT:=120}"
+
+KUBE_CONTEXT="kind-${KIND_CLUSTER_NAME}"
+
+kubectl_ctx() {
+  kubectl --context "${KUBE_CONTEXT}" "$@"
+}
+
+pick_free_port() {
+  if [ -n "${OBSERVABILITY_GW_PORT:-}" ]; then
+    echo "${OBSERVABILITY_GW_PORT}"
+    return
+  fi
+  if command -v python3 &>/dev/null; then
+    python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
+    return
+  fi
+  local port=29100
+  while ss -tln 2>/dev/null | grep -q ":${port} "; do
+    port=$((port + 1))
+  done
+  echo "${port}"
+}
+
+command -v curl &>/dev/null || { echo "ERROR: curl required" >&2; exit 1; }
+kubectl_ctx cluster-info &>/dev/null || {
+  echo "ERROR: KIND cluster context ${KUBE_CONTEXT} is not reachable. Run: make cluster.kind" >&2
+  exit 1
+}
+
+echo "=== Waiting for Gateway ${GATEWAY_NAME} to be Programmed ==="
+if ! kubectl_ctx -n "${DEMO_NAMESPACE}" wait --for=condition=Programmed \
+  "gateway/${GATEWAY_NAME}" --timeout="${GW_WAIT_TIMEOUT}" 2>/dev/null; then
+  echo "ERROR: Gateway ${DEMO_NAMESPACE}/${GATEWAY_NAME} not Programmed within ${GW_WAIT_TIMEOUT}" >&2
+  exit 1
+fi
+
+echo "=== Waiting for Gateway pod Ready ==="
+if ! kubectl_ctx -n "${DEMO_NAMESPACE}" wait --for=condition=Ready \
+  pod -l "gateway.networking.k8s.io/gateway-name=${GATEWAY_NAME}" \
+  --timeout="${GW_WAIT_TIMEOUT}" 2>/dev/null; then
+  echo "ERROR: Gateway pod for ${GATEWAY_NAME} not Ready within ${GW_WAIT_TIMEOUT}" >&2
+  exit 1
+fi
+
+gw_pod="$(kubectl_ctx -n "${DEMO_NAMESPACE}" get pod \
+  -l "gateway.networking.k8s.io/gateway-name=${GATEWAY_NAME}" \
+  --field-selector=status.phase=Running \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+if [ -z "${gw_pod}" ]; then
+  echo "ERROR: Gateway pod not found in ${DEMO_NAMESPACE}" >&2
+  exit 1
+fi
+
+pf_port="$(pick_free_port)"
+pf_pid=""
+pf_target="pod/${gw_pod}"
+cleanup() {
+  if [ -n "${pf_pid}" ] && kill -0 "${pf_pid}" 2>/dev/null; then
+    kill "${pf_pid}" 2>/dev/null || true
+    wait "${pf_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+start_port_forward() {
+  if [ -n "${pf_pid}" ] && kill -0 "${pf_pid}" 2>/dev/null; then
+    kill "${pf_pid}" 2>/dev/null || true
+    wait "${pf_pid}" 2>/dev/null || true
+  fi
+  kubectl_ctx -n "${DEMO_NAMESPACE}" port-forward "${pf_target}" "${pf_port}:80" >/dev/null 2>&1 &
+  pf_pid=$!
+  sleep 1
+}
+
+echo "=== Port-forwarding ${pf_target} -> localhost:${pf_port} ==="
+start_port_forward
+if ! kill -0 "${pf_pid}" 2>/dev/null; then
+  echo "ERROR: port-forward to ${gw_pod} failed to start (is localhost:${pf_port} in use?)" >&2
+  exit 1
+fi
+
+base="http://127.0.0.1:${pf_port}"
+echo "=== Waiting for HTTP via Gateway (up to ${HTTP_WAIT_TIMEOUT}s) ==="
+http_deadline=$(($(date +%s) + HTTP_WAIT_TIMEOUT))
+http_ready=false
+while [ "$(date +%s)" -lt "${http_deadline}" ]; do
+  if ! kill -0 "${pf_pid}" 2>/dev/null; then
+    echo "port-forward exited; restarting..." >&2
+    start_port_forward
+  fi
+  if curl -sf "${base}/echo" -o /dev/null; then
+    http_ready=true
+    break
+  fi
+  sleep 2
+done
+if [ "${http_ready}" != "true" ]; then
+  echo "ERROR: gateway HTTP not reachable at ${base}/echo within ${HTTP_WAIT_TIMEOUT}s" >&2
+  exit 1
+fi
+
+echo "=== Seeding HTTP traffic through Gateway ==="
+ok=0
+fail=0
+
+curl_once() {
+  if curl -sf "$1" -o /dev/null; then
+    ok=$((ok + 1))
+  else
+    fail=$((fail + 1))
+  fi
+}
+
+for i in $(seq 1 20); do
+  curl_once "${base}/echo?n=${i}"
+  curl_once "${base}/"
+done
+for path in "/?evilmonkey=1" "/?q=1'%20OR%201=1--" "/?id=union+select+1"; do
+  curl_once "${base}${path}"
+done
+
+echo "Traffic seeding finished: ${ok} succeeded, ${fail} failed (gateway via port-forward ${pf_port})"
+if [ "${ok}" -eq 0 ]; then
+  echo "ERROR: all HTTP requests failed; gateway may be unreachable" >&2
+  exit 1
+fi
+if [ "${fail}" -gt 0 ]; then
+  echo "WARNING: ${fail} request(s) failed (non-fatal)" >&2
+fi

--- a/hack/observability/validate-dashboards.sh
+++ b/hack/observability/validate-dashboards.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Validate committed chart dashboard JSON (syntax, required fields, metric refs, size).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DASH_DIR="${ROOT_DIR}/charts/coraza-kubernetes-operator/dashboards"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+require_cmd() {
+  command -v "$1" &>/dev/null || { echo "ERROR: $1 required" >&2; exit 1; }
+}
+
+require_cmd jq
+
+echo "=== Dashboard JSON syntax ==="
+for f in "${DASH_DIR}"/*.json; do
+  if jq empty "${f}" 2>/dev/null; then
+    pass "$(basename "${f}") valid JSON"
+  else
+    fail "$(basename "${f}") invalid JSON"
+  fi
+done
+
+echo "=== Dashboard required fields ==="
+for f in "${DASH_DIR}"/*.json; do
+  uid="$(jq -r '.uid // empty' "${f}")"
+  title="$(jq -r '.title // empty' "${f}")"
+  if [ -n "${uid}" ] && [ -n "${title}" ]; then
+    pass "$(basename "${f}") has uid and title"
+  else
+    fail "$(basename "${f}") missing uid or title"
+  fi
+done
+
+echo "=== PromQL metric references ==="
+OVERVIEW="${DASH_DIR}/coraza-operator-overview.json"
+RESOURCES="${DASH_DIR}/coraza-operator-resources.json"
+
+# Collect expr fields from panel targets (nested rows included), not arbitrary JSON text.
+collect_exprs() {
+  jq -r '[.. | objects | .expr? | select(type == "string" and length > 0)] | unique | .[]' "$1"
+}
+
+check_metric_in_exprs() {
+  local file="$1"
+  local metric="$2"
+  local label="$3"
+  if collect_exprs "${file}" | grep -qF "${metric}"; then
+    pass "${label} references ${metric}"
+  else
+    fail "${label} missing reference to ${metric}"
+  fi
+}
+
+for metric in \
+  coraza_cache_size_bytes \
+  coraza:engines_not_ready:count \
+  coraza_rulesource_validations_total \
+  coraza_ruleset_validations_total \
+  coraza_cache_set_duration_seconds \
+  rest_client_requests_total; do
+  check_metric_in_exprs "${OVERVIEW}" "${metric}" "overview"
+done
+
+check_metric_in_exprs "${OVERVIEW}" controller_runtime_reconcile_total "overview"
+check_metric_in_exprs "${RESOURCES}" controller_runtime_reconcile_total "resources"
+
+for metric in coraza_engine_condition coraza_ruleset_condition; do
+  check_metric_in_exprs "${RESOURCES}" "${metric}" "resources"
+done
+
+echo "=== ConfigMap size budget ==="
+# Per-file limit (Kubernetes ConfigMap value size). Combined budget leaves headroom
+# for Helm template keys and etcd's ~1.5MiB ConfigMap object limit.
+MAX_CONFIGMAP_COMBINED_BYTES=1048576
+total=0
+for f in "${DASH_DIR}"/*.json; do
+  size=$(wc -c < "${f}")
+  total=$((total + size))
+  if [ "${size}" -lt 524288 ]; then
+    pass "$(basename "${f}") size ${size} bytes (<512KiB)"
+  else
+    fail "$(basename "${f}") too large: ${size} bytes"
+  fi
+done
+pass "combined dashboard JSON size ${total} bytes"
+# Helm embeds JSON as indented YAML (~20% overhead vs raw files).
+helm_budget=$((MAX_CONFIGMAP_COMBINED_BYTES * 80 / 100))
+if [ "${total}" -gt "${MAX_CONFIGMAP_COMBINED_BYTES}" ]; then
+  fail "combined dashboard JSON ${total} bytes exceeds safe ConfigMap budget (${MAX_CONFIGMAP_COMBINED_BYTES})"
+elif [ "${total}" -gt "${helm_budget}" ]; then
+  fail "combined dashboard JSON ${total} bytes leaves little headroom for Helm YAML embedding (budget ${helm_budget})"
+else
+  pass "combined dashboard JSON within safe ConfigMap budget (${MAX_CONFIGMAP_COMBINED_BYTES}, helm headroom ${helm_budget})"
+fi
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi

--- a/hack/test-helm-manifests.sh
+++ b/hack/test-helm-manifests.sh
@@ -111,13 +111,37 @@ out=$(render --set metrics.podMonitor.enabled=true \
 echo "$out" | grep -q "coraza_waf_requests_total" && pass "User metricRelabelings injected" || fail "User metricRelabelings missing"
 echo "$out" | grep -qF 'coraza_waf_.*' && pass "Mandatory cardinality guard still present" || fail "Mandatory cardinality guard missing"
 
-# ── Test 13: ServiceMonitor additionalLabels ─────────────────────────────────
+# ── Test 14: Grafana dashboard ConfigMap ─────────────────────────────────────
+section "Grafana dashboard ConfigMap"
+dash_tmp=$(mktemp /tmp/coraza-dashboard-helm-XXXXXX.yaml)
+render --set metrics.enabled=true --set metrics.grafanaDashboard.enabled=true \
+  --set metrics.prometheusRule.enabled=true \
+  -s templates/grafana-dashboard-configmap.yaml > "${dash_tmp}"
+grep -q "kind: ConfigMap" "${dash_tmp}" && pass "Dashboard ConfigMap rendered" || fail "Dashboard ConfigMap missing"
+grep -q "grafana_dashboard" "${dash_tmp}" && pass "grafana_dashboard label present" || fail "grafana_dashboard label missing"
+grep -q "coraza-operator-overview.json" "${dash_tmp}" && pass "Overview dashboard embedded" || fail "Overview dashboard missing"
+grep -q "coraza-operator-resources.json" "${dash_tmp}" && pass "Resources dashboard embedded" || fail "Resources dashboard missing"
+grep -q "grafana_folder" "${dash_tmp}" && pass "grafana_folder annotation present" || fail "grafana_folder annotation missing"
+rm -f "${dash_tmp}"
+
+# ── Test 15: ServiceMonitor additionalLabels ─────────────────────────────────
 section "ServiceMonitor additionalLabels"
 out=$(render --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true \
   --set 'metrics.serviceMonitor.additionalLabels.release=kube-prometheus-stack')
 echo "$out" | grep -q "release: kube-prometheus-stack" && pass "ServiceMonitor additionalLabels merged" || fail "ServiceMonitor additionalLabels not merged"
 
-# ── Test 14: promtool check rules (optional) ─────────────────────────────────
+# ── Test 16: Grafana dashboard gated on metrics.enabled ──────────────────────
+section "Grafana dashboard respects metrics.enabled gate"
+out=$(render --set metrics.enabled=false --set metrics.grafanaDashboard.enabled=true)
+echo "$out" | grep -q "coraza-operator-overview.json" && fail "Dashboard should be gated on metrics.enabled" || pass "Dashboard correctly gated"
+
+# ── Test 16b: Grafana dashboard requires PrometheusRule ───────────────────────
+section "Grafana dashboard requires prometheusRule"
+out=$(render --set metrics.enabled=true --set metrics.grafanaDashboard.enabled=true \
+  --set metrics.prometheusRule.enabled=false)
+echo "$out" | grep -q "coraza-operator-overview.json" && fail "Dashboard should require prometheusRule.enabled" || pass "Dashboard correctly gated on prometheusRule"
+
+# ── Test 17: promtool check rules (optional) ─────────────────────────────────
 if command -v promtool &>/dev/null; then
   section "promtool check rules"
   tmpfile=$(mktemp /tmp/prometheusrule-XXXXXX.yaml)

--- a/tools/grafana-dashboards/cmd/generate/main.go
+++ b/tools/grafana-dashboards/cmd/generate/main.go
@@ -1,0 +1,61 @@
+// Command generate writes Grafana dashboard JSON for the Coraza operator Helm chart.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/dashboards"
+)
+
+const defaultOut = "../../charts/coraza-kubernetes-operator/dashboards"
+
+func main() {
+	out := flag.String("out", defaultOut, "output directory for dashboard JSON")
+	flag.Parse()
+
+	outDir, err := filepath.Abs(*out)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve output dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := generateDashboard(outDir, "coraza-operator-overview.json", dashboards.BuildOverview); err != nil {
+		os.Exit(1)
+	}
+	if err := generateDashboard(outDir, "coraza-operator-resources.json", dashboards.BuildResources); err != nil {
+		os.Exit(1)
+	}
+}
+
+func generateDashboard(outDir, name string, build func() (dashboard.Dashboard, error)) error {
+	dash, err := build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build %s: %v\n", name, err)
+		return err
+	}
+	path := filepath.Join(outDir, name)
+	if err := writeDashboard(path, dash); err != nil {
+		fmt.Fprintf(os.Stderr, "write %s: %v\n", path, err)
+		return err
+	}
+	fmt.Printf("wrote %s\n", path)
+	return nil
+}
+
+func writeDashboard(path string, dashboard any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(dashboard, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}

--- a/tools/grafana-dashboards/go.mod
+++ b/tools/grafana-dashboards/go.mod
@@ -1,0 +1,5 @@
+module github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards
+
+go 1.26.2
+
+require github.com/grafana/grafana-foundation-sdk/go v0.0.18

--- a/tools/grafana-dashboards/go.sum
+++ b/tools/grafana-dashboards/go.sum
@@ -1,0 +1,2 @@
+github.com/grafana/grafana-foundation-sdk/go v0.0.18 h1:DkWn1vY9FYYVVWzrZQCqZnGxsN8R/RQUJigG6UkfXIo=
+github.com/grafana/grafana-foundation-sdk/go v0.0.18/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=

--- a/tools/grafana-dashboards/internal/dashboards/base.go
+++ b/tools/grafana-dashboards/internal/dashboards/base.go
@@ -1,0 +1,27 @@
+package dashboards
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+)
+
+func overviewBaseBuilder() *dashboard.DashboardBuilder {
+	return dashboard.NewDashboardBuilder("Coraza Operator — Overview").
+		Uid("coraza-operator-overview").
+		Tags([]string{"coraza", "operator", "control-plane", "waf"}).
+		Timezone("browser").
+		Editable().
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
+		Refresh("30s").
+		Time("now-1h", "now").
+		Version(1).
+		Link(dashboard.NewDashboardLinkBuilder("Resource drill-down").
+			Type(dashboard.DashboardLinkTypeLink).
+			Url("/d/coraza-operator-resources/coraza-operator-resources?${__url_time_range}").
+			Icon("external link"),
+		).
+		WithVariable(dashboard.NewDatasourceVariableBuilder("DS_PROMETHEUS").
+			Label("Datasource").
+			Type("prometheus"),
+		).
+		Annotation(builtInAnnotations())
+}

--- a/tools/grafana-dashboards/internal/dashboards/golden_test.go
+++ b/tools/grafana-dashboards/internal/dashboards/golden_test.go
@@ -1,0 +1,129 @@
+package dashboards
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+var updateGolden = flag.Bool("update", false, "rewrite testdata/golden/*.semantic.json from the generator")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
+func TestCommittedDashboardsMatchGenerator(t *testing.T) {
+	cases := []struct {
+		name  string
+		file  string
+		build func() (any, error)
+	}{
+		{"overview", "coraza-operator-overview.json", func() (any, error) { return BuildOverview() }},
+		{"resources", "coraza-operator-resources.json", func() (any, error) { return BuildResources() }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			committedPath := filepath.Join(chartDashboardsDir(), tc.file)
+			committedData, err := os.ReadFile(committedPath)
+			if err != nil {
+				t.Fatalf("read committed %s: %v", committedPath, err)
+			}
+
+			dash, err := tc.build()
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			generated, err := SemanticsFromDashboard(dash)
+			if err != nil {
+				t.Fatalf("semantics from generator: %v", err)
+			}
+			committed, err := SemanticsFromJSON(committedData)
+			if err != nil {
+				t.Fatalf("semantics from committed: %v", err)
+			}
+
+			if !reflect.DeepEqual(committed, generated) {
+				t.Fatalf("committed chart JSON is stale; run: make observability.dashboard.generate\ncommitted: %+v\ngenerated: %+v", committed, generated)
+			}
+		})
+	}
+}
+
+func TestDashboardSemanticsGolden(t *testing.T) {
+	cases := []struct {
+		name    string
+		golden  string
+		build   func() (any, error)
+	}{
+		{"overview", "overview.semantic.json", func() (any, error) { return BuildOverview() }},
+		{"resources", "resources.semantic.json", func() (any, error) { return BuildResources() }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dash, err := tc.build()
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			got, err := SemanticsFromDashboard(dash)
+			if err != nil {
+				t.Fatalf("semantics: %v", err)
+			}
+
+			goldenPath := filepath.Join(testdataDir(), "golden", tc.golden)
+			if *updateGolden {
+				writeGolden(t, goldenPath, got)
+				return
+			}
+
+			wantData, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("read golden %s: %v (run: go test ./... -update)", goldenPath, err)
+			}
+			var want DashboardSemantics
+			if err := json.Unmarshal(wantData, &want); err != nil {
+				t.Fatalf("unmarshal golden: %v", err)
+			}
+			if !reflect.DeepEqual(want, got) {
+				t.Fatalf("generator semantics changed; run: cd tools/grafana-dashboards && go test ./... -update")
+			}
+		})
+	}
+}
+
+func writeGolden(t *testing.T, path string, sem DashboardSemantics) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, err := json.MarshalIndent(sem, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func chartDashboardsDir() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "../../charts/coraza-kubernetes-operator/dashboards"
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "../../../../charts/coraza-kubernetes-operator/dashboards"))
+}
+
+func testdataDir() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "testdata"
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "../../testdata"))
+}

--- a/tools/grafana-dashboards/internal/dashboards/overview.go
+++ b/tools/grafana-dashboards/internal/dashboards/overview.go
@@ -1,0 +1,515 @@
+package dashboards
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/text"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/panels"
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/prom"
+)
+
+type healthStat struct {
+	title       string
+	expr        string
+	description string
+	unit        string
+	steps       []panels.ThresholdStep
+}
+
+// BuildOverview generates the full Overview dashboard.
+func BuildOverview() (dashboard.Dashboard, error) {
+	builder := overviewBaseBuilder()
+	addOverviewIntro(builder)
+	addHealthSummary(builder)
+	addReconciliation(builder)
+	addValidation(builder)
+	addCacheRED(builder)
+	addCacheUSE(builder)
+	addKubernetesAPI(builder)
+	addResourceCounts(builder)
+	return builder.Build()
+}
+
+func addOverviewIntro(builder *dashboard.DashboardBuilder) {
+	builder.WithPanel(text.NewPanelBuilder().
+		Id(1).
+		Title("").
+		GridPos(dashboard.GridPos{H: 3, W: 24, X: 0, Y: 0}).
+		Mode(text.TextModeMarkdown).
+		Content(
+			"Control-plane health for the Coraza Kubernetes Operator. " +
+				"Use **Resource drill-down** (top-right link) for per-CR troubleshooting. " +
+				"Alerts are defined in the Helm `PrometheusRule` when enabled.",
+		),
+	)
+}
+
+func addHealthSummary(builder *dashboard.DashboardBuilder) {
+	builder.WithRow(dashboard.NewRowBuilder("Health summary").
+		Id(2).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: 3}),
+	)
+
+	health := []healthStat{
+		{
+			title:       "Engines not ready",
+			expr:        "coraza:engines_not_ready:count",
+			description: "Recording rule from PrometheusRule. Count of Engines where Ready != True.",
+			unit:        "none",
+			steps:       []panels.ThresholdStep{{Color: "green"}, {Value: floatPtr(1), Color: "red"}},
+		},
+		{
+			title:       "RuleSets not ready",
+			expr:        "coraza:rulesets_not_ready:count",
+			description: "Recording rule from PrometheusRule.",
+			unit:        "none",
+			steps:       []panels.ThresholdStep{{Color: "green"}, {Value: floatPtr(1), Color: "red"}},
+		},
+		{
+			title:       "RuleSources degraded",
+			expr:        "coraza:rulesources_degraded:count",
+			description: "Recording rule from PrometheusRule. RuleSources in Degraded condition.",
+			unit:        "none",
+			steps: []panels.ThresholdStep{
+				{Color: "green"},
+				{Value: floatPtr(1), Color: "yellow"},
+				{Value: floatPtr(2), Color: "red"},
+			},
+		},
+		{
+			title: "Reconcile error ratio",
+			expr: "(sum(rate(controller_runtime_reconcile_errors_total" +
+				"{controller=~\"ruleset|engine|rulesource\"}[5m])) / " +
+				"sum(rate(controller_runtime_reconcile_total" +
+				"{controller=~\"ruleset|engine|rulesource\"}[5m]))) " +
+				"and sum(rate(controller_runtime_reconcile_total" +
+				"{controller=~\"ruleset|engine|rulesource\"}[5m])) > 0",
+			description: "Ratio of reconcile errors to total reconciles (5m rate).",
+			unit:        "percentunit",
+			steps: []panels.ThresholdStep{
+				{Color: "green"},
+				{Value: floatPtr(0.01), Color: "yellow"},
+				{Value: floatPtr(0.1), Color: "red"},
+			},
+		},
+		{
+			title: "Cache utilization",
+			expr: "(coraza_cache_size_bytes / coraza_cache_config_max_size_bytes) " +
+				"and coraza_cache_config_max_size_bytes > 0",
+			description: "Cache size vs configured maximum.",
+			unit:        "percentunit",
+			steps: []panels.ThresholdStep{
+				{Color: "green"},
+				{Value: floatPtr(0.7), Color: "yellow"},
+				{Value: floatPtr(0.9), Color: "red"},
+			},
+		},
+		{
+			title:       "Cache hit ratio",
+			expr:        "coraza:cache_hit_ratio:rate5m",
+			description: "Recording rule: 200s / (200s + 404s) over 5m. Shows no data when there is no cache traffic.",
+			unit:        "percentunit",
+			steps: []panels.ThresholdStep{
+				{Color: "red"},
+				{Value: floatPtr(0.5), Color: "yellow"},
+				{Value: floatPtr(0.8), Color: "green"},
+			},
+		},
+	}
+
+	const healthRowY uint32 = 4
+	for i, stat := range health {
+		builder.WithPanel(panels.StatPanel(panels.StatPanelConfig{
+			ID:          uint32(3 + i),
+			Title:       stat.title,
+			Description: stat.description,
+			Expr:        stat.expr,
+			Unit:        stat.unit,
+			Steps:       stat.steps,
+			GridPos: dashboard.GridPos{
+				H: 4,
+				W: 4,
+				X: uint32(i * 4),
+				Y: healthRowY,
+			},
+		}))
+	}
+}
+
+func addReconciliation(builder *dashboard.DashboardBuilder) {
+	const y uint32 = 8
+	builder.WithRow(dashboard.NewRowBuilder("Reconciliation").
+		Id(9).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: y}),
+	)
+
+	controllerFilter := `{controller=~"ruleset|engine|rulesource"}`
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          10,
+		Title:       "Reconcile rate",
+		Description: "Reconciles per second by controller and result.",
+		Unit:        "ops",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 1},
+		Queries: []prom.QuerySpec{{
+			Expr:   `sum by (controller, result) (rate(controller_runtime_reconcile_total` + controllerFilter + `[5m]))`,
+			Legend: "{{controller}} {{result}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:      11,
+		Title:   "Reconcile errors",
+		Unit:    "ops",
+		GridPos: dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 1},
+		Queries: []prom.QuerySpec{{
+			Expr:   `sum by (controller) (rate(controller_runtime_reconcile_errors_total` + controllerFilter + `[5m]))`,
+			Legend: "{{controller}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:      12,
+		Title:   "Reconcile duration p99",
+		Unit:    "s",
+		GridPos: dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 9},
+		Queries: []prom.QuerySpec{
+			{
+				Expr:   `histogram_quantile(0.99, sum by (le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket` + controllerFilter + `[5m])))`,
+				Legend: "{{controller}} p99",
+			},
+			{
+				Expr:   `histogram_quantile(0.50, sum by (le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket` + controllerFilter + `[5m])))`,
+				Legend: "{{controller}} p50",
+			},
+		},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:      13,
+		Title:   "Workqueue depth",
+		GridPos: dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 9},
+		Queries: []prom.QuerySpec{{
+			Expr:   `workqueue_depth{name=~"ruleset|engine|rulesource"}`,
+			Legend: "{{name}}",
+		}},
+	}))
+}
+
+func addValidation(builder *dashboard.DashboardBuilder) {
+	const y uint32 = 24
+	builder.WithRow(dashboard.NewRowBuilder("Validation").
+		Id(14).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: y}),
+	)
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          15,
+		Title:       "RuleSource validation rate",
+		Description: "RuleSource validations per second by outcome (valid=Coraza parse succeeded, invalid=parse failed, skipped=annotation or patch-only).",
+		Unit:        "ops",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 1},
+		Queries: []prom.QuerySpec{{
+			Expr:   "sum by (outcome) (rate(coraza_rulesource_validations_total[5m]))",
+			Legend: "{{outcome}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          16,
+		Title:       "RuleSet validation rate",
+		Description: "RuleSet aggregate validations per second (valid=Coraza parse succeeded; does not imply Ready).",
+		Unit:        "ops",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 1},
+		Queries: []prom.QuerySpec{{
+			Expr:   "sum by (outcome) (rate(coraza_ruleset_validations_total[5m]))",
+			Legend: "{{outcome}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          17,
+		Title:       "RuleSource validation duration",
+		Description: "RuleSource validation latency by outcome.",
+		Unit:        "s",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 9},
+		Queries: []prom.QuerySpec{
+			{
+				Expr:   "histogram_quantile(0.99, sum by (le, outcome) (rate(coraza_rulesource_validation_duration_seconds_bucket[5m])))",
+				Legend: "{{outcome}} p99",
+			},
+			{
+				Expr:   "histogram_quantile(0.50, sum by (le, outcome) (rate(coraza_rulesource_validation_duration_seconds_bucket[5m])))",
+				Legend: "{{outcome}} p50",
+			},
+		},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          18,
+		Title:       "RuleSet validation duration",
+		Description: "RuleSet aggregate validation latency by outcome.",
+		Unit:        "s",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 9},
+		Queries: []prom.QuerySpec{
+			{
+				Expr:   "histogram_quantile(0.99, sum by (le, outcome) (rate(coraza_ruleset_validation_duration_seconds_bucket[5m])))",
+				Legend: "{{outcome}} p99",
+			},
+			{
+				Expr:   "histogram_quantile(0.50, sum by (le, outcome) (rate(coraza_ruleset_validation_duration_seconds_bucket[5m])))",
+				Legend: "{{outcome}} p50",
+			},
+		},
+	}))
+}
+
+func addCacheRED(builder *dashboard.DashboardBuilder) {
+	const y uint32 = 40
+	builder.WithRow(dashboard.NewRowBuilder("Cache server — RED").
+		Id(19).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: y}),
+	)
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:      20,
+		Title:   "Request rate",
+		Unit:    "reqps",
+		GridPos: dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 1},
+		Queries: []prom.QuerySpec{{
+			Expr:   "sum by (handler, code) (rate(coraza_cache_server_requests_total[5m]))",
+			Legend: "{{handler}} {{code}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          21,
+		Title:       "Errors & auth failures",
+		Description: "Cache server 5xx error rate and authentication failure rate.",
+		Unit:        "reqps",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 1},
+		Queries: []prom.QuerySpec{
+			{
+				Expr:   `sum(rate(coraza_cache_server_requests_total{code=~"5.."}[5m]))`,
+				Legend: "5xx",
+			},
+			{
+				Expr:   "rate(coraza_cache_server_auth_failures_total[5m])",
+				Legend: "auth failures",
+			},
+		},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:      22,
+		Title:   "Request latency",
+		Unit:    "s",
+		GridPos: dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 9},
+		Queries: []prom.QuerySpec{
+			{
+				Expr:   "histogram_quantile(0.99, sum by (le, handler) (rate(coraza_cache_server_request_duration_seconds_bucket[5m])))",
+				Legend: "{{handler}} p99",
+			},
+			{
+				Expr:   "histogram_quantile(0.50, sum by (le, handler) (rate(coraza_cache_server_request_duration_seconds_bucket[5m])))",
+				Legend: "{{handler}} p50",
+			},
+		},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:      23,
+		Title:   "In-flight requests",
+		GridPos: dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 9},
+		Queries: []prom.QuerySpec{{
+			Expr:   "coraza_cache_server_in_flight_requests",
+			Legend: "{{handler}}",
+		}},
+	}))
+}
+
+func addCacheUSE(builder *dashboard.DashboardBuilder) {
+	const y uint32 = 56
+	builder.WithRow(dashboard.NewRowBuilder("Cache server — USE").
+		Id(24).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: y}),
+	)
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          25,
+		Title:       "Cache size vs limit",
+		Description: "RuleSet cache payload size vs configured maximum (always emitted by the operator).",
+		Unit:        "bytes",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 1},
+		Queries: []prom.QuerySpec{
+			{Expr: "coraza_cache_size_bytes", Legend: "size"},
+			{Expr: "coraza_cache_config_max_size_bytes", Legend: "max"},
+		},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          26,
+		Title:       "GC prune rate",
+		Description: "Entries pruned per second by reason (age/size). Flat at zero until GC runs.",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 1},
+		Queries: []prom.QuerySpec{{
+			Expr:   "sum by (reason) (rate(coraza_cache_gc_pruned_entries_total[15m]))",
+			Legend: "{{reason}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          27,
+		Title:       "Cache instances & entries",
+		Description: "Distinct cache keys and total stored revisions.",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 9},
+		Queries: []prom.QuerySpec{
+			{Expr: "coraza_cache_instances", Legend: "instances"},
+			{Expr: "coraza_cache_total_entries", Legend: "entries"},
+		},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          28,
+		Title:       "Cache Put duration",
+		Description: "Latency of RuleSet cache Put operations after successful validation.",
+		Unit:        "s",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 9},
+		Queries: []prom.QuerySpec{
+			{
+				Expr:   "histogram_quantile(0.99, sum by (le, namespace) (rate(coraza_cache_set_duration_seconds_bucket[5m])))",
+				Legend: "{{namespace}} p99",
+			},
+			{
+				Expr:   "histogram_quantile(0.50, sum by (le, namespace) (rate(coraza_cache_set_duration_seconds_bucket[5m])))",
+				Legend: "{{namespace}} p50",
+			},
+		},
+	}))
+}
+
+func addKubernetesAPI(builder *dashboard.DashboardBuilder) {
+	const y uint32 = 72
+	builder.WithRow(dashboard.NewRowBuilder("Kubernetes API & workqueue").
+		Id(29).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: y}),
+	)
+
+	nameFilter := `{name=~"ruleset|engine|rulesource"}`
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          30,
+		Title:       "API request rate",
+		Description: "Kubernetes API request rate by verb and resource (from client-go).",
+		Unit:        "reqps",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 1},
+		Queries: []prom.QuerySpec{{
+			Expr:   "sum by (verb, resource) (rate(rest_client_requests_total[5m]))",
+			Legend: "{{verb}} {{resource}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          31,
+		Title:       "API errors (non-2xx)",
+		Description: "Non-success API responses by status code.",
+		Unit:        "reqps",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 1},
+		Queries: []prom.QuerySpec{{
+			Expr:   `sum by (code) (rate(rest_client_requests_total{code!~"2.."}[5m]))`,
+			Legend: "{{code}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          32,
+		Title:       "API request latency p99",
+		Description: "Kubernetes API call latency by verb.",
+		Unit:        "s",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 9},
+		Queries: []prom.QuerySpec{
+			{
+				Expr:   "histogram_quantile(0.99, sum by (le, verb) (rate(rest_client_request_duration_seconds_bucket[5m])))",
+				Legend: "{{verb}} p99",
+			},
+			{
+				Expr:   "histogram_quantile(0.50, sum by (le, verb) (rate(rest_client_request_duration_seconds_bucket[5m])))",
+				Legend: "{{verb}} p50",
+			},
+		},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          33,
+		Title:       "Workqueue retries",
+		Description: "Workqueue retry rate per controller.",
+		Unit:        "ops",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 9},
+		Queries: []prom.QuerySpec{{
+			Expr:   "sum by (name) (rate(workqueue_retries_total" + nameFilter + "[5m]))",
+			Legend: "{{name}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          34,
+		Title:       "Longest running processor",
+		Description: "Duration of the longest currently-running reconcile per controller.",
+		Unit:        "s",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 0, Y: y + 17},
+		Queries: []prom.QuerySpec{{
+			Expr:   "workqueue_longest_running_processor_seconds" + nameFilter,
+			Legend: "{{name}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          35,
+		Title:       "Unfinished work",
+		Description: "Total seconds of unfinished work in the queue per controller.",
+		Unit:        "s",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 12, Y: y + 17},
+		Queries: []prom.QuerySpec{{
+			Expr:   "workqueue_unfinished_work_seconds" + nameFilter,
+			Legend: "{{name}}",
+		}},
+	}))
+}
+
+func addResourceCounts(builder *dashboard.DashboardBuilder) {
+	const y uint32 = 96
+	builder.WithRow(dashboard.NewRowBuilder("Resource counts by namespace").
+		Id(36).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: y}),
+	)
+
+	resourceCounts := []struct {
+		title  string
+		metric string
+		desc   string
+	}{
+		{"Engines", "coraza_engines", "Current per-namespace engine count (instant; empty when zero)."},
+		{"RuleSets", "coraza_rulesets", "Current per-namespace ruleset count (instant; empty when zero)."},
+		{"RuleSources", "coraza_rulesources", "Current per-namespace rulesource count (instant; empty when zero)."},
+		{"RuleData", "coraza_ruledatas", "Current per-namespace ruledata count (instant; empty when zero)."},
+	}
+
+	for i, rc := range resourceCounts {
+		builder.WithPanel(panels.ResourceCountTable(panels.ResourceCountTableConfig{
+			ID:          uint32(37 + i),
+			Title:       rc.title,
+			Description: rc.desc,
+			Expr:        rc.metric,
+			GridPos: dashboard.GridPos{
+				H: 6,
+				W: 12,
+				X: uint32((i % 2) * 12),
+				Y: y + 1 + uint32(i/2)*6,
+			},
+		}))
+	}
+}
+
+func floatPtr(v float64) *float64 {
+	return &v
+}

--- a/tools/grafana-dashboards/internal/dashboards/overview_test.go
+++ b/tools/grafana-dashboards/internal/dashboards/overview_test.go
@@ -1,0 +1,16 @@
+package dashboards
+
+import "testing"
+
+func TestBuildOverview(t *testing.T) {
+	dash, err := BuildOverview()
+	if err != nil {
+		t.Fatalf("BuildOverview: %v", err)
+	}
+	if dash.Uid == nil || *dash.Uid != "coraza-operator-overview" {
+		t.Fatalf("unexpected uid: %v", dash.Uid)
+	}
+	if len(dash.Panels) != 40 {
+		t.Fatalf("expected 40 panels (full overview), got %d", len(dash.Panels))
+	}
+}

--- a/tools/grafana-dashboards/internal/dashboards/resources.go
+++ b/tools/grafana-dashboards/internal/dashboards/resources.go
@@ -1,0 +1,160 @@
+package dashboards
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/text"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/panels"
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/prom"
+)
+
+// BuildResources generates the full Resources drill-down dashboard.
+func BuildResources() (dashboard.Dashboard, error) {
+	builder := resourcesBaseBuilder()
+	addResourcesIntro(builder)
+	addSelectedEngine(builder)
+	addRuleSetsInNamespace(builder)
+	addNamespaceInventory(builder)
+	addOperatorActivity(builder)
+	return builder.Build()
+}
+
+func addResourcesIntro(builder *dashboard.DashboardBuilder) {
+	builder.WithPanel(text.NewPanelBuilder().
+		Id(1).
+		Title("").
+		GridPos(dashboard.GridPos{H: 3, W: 24, X: 0, Y: 0}).
+		Mode(text.TextModeMarkdown).
+		Content(
+			"Drill-down for Coraza CRs. Pick **Namespace** to scope all tables below. " +
+				"Each table row is one resource (`namespace/name`). " +
+				"**Engine** / **RuleSet** dropdowns optionally narrow the **Engine details** panel only. " +
+				"Condition and composition tables always list every resource in the namespace.",
+		),
+	)
+}
+
+func addSelectedEngine(builder *dashboard.DashboardBuilder) {
+	const rowY uint32 = 3
+
+	builder.WithRow(dashboard.NewRowBuilder("Selected Engine").
+		Id(2).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: rowY}),
+	)
+
+	builder.WithPanel(panels.ResourceConditionTable(panels.ConditionTableConfig{
+		ID:             3,
+		Title:          "Engine conditions",
+		Description:    "One row per Engine in the selected namespace(s).",
+		Metric:         "coraza_engine_condition",
+		Conditions:     []string{"Ready", "Progressing", "Degraded", "Accepted"},
+		GridPos:        dashboard.GridPos{H: 6, W: 24, X: 0, Y: rowY + 1},
+		SortByResource: true,
+	}))
+
+	builder.WithPanel(panels.TablePanel(panels.TablePanelConfig{
+		ID:          4,
+		Title:       "Engine details",
+		Description: "Engine metadata (filtered by Engine and RuleSet dropdowns; set All to list every engine).",
+		GridPos:     dashboard.GridPos{H: 6, W: 24, X: 0, Y: rowY + 7},
+		Expr:        `coraza_engine_info{namespace=~"$namespace", name=~"$engine", ruleset_name=~"$ruleset"}`,
+		Transformations: []dashboard.DataTransformerConfig{
+			panels.OrganizeExclude("Time", "Value"),
+		},
+	}))
+}
+
+func addRuleSetsInNamespace(builder *dashboard.DashboardBuilder) {
+	const rowY uint32 = 16
+
+	builder.WithRow(dashboard.NewRowBuilder("RuleSets in namespace").
+		Id(5).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: rowY}),
+	)
+
+	builder.WithPanel(panels.ResourceConditionTable(panels.ConditionTableConfig{
+		ID:             6,
+		Title:          "RuleSet conditions",
+		Description:    "One row per RuleSet in the selected namespace(s).",
+		Metric:         "coraza_ruleset_condition",
+		Conditions:     []string{"Ready", "Progressing", "Degraded"},
+		GridPos:        dashboard.GridPos{H: 6, W: 24, X: 0, Y: rowY + 1},
+		SortByResource: true,
+	}))
+
+	builder.WithPanel(panels.RulesetCompositionTable(panels.RulesetCompositionTableConfig{
+		ID:          7,
+		Title:       "RuleSet composition",
+		Description: "RuleSource and RuleData reference counts per RuleSet.",
+		GridPos:     dashboard.GridPos{H: 5, W: 24, X: 0, Y: rowY + 7},
+	}))
+}
+
+func addNamespaceInventory(builder *dashboard.DashboardBuilder) {
+	const enginesRowY uint32 = 28
+
+	builder.WithRow(dashboard.NewRowBuilder("Namespace inventory — Engines").
+		Id(8).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: enginesRowY}),
+	)
+
+	builder.WithPanel(panels.ResourceConditionTable(panels.ConditionTableConfig{
+		ID:             9,
+		Title:          "Engines in namespace",
+		Description:    "Ready and Degraded condition values per engine (namespace/name).",
+		Metric:         "coraza_engine_condition",
+		Conditions:     []string{"Ready", "Degraded"},
+		GridPos:        dashboard.GridPos{H: 10, W: 24, X: 0, Y: enginesRowY + 1},
+		SortByResource: true,
+	}))
+
+	const rulesourcesRowY uint32 = 39
+	builder.WithRow(dashboard.NewRowBuilder("Namespace inventory — RuleSources").
+		Id(10).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: rulesourcesRowY}),
+	)
+
+	builder.WithPanel(panels.ResourceConditionTable(panels.ConditionTableConfig{
+		ID:             11,
+		Title:          "RuleSources",
+		Metric:         "coraza_rulesource_condition",
+		Conditions:     []string{"Ready", "Degraded"},
+		GridPos:        dashboard.GridPos{H: 8, W: 24, X: 0, Y: rulesourcesRowY + 1},
+		SortByResource: true,
+	}))
+}
+
+func addOperatorActivity(builder *dashboard.DashboardBuilder) {
+	const rowY uint32 = 48
+	const panelY uint32 = 49
+	controllerFilter := `{controller=~"ruleset|engine|rulesource"}`
+
+	builder.WithRow(dashboard.NewRowBuilder("Operator-wide activity").
+		Id(12).
+		GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: rowY}),
+	)
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          13,
+		Title:       "Reconcile rate (all controllers)",
+		Description: "Operator-wide; not filtered by namespace variable.",
+		Unit:        "ops",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 0, Y: panelY},
+		Queries: []prom.QuerySpec{{
+			Expr:   `sum by (controller, result) (rate(controller_runtime_reconcile_total` + controllerFilter + `[5m]))`,
+			Legend: "{{controller}} {{result}}",
+		}},
+	}))
+
+	builder.WithPanel(panels.TimeseriesPanel(panels.TimeseriesPanelConfig{
+		ID:          14,
+		Title:       "Cache request rate",
+		Description: "Cache is operator-scoped; keys are ruleset namespace/name.",
+		Unit:        "reqps",
+		GridPos:     dashboard.GridPos{H: 8, W: 12, X: 12, Y: panelY},
+		Queries: []prom.QuerySpec{{
+			Expr:   "sum by (handler) (rate(coraza_cache_server_requests_total[5m]))",
+			Legend: "{{handler}}",
+		}},
+	}))
+}

--- a/tools/grafana-dashboards/internal/dashboards/resources_test.go
+++ b/tools/grafana-dashboards/internal/dashboards/resources_test.go
@@ -1,0 +1,19 @@
+package dashboards
+
+import "testing"
+
+func TestBuildResources(t *testing.T) {
+	dash, err := BuildResources()
+	if err != nil {
+		t.Fatalf("BuildResources: %v", err)
+	}
+	if dash.Uid == nil || *dash.Uid != "coraza-operator-resources" {
+		t.Fatalf("unexpected uid: %v", dash.Uid)
+	}
+	if len(dash.Templating.List) < 4 {
+		t.Fatalf("expected DS + namespace + engine + ruleset variables, got %d", len(dash.Templating.List))
+	}
+	if len(dash.Panels) != 14 {
+		t.Fatalf("expected 14 panels (full resources), got %d", len(dash.Panels))
+	}
+}

--- a/tools/grafana-dashboards/internal/dashboards/semantic.go
+++ b/tools/grafana-dashboards/internal/dashboards/semantic.go
@@ -1,0 +1,164 @@
+package dashboards
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// DashboardSemantics is a stable fingerprint for dashboard parity tests.
+type DashboardSemantics struct {
+	UID    string            `json:"uid"`
+	Title  string            `json:"title"`
+	Tags   []string          `json:"tags"`
+	Panels []PanelSemantics  `json:"panels"`
+	Links  []LinkSemantics   `json:"links,omitempty"`
+	Vars   []VariableSemantics `json:"variables,omitempty"`
+}
+
+// PanelSemantics captures panel type, layout, queries, and transformation chain.
+type PanelSemantics struct {
+	ID              uint32   `json:"id,omitempty"`
+	Type            string   `json:"type"`
+	Title           string   `json:"title"`
+	GridPos         gridPos  `json:"gridPos,omitempty"`
+	Exprs           []string `json:"exprs,omitempty"`
+	TransformationIDs []string `json:"transformationIds,omitempty"`
+}
+
+type gridPos struct {
+	H uint32 `json:"h"`
+	W uint32 `json:"w"`
+	X uint32 `json:"x"`
+	Y uint32 `json:"y"`
+}
+
+// LinkSemantics captures cross-dashboard links.
+type LinkSemantics struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}
+
+// VariableSemantics captures templating variable names and query definitions.
+type VariableSemantics struct {
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Definition string `json:"definition,omitempty"`
+	Multi      bool   `json:"multi,omitempty"`
+	IncludeAll bool   `json:"includeAll,omitempty"`
+}
+
+type rawDashboard struct {
+	UID    string       `json:"uid"`
+	Title  string       `json:"title"`
+	Tags   []string     `json:"tags"`
+	Links  []rawLink    `json:"links"`
+	Panels []rawPanel   `json:"panels"`
+	Templating struct {
+		List []rawVariable `json:"list"`
+	} `json:"templating"`
+}
+
+type rawLink struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}
+
+type rawPanel struct {
+	ID              *uint32           `json:"id"`
+	Type            string            `json:"type"`
+	Title           string            `json:"title"`
+	GridPos         *gridPos          `json:"gridPos"`
+	Targets         []rawTarget       `json:"targets"`
+	Transformations []rawTransformation `json:"transformations"`
+}
+
+type rawTarget struct {
+	Expr string `json:"expr"`
+}
+
+type rawTransformation struct {
+	ID string `json:"id"`
+}
+
+type rawVariable struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Definition  string `json:"definition"`
+	Multi       bool   `json:"multi"`
+	IncludeAll  bool   `json:"includeAll"`
+}
+
+// SemanticsFromJSON extracts a comparable dashboard fingerprint from marshaled JSON.
+func SemanticsFromJSON(data []byte) (DashboardSemantics, error) {
+	var raw rawDashboard
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return DashboardSemantics{}, err
+	}
+	return semanticsFromRaw(raw), nil
+}
+
+// SemanticsFromDashboard marshals a built dashboard and extracts semantics.
+func SemanticsFromDashboard(dash any) (DashboardSemantics, error) {
+	data, err := json.Marshal(dash)
+	if err != nil {
+		return DashboardSemantics{}, err
+	}
+	return SemanticsFromJSON(data)
+}
+
+func semanticsFromRaw(raw rawDashboard) DashboardSemantics {
+	sem := DashboardSemantics{
+		UID:   raw.UID,
+		Title: raw.Title,
+		Tags:  append([]string(nil), raw.Tags...),
+	}
+	sort.Strings(sem.Tags)
+
+	for _, link := range raw.Links {
+		sem.Links = append(sem.Links, LinkSemantics{Title: link.Title, URL: link.URL})
+	}
+	sort.Slice(sem.Links, func(i, j int) bool {
+		return sem.Links[i].Title < sem.Links[j].Title
+	})
+
+	for _, v := range raw.Templating.List {
+		if v.Name == "" {
+			continue
+		}
+		sem.Vars = append(sem.Vars, VariableSemantics{
+			Name:       v.Name,
+			Type:       v.Type,
+			Definition: v.Definition,
+			Multi:      v.Multi,
+			IncludeAll: v.IncludeAll,
+		})
+	}
+	sort.Slice(sem.Vars, func(i, j int) bool {
+		return sem.Vars[i].Name < sem.Vars[j].Name
+	})
+
+	for _, panel := range raw.Panels {
+		ps := PanelSemantics{
+			Type:  panel.Type,
+			Title: panel.Title,
+		}
+		if panel.ID != nil {
+			ps.ID = *panel.ID
+		}
+		if panel.GridPos != nil {
+			ps.GridPos = *panel.GridPos
+		}
+		for _, target := range panel.Targets {
+			if target.Expr != "" {
+				ps.Exprs = append(ps.Exprs, target.Expr)
+			}
+		}
+		sort.Strings(ps.Exprs)
+		for _, tr := range panel.Transformations {
+			ps.TransformationIDs = append(ps.TransformationIDs, tr.ID)
+		}
+		sem.Panels = append(sem.Panels, ps)
+	}
+
+	return sem
+}

--- a/tools/grafana-dashboards/internal/dashboards/variables.go
+++ b/tools/grafana-dashboards/internal/dashboards/variables.go
@@ -1,0 +1,95 @@
+package dashboards
+
+import (
+	cog "github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+)
+
+const namespaceLabelValuesQuery = `label_values({__name__=~"coraza_(engines|rulesets|rulesources|ruledatas|` +
+	`engine_info|ruleset_info|rulesource_info|ruledata_info)"}, namespace)`
+
+func allVariableCurrent() dashboard.VariableOption {
+	return dashboard.VariableOption{
+		Selected: cog.ToPtr(true),
+		Text:     dashboard.StringOrArrayOfString{String: cog.ToPtr("All")},
+		Value:    dashboard.StringOrArrayOfString{String: cog.ToPtr("$__all")},
+	}
+}
+
+func prometheusQueryVariable(name, label, definition string) *dashboard.QueryVariableBuilder {
+	return dashboard.NewQueryVariableBuilder(name).
+		Label(label).
+		Datasource(promDatasourceRef()).
+		Definition(definition).
+		Query(prometheusVariableQuery(definition)).
+		Current(allVariableCurrent()).
+		Multi(true).
+		IncludeAll(true).
+		AllValue(".*").
+		Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+		Sort(dashboard.VariableSortAlphabeticalAsc)
+}
+
+func prometheusVariableQuery(query string) dashboard.StringOrMap {
+	return dashboard.StringOrMap{
+		Map: map[string]any{
+			"query": query,
+			"refId": "PrometheusVariableQueryEditor-VariableQuery",
+		},
+	}
+}
+
+func promDatasourceRef() common.DataSourceRef {
+	return common.DataSourceRef{
+		Type: cog.ToPtr("prometheus"),
+		Uid:  cog.ToPtr("${DS_PROMETHEUS}"),
+	}
+}
+
+func builtInAnnotations() *dashboard.AnnotationQueryBuilder {
+	return dashboard.NewAnnotationQueryBuilder().
+		Name("Annotations & Alerts").
+		Enable(true).
+		Hide(true).
+		IconColor("rgba(0, 211, 255, 1)").
+		Type("dashboard").
+		BuiltIn(1).
+		Datasource(common.DataSourceRef{
+			Type: cog.ToPtr("grafana"),
+			Uid:  cog.ToPtr("-- Grafana --"),
+		})
+}
+
+func resourcesBaseBuilder() *dashboard.DashboardBuilder {
+	return dashboard.NewDashboardBuilder("Coraza Operator — Resources").
+		Uid("coraza-operator-resources").
+		Tags([]string{"coraza", "operator", "control-plane", "waf"}).
+		Timezone("browser").
+		Editable().
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
+		Refresh("30s").
+		Time("now-1h", "now").
+		Version(1).
+		Link(dashboard.NewDashboardLinkBuilder("Overview").
+			Type(dashboard.DashboardLinkTypeLink).
+			Url("/d/coraza-operator-overview/coraza-operator-overview?${__url_time_range}").
+			Icon("dashboard"),
+		).
+		WithVariable(dashboard.NewDatasourceVariableBuilder("DS_PROMETHEUS").
+			Label("Datasource").
+			Type("prometheus"),
+		).
+		WithVariable(prometheusQueryVariable("namespace", "Namespace", namespaceLabelValuesQuery)).
+		WithVariable(prometheusQueryVariable(
+			"engine",
+			"Engine",
+			`label_values(coraza_engine_info{namespace=~"$namespace"}, name)`,
+		)).
+		WithVariable(prometheusQueryVariable(
+			"ruleset",
+			"RuleSet",
+			`label_values(coraza_ruleset_info{namespace=~"$namespace"}, name)`,
+		)).
+		Annotation(builtInAnnotations())
+}

--- a/tools/grafana-dashboards/internal/panels/conditions.go
+++ b/tools/grafana-dashboards/internal/panels/conditions.go
@@ -1,0 +1,209 @@
+package panels
+
+import (
+	"fmt"
+	"strings"
+
+	cog "github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/table"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/prom"
+)
+
+// ConditionTableConfig configures a pivoted resource condition table.
+type ConditionTableConfig struct {
+	ID             uint32
+	Title          string
+	Description    string
+	Metric         string
+	Conditions     []string
+	GridPos        dashboard.GridPos
+	MatchNameVar   string // optional templating variable name (without $)
+	SortByResource bool
+}
+
+// RulesetCompositionTableConfig configures the RuleSet sources/data merge table.
+type RulesetCompositionTableConfig struct {
+	ID           uint32
+	Title        string
+	Description  string
+	GridPos      dashboard.GridPos
+	MatchNameVar string
+}
+
+// ResourceConditionTable builds a condition pivot table (groupingToMatrix → renameByRegex → organize).
+func ResourceConditionTable(cfg ConditionTableConfig) *table.PanelBuilder {
+	condRE := strings.Join(cfg.Conditions, "|")
+	labelSelector := `namespace=~"$namespace"`
+	if cfg.MatchNameVar != "" {
+		labelSelector += fmt.Sprintf(`, name=~"$%s"`, cfg.MatchNameVar)
+	}
+	expr := fmt.Sprintf(
+		`label_join(%s{%s, condition=~"%s"}, "resource", "/", "namespace", "name")`,
+		cfg.Metric, labelSelector, condRE,
+	)
+
+	b := table.NewPanelBuilder().
+		Id(cfg.ID).
+		Title(cfg.Title).
+		Description(cfg.Description).
+		Datasource(prom.Datasource()).
+		GridPos(cfg.GridPos).
+		CellHeight(common.TableCellHeightSm).
+		ShowHeader(true).
+		Footer(common.NewTableFooterOptionsBuilder().Show(false)).
+		ColorScheme(dashboard.NewFieldColorBuilder().Mode(dashboard.FieldColorModeIdThresholds)).
+		WithTarget(prom.TableQuery(expr, "A"))
+
+	for _, cond := range cfg.Conditions {
+		b = b.OverrideByName(cond, conditionFieldOverrides(cond))
+	}
+
+	for _, t := range conditionTableTransformations(cfg.Conditions) {
+		b = b.WithTransformation(t)
+	}
+
+	if cfg.SortByResource {
+		b = b.SortBy([]cog.Builder[common.TableSortByFieldState]{
+			common.NewTableSortByFieldStateBuilder().DisplayName("Resource").Desc(false),
+		})
+	}
+
+	return b
+}
+
+// RulesetCompositionTable builds the merged RuleSet sources/data files table.
+func RulesetCompositionTable(cfg RulesetCompositionTableConfig) *table.PanelBuilder {
+	labelSelector := `namespace=~"$namespace"`
+	if cfg.MatchNameVar != "" {
+		labelSelector += fmt.Sprintf(`, name=~"$%s"`, cfg.MatchNameVar)
+	}
+
+	b := table.NewPanelBuilder().
+		Id(cfg.ID).
+		Title(cfg.Title).
+		Description(cfg.Description).
+		Datasource(prom.Datasource()).
+		GridPos(cfg.GridPos).
+		CellHeight(common.TableCellHeightSm).
+		ShowHeader(true).
+		Footer(common.NewTableFooterOptionsBuilder().Show(false)).
+		WithTarget(prom.TableQuery(fmt.Sprintf("coraza_ruleset_sources{%s}", labelSelector), "A")).
+		WithTarget(prom.TableQuery(fmt.Sprintf("coraza_ruleset_data_files{%s}", labelSelector), "B")).
+		SortBy([]cog.Builder[common.TableSortByFieldState]{
+			common.NewTableSortByFieldStateBuilder().DisplayName("namespace").Desc(false),
+		})
+
+	b = b.WithTransformation(dashboard.DataTransformerConfig{Id: "merge", Options: map[string]any{}})
+	b = b.WithTransformation(dashboard.DataTransformerConfig{
+		Id: "organize",
+		Options: map[string]any{
+			"excludeByName": map[string]bool{"Time": true},
+			"indexByName": map[string]int{
+				"namespace": 0,
+				"name":      1,
+				"Value #A":  2,
+				"Value #B":  3,
+			},
+			"renameByName": map[string]string{
+				"Value #A": "Sources",
+				"Value #B": "Data files",
+			},
+		},
+	})
+
+	return b
+}
+
+func conditionTableTransformations(conditions []string) []dashboard.DataTransformerConfig {
+	indexByName := map[string]int{"Resource": 0}
+	for i, cond := range conditions {
+		indexByName[cond] = i + 1
+	}
+
+	return []dashboard.DataTransformerConfig{
+		{
+			Id: "groupingToMatrix",
+			Options: map[string]any{
+				"columnField": "condition",
+				"rowField":    "resource",
+				"valueField":  "Value",
+				"emptyValue":  "null",
+			},
+		},
+		{
+			Id: "renameByRegex",
+			Options: map[string]any{
+				"regex":         `resource\\condition`,
+				"renamePattern": "Resource",
+			},
+		},
+		{
+			Id: "organize",
+			Options: map[string]any{
+				"excludeByName": map[string]bool{"Time": true},
+				"indexByName":   indexByName,
+			},
+		},
+	}
+}
+
+func conditionFieldOverrides(condition string) []dashboard.DynamicConfigValue {
+	return []dashboard.DynamicConfigValue{
+		{Id: "mappings", Value: conditionValueMapping(condition)},
+		{Id: "custom.cellOptions", Value: map[string]string{"type": "color-background"}},
+		{Id: "thresholds", Value: absoluteThresholdsJSON(conditionStatSteps(condition))},
+	}
+}
+
+func conditionValueMapping(condition string) dashboard.ValueMap {
+	absentText := "Absent"
+	if condition == "Progressing" || condition == "Degraded" {
+		absentText = "No"
+	}
+	idx0, idx1, idx2 := int32(0), int32(1), int32(2)
+	return dashboard.ValueMap{
+		Type: dashboard.MappingTypeValueToText,
+		Options: map[string]dashboard.ValueMappingResult{
+			"-1": {Text: cog.ToPtr(absentText), Index: &idx0},
+			"0":  {Text: cog.ToPtr("False"), Index: &idx1},
+			"1":  {Text: cog.ToPtr("True"), Index: &idx2},
+		},
+	}
+}
+
+func conditionStatSteps(condition string) []ThresholdStep {
+	switch condition {
+	case "Progressing":
+		return []ThresholdStep{{Color: "green"}, {Value: floatPtr(1), Color: "yellow"}}
+	case "Degraded":
+		return []ThresholdStep{{Color: "green"}, {Value: floatPtr(1), Color: "red"}}
+	default:
+		return []ThresholdStep{
+			{Color: "red"},
+			{Value: floatPtr(0.5), Color: "yellow"},
+			{Value: floatPtr(1), Color: "green"},
+		}
+	}
+}
+
+// absoluteThresholdsJSON returns a map matching Grafana JSON threshold shape for DynamicConfigValue.
+func absoluteThresholdsJSON(steps []ThresholdStep) map[string]any {
+	thresholdSteps := make([]map[string]any, len(steps))
+	for i, step := range steps {
+		thresholdSteps[i] = map[string]any{
+			"color": step.Color,
+			"value": step.Value,
+		}
+	}
+	return map[string]any{
+		"mode":  "absolute",
+		"steps": thresholdSteps,
+	}
+}
+
+func floatPtr(v float64) *float64 {
+	return &v
+}

--- a/tools/grafana-dashboards/internal/panels/conditions_test.go
+++ b/tools/grafana-dashboards/internal/panels/conditions_test.go
@@ -1,0 +1,42 @@
+package panels
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+)
+
+func TestConditionTableTransformations(t *testing.T) {
+	conditions := []string{"Ready", "Degraded"}
+	transforms := conditionTableTransformations(conditions)
+	if len(transforms) != 3 {
+		t.Fatalf("expected 3 transformations, got %d", len(transforms))
+	}
+	if transforms[0].Id != "groupingToMatrix" {
+		t.Fatalf("unexpected first transform: %s", transforms[0].Id)
+	}
+	organize := transforms[2].Options.(map[string]any)
+	indexByName := organize["indexByName"].(map[string]int)
+	if indexByName["Resource"] != 0 || indexByName["Ready"] != 1 || indexByName["Degraded"] != 2 {
+		t.Fatalf("unexpected indexByName: %v", indexByName)
+	}
+}
+
+func TestResourceConditionTableBuild(t *testing.T) {
+	panel, err := ResourceConditionTable(ConditionTableConfig{
+		ID:         1,
+		Title:      "Test",
+		Metric:     "coraza_engine_condition",
+		Conditions: []string{"Ready"},
+		GridPos:    dashboard.GridPos{H: 6, W: 24},
+	}).Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if panel.Type != "table" {
+		t.Fatalf("expected table panel, got %s", panel.Type)
+	}
+	if len(panel.Targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(panel.Targets))
+	}
+}

--- a/tools/grafana-dashboards/internal/panels/resource_count_table.go
+++ b/tools/grafana-dashboards/internal/panels/resource_count_table.go
@@ -1,0 +1,53 @@
+package panels
+
+import (
+	cog "github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/table"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/prom"
+)
+
+// ResourceCountTableConfig configures a per-namespace resource count table.
+type ResourceCountTableConfig struct {
+	ID          uint32
+	Title       string
+	Description string
+	Expr        string
+	GridPos     dashboard.GridPos
+}
+
+// ResourceCountTable builds an instant Prometheus table with namespace and count
+// columns. Unlike bar gauges, the namespace label stays visible with one row.
+func ResourceCountTable(cfg ResourceCountTableConfig) *table.PanelBuilder {
+	return table.NewPanelBuilder().
+		Id(cfg.ID).
+		Title(cfg.Title).
+		Description(cfg.Description).
+		Datasource(prom.Datasource()).
+		GridPos(cfg.GridPos).
+		CellHeight(common.TableCellHeightSm).
+		ShowHeader(true).
+		Footer(common.NewTableFooterOptionsBuilder().Show(false)).
+		WithTarget(prom.TableQuery(cfg.Expr, "A")).
+		WithTransformation(dashboard.DataTransformerConfig{
+			Id: "organize",
+			Options: map[string]any{
+				"excludeByName": map[string]bool{
+					"Time":     true,
+					"__name__": true,
+				},
+				"indexByName": map[string]int{
+					"namespace": 0,
+					"Value":     1,
+				},
+				"renameByName": map[string]string{
+					"Value": "Count",
+				},
+			},
+		}).
+		SortBy([]cog.Builder[common.TableSortByFieldState]{
+			common.NewTableSortByFieldStateBuilder().DisplayName("namespace").Desc(false),
+		})
+}

--- a/tools/grafana-dashboards/internal/panels/stat.go
+++ b/tools/grafana-dashboards/internal/panels/stat.go
@@ -1,0 +1,37 @@
+package panels
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/stat"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/prom"
+)
+
+// StatPanelConfig configures a single-value stat panel.
+type StatPanelConfig struct {
+	ID          uint32
+	Title       string
+	Description string
+	Expr        string
+	Unit        string
+	GridPos     dashboard.GridPos
+	Steps       []ThresholdStep
+}
+
+// StatPanel builds a stat panel matching the Python generator defaults.
+func StatPanel(cfg StatPanelConfig) *stat.PanelBuilder {
+	return stat.NewPanelBuilder().
+		Id(cfg.ID).
+		Title(cfg.Title).
+		Description(cfg.Description).
+		Datasource(prom.Datasource()).
+		GridPos(cfg.GridPos).
+		Unit(cfg.Unit).
+		ColorScheme(dashboard.NewFieldColorBuilder().Mode(dashboard.FieldColorModeIdThresholds)).
+		Thresholds(AbsoluteThresholds(cfg.Steps)).
+		ColorMode(common.BigValueColorModeBackground).
+		GraphMode(common.BigValueGraphModeNone).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().Calcs([]string{"lastNotNull"})).
+		WithTarget(prom.Query(cfg.Expr))
+}

--- a/tools/grafana-dashboards/internal/panels/table.go
+++ b/tools/grafana-dashboards/internal/panels/table.go
@@ -1,0 +1,52 @@
+package panels
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/table"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/prom"
+)
+
+// TablePanelConfig configures a table panel.
+type TablePanelConfig struct {
+	ID              uint32
+	Title           string
+	Description     string
+	GridPos         dashboard.GridPos
+	Expr            string
+	Transformations []dashboard.DataTransformerConfig
+}
+
+// TablePanel builds a table panel with optional transformations.
+func TablePanel(cfg TablePanelConfig) *table.PanelBuilder {
+	b := table.NewPanelBuilder().
+		Id(cfg.ID).
+		Title(cfg.Title).
+		Description(cfg.Description).
+		Datasource(prom.Datasource()).
+		GridPos(cfg.GridPos).
+		CellHeight(common.TableCellHeightSm).
+		ShowHeader(true).
+		Footer(common.NewTableFooterOptionsBuilder().Show(false)).
+		WithTarget(prom.TableQuery(cfg.Expr, "A"))
+
+	for _, t := range cfg.Transformations {
+		b = b.WithTransformation(t)
+	}
+	return b
+}
+
+// OrganizeExclude hides named columns via an organize transformation.
+func OrganizeExclude(columns ...string) dashboard.DataTransformerConfig {
+	exclude := make(map[string]bool, len(columns))
+	for _, col := range columns {
+		exclude[col] = true
+	}
+	return dashboard.DataTransformerConfig{
+		Id: "organize",
+		Options: map[string]any{
+			"excludeByName": exclude,
+		},
+	}
+}

--- a/tools/grafana-dashboards/internal/panels/thresholds.go
+++ b/tools/grafana-dashboards/internal/panels/thresholds.go
@@ -1,0 +1,25 @@
+package panels
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+)
+
+// ThresholdStep is one absolute threshold color step (nil Value is the base color).
+type ThresholdStep struct {
+	Value *float64
+	Color string
+}
+
+// AbsoluteThresholds builds Grafana absolute threshold config from ordered steps.
+func AbsoluteThresholds(steps []ThresholdStep) *dashboard.ThresholdsConfigBuilder {
+	thresholds := make([]dashboard.Threshold, len(steps))
+	for i, step := range steps {
+		thresholds[i] = dashboard.Threshold{
+			Value: step.Value,
+			Color: step.Color,
+		}
+	}
+	return dashboard.NewThresholdsConfigBuilder().
+		Mode(dashboard.ThresholdsModeAbsolute).
+		Steps(thresholds)
+}

--- a/tools/grafana-dashboards/internal/panels/timeseries.go
+++ b/tools/grafana-dashboards/internal/panels/timeseries.go
@@ -1,0 +1,60 @@
+package panels
+
+import (
+	cog "github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/cog/variants"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+
+	"github.com/networking-incubator/coraza-kubernetes-operator/tools/grafana-dashboards/internal/prom"
+)
+
+// TimeseriesPanelConfig configures a timeseries panel matching the Python generator defaults.
+type TimeseriesPanelConfig struct {
+	ID          uint32
+	Title       string
+	Description string
+	Unit        string
+	GridPos     dashboard.GridPos
+	Queries     []prom.QuerySpec
+}
+
+// TimeseriesPanel builds a timeseries panel with palette-classic styling.
+func TimeseriesPanel(cfg TimeseriesPanelConfig) *timeseries.PanelBuilder {
+	unit := cfg.Unit
+	if unit == "" {
+		unit = "short"
+	}
+
+	spanNulls := common.BoolOrFloat64{Bool: cog.ToPtr(true)}
+
+	return timeseries.NewPanelBuilder().
+		Id(cfg.ID).
+		Title(cfg.Title).
+		Description(cfg.Description).
+		Datasource(prom.Datasource()).
+		GridPos(cfg.GridPos).
+		Unit(unit).
+		ColorScheme(dashboard.NewFieldColorBuilder().Mode(dashboard.FieldColorModeIdPaletteClassic)).
+		DrawStyle(common.GraphDrawStyleLine).
+		FillOpacity(10).
+		LineWidth(1).
+		ShowPoints(common.VisibilityModeNever).
+		AxisSoftMin(0).
+		SpanNulls(spanNulls).
+		Legend(common.NewVizLegendOptionsBuilder().
+			DisplayMode(common.LegendDisplayModeList).
+			Placement(common.LegendPlacementBottom).
+			ShowLegend(true),
+		).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Targets(promQueries(cfg.Queries))
+}
+
+func promQueries(specs []prom.QuerySpec) []cog.Builder[variants.Dataquery] {
+	return prom.Queries(specs)
+}

--- a/tools/grafana-dashboards/internal/prom/prom.go
+++ b/tools/grafana-dashboards/internal/prom/prom.go
@@ -1,0 +1,73 @@
+package prom
+
+import (
+	cog "github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/cog/variants"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+)
+
+// QuerySpec describes one Prometheus target on a panel.
+type QuerySpec struct {
+	Expr   string
+	Legend string
+}
+
+// Datasource returns the Prometheus datasource variable reference used by all panels.
+func Datasource() common.DataSourceRef {
+	return common.DataSourceRef{
+		Type: cog.ToPtr("prometheus"),
+		Uid:  cog.ToPtr("${DS_PROMETHEUS}"),
+	}
+}
+
+// Query builds a range Prometheus target with refId A.
+func Query(expr string) *prometheus.DataqueryBuilder {
+	return QueryWithRef(expr, "A", "")
+}
+
+// TableQuery builds an instant Prometheus target formatted as a table.
+func TableQuery(expr, refID string) *prometheus.DataqueryBuilder {
+	return prometheus.NewDataqueryBuilder().
+		Datasource(Datasource()).
+		Expr(expr).
+		RefId(refID).
+		Instant().
+		Format(prometheus.PromQueryFormatTable)
+}
+
+// QueryWithRef builds a range Prometheus target with legend and refId.
+func QueryWithRef(expr, refID, legend string) *prometheus.DataqueryBuilder {
+	b := prometheus.NewDataqueryBuilder().
+		Datasource(Datasource()).
+		Expr(expr).
+		RefId(refID).
+		Range()
+	if legend != "" {
+		b = b.LegendFormat(legend)
+	}
+	return b
+}
+
+// InstantQueryWithRef builds an instant Prometheus target with legend and refId.
+func InstantQueryWithRef(expr, refID, legend string) *prometheus.DataqueryBuilder {
+	b := prometheus.NewDataqueryBuilder().
+		Datasource(Datasource()).
+		Expr(expr).
+		RefId(refID).
+		Instant()
+	if legend != "" {
+		b = b.LegendFormat(legend)
+	}
+	return b
+}
+
+// Queries builds range Prometheus targets with refIds A, B, C, …
+func Queries(specs []QuerySpec) []cog.Builder[variants.Dataquery] {
+	targets := make([]cog.Builder[variants.Dataquery], len(specs))
+	for i, spec := range specs {
+		refID := string(rune('A' + i))
+		targets[i] = QueryWithRef(spec.Expr, refID, spec.Legend)
+	}
+	return targets
+}

--- a/tools/grafana-dashboards/testdata/golden/overview.semantic.json
+++ b/tools/grafana-dashboards/testdata/golden/overview.semantic.json
@@ -1,0 +1,581 @@
+{
+  "uid": "coraza-operator-overview",
+  "title": "Coraza Operator — Overview",
+  "tags": [
+    "control-plane",
+    "coraza",
+    "operator",
+    "waf"
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": 2,
+      "type": "row",
+      "title": "Health summary",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Engines not ready",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "exprs": [
+        "coraza:engines_not_ready:count"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "RuleSets not ready",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 4
+      },
+      "exprs": [
+        "coraza:rulesets_not_ready:count"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "RuleSources degraded",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 4
+      },
+      "exprs": [
+        "coraza:rulesources_degraded:count"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Reconcile error ratio",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 4
+      },
+      "exprs": [
+        "(sum(rate(controller_runtime_reconcile_errors_total{controller=~\"ruleset|engine|rulesource\"}[5m])) / sum(rate(controller_runtime_reconcile_total{controller=~\"ruleset|engine|rulesource\"}[5m]))) and sum(rate(controller_runtime_reconcile_total{controller=~\"ruleset|engine|rulesource\"}[5m])) \u003e 0"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Cache utilization",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 4
+      },
+      "exprs": [
+        "(coraza_cache_size_bytes / coraza_cache_config_max_size_bytes) and coraza_cache_config_max_size_bytes \u003e 0"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Cache hit ratio",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "exprs": [
+        "coraza:cache_hit_ratio:rate5m"
+      ]
+    },
+    {
+      "id": 9,
+      "type": "row",
+      "title": "Reconciliation",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Reconcile rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "exprs": [
+        "sum by (controller, result) (rate(controller_runtime_reconcile_total{controller=~\"ruleset|engine|rulesource\"}[5m]))"
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Reconcile errors",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "exprs": [
+        "sum by (controller) (rate(controller_runtime_reconcile_errors_total{controller=~\"ruleset|engine|rulesource\"}[5m]))"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Reconcile duration p99",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "exprs": [
+        "histogram_quantile(0.50, sum by (le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket{controller=~\"ruleset|engine|rulesource\"}[5m])))",
+        "histogram_quantile(0.99, sum by (le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket{controller=~\"ruleset|engine|rulesource\"}[5m])))"
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Workqueue depth",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "exprs": [
+        "workqueue_depth{name=~\"ruleset|engine|rulesource\"}"
+      ]
+    },
+    {
+      "id": 14,
+      "type": "row",
+      "title": "Validation",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      }
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "RuleSource validation rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "exprs": [
+        "sum by (outcome) (rate(coraza_rulesource_validations_total[5m]))"
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "RuleSet validation rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "exprs": [
+        "sum by (outcome) (rate(coraza_ruleset_validations_total[5m]))"
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "RuleSource validation duration",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "exprs": [
+        "histogram_quantile(0.50, sum by (le, outcome) (rate(coraza_rulesource_validation_duration_seconds_bucket[5m])))",
+        "histogram_quantile(0.99, sum by (le, outcome) (rate(coraza_rulesource_validation_duration_seconds_bucket[5m])))"
+      ]
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "RuleSet validation duration",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "exprs": [
+        "histogram_quantile(0.50, sum by (le, outcome) (rate(coraza_ruleset_validation_duration_seconds_bucket[5m])))",
+        "histogram_quantile(0.99, sum by (le, outcome) (rate(coraza_ruleset_validation_duration_seconds_bucket[5m])))"
+      ]
+    },
+    {
+      "id": 19,
+      "type": "row",
+      "title": "Cache server — RED",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Request rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "exprs": [
+        "sum by (handler, code) (rate(coraza_cache_server_requests_total[5m]))"
+      ]
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Errors \u0026 auth failures",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "exprs": [
+        "rate(coraza_cache_server_auth_failures_total[5m])",
+        "sum(rate(coraza_cache_server_requests_total{code=~\"5..\"}[5m]))"
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Request latency",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "exprs": [
+        "histogram_quantile(0.50, sum by (le, handler) (rate(coraza_cache_server_request_duration_seconds_bucket[5m])))",
+        "histogram_quantile(0.99, sum by (le, handler) (rate(coraza_cache_server_request_duration_seconds_bucket[5m])))"
+      ]
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "In-flight requests",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "exprs": [
+        "coraza_cache_server_in_flight_requests"
+      ]
+    },
+    {
+      "id": 24,
+      "type": "row",
+      "title": "Cache server — USE",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      }
+    },
+    {
+      "id": 25,
+      "type": "timeseries",
+      "title": "Cache size vs limit",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "exprs": [
+        "coraza_cache_config_max_size_bytes",
+        "coraza_cache_size_bytes"
+      ]
+    },
+    {
+      "id": 26,
+      "type": "timeseries",
+      "title": "GC prune rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "exprs": [
+        "sum by (reason) (rate(coraza_cache_gc_pruned_entries_total[15m]))"
+      ]
+    },
+    {
+      "id": 27,
+      "type": "timeseries",
+      "title": "Cache instances \u0026 entries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "exprs": [
+        "coraza_cache_instances",
+        "coraza_cache_total_entries"
+      ]
+    },
+    {
+      "id": 28,
+      "type": "timeseries",
+      "title": "Cache Put duration",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 65
+      },
+      "exprs": [
+        "histogram_quantile(0.50, sum by (le, namespace) (rate(coraza_cache_set_duration_seconds_bucket[5m])))",
+        "histogram_quantile(0.99, sum by (le, namespace) (rate(coraza_cache_set_duration_seconds_bucket[5m])))"
+      ]
+    },
+    {
+      "id": 29,
+      "type": "row",
+      "title": "Kubernetes API \u0026 workqueue",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 72
+      }
+    },
+    {
+      "id": 30,
+      "type": "timeseries",
+      "title": "API request rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 73
+      },
+      "exprs": [
+        "sum by (verb, resource) (rate(rest_client_requests_total[5m]))"
+      ]
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "API errors (non-2xx)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 73
+      },
+      "exprs": [
+        "sum by (code) (rate(rest_client_requests_total{code!~\"2..\"}[5m]))"
+      ]
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "API request latency p99",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 81
+      },
+      "exprs": [
+        "histogram_quantile(0.50, sum by (le, verb) (rate(rest_client_request_duration_seconds_bucket[5m])))",
+        "histogram_quantile(0.99, sum by (le, verb) (rate(rest_client_request_duration_seconds_bucket[5m])))"
+      ]
+    },
+    {
+      "id": 33,
+      "type": "timeseries",
+      "title": "Workqueue retries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 81
+      },
+      "exprs": [
+        "sum by (name) (rate(workqueue_retries_total{name=~\"ruleset|engine|rulesource\"}[5m]))"
+      ]
+    },
+    {
+      "id": 34,
+      "type": "timeseries",
+      "title": "Longest running processor",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 89
+      },
+      "exprs": [
+        "workqueue_longest_running_processor_seconds{name=~\"ruleset|engine|rulesource\"}"
+      ]
+    },
+    {
+      "id": 35,
+      "type": "timeseries",
+      "title": "Unfinished work",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 89
+      },
+      "exprs": [
+        "workqueue_unfinished_work_seconds{name=~\"ruleset|engine|rulesource\"}"
+      ]
+    },
+    {
+      "id": 36,
+      "type": "row",
+      "title": "Resource counts by namespace",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 96
+      }
+    },
+    {
+      "id": 37,
+      "type": "table",
+      "title": "Engines",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 97
+      },
+      "exprs": [
+        "coraza_engines"
+      ],
+      "transformationIds": [
+        "organize"
+      ]
+    },
+    {
+      "id": 38,
+      "type": "table",
+      "title": "RuleSets",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 97
+      },
+      "exprs": [
+        "coraza_rulesets"
+      ],
+      "transformationIds": [
+        "organize"
+      ]
+    },
+    {
+      "id": 39,
+      "type": "table",
+      "title": "RuleSources",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 103
+      },
+      "exprs": [
+        "coraza_rulesources"
+      ],
+      "transformationIds": [
+        "organize"
+      ]
+    },
+    {
+      "id": 40,
+      "type": "table",
+      "title": "RuleData",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 103
+      },
+      "exprs": [
+        "coraza_ruledatas"
+      ],
+      "transformationIds": [
+        "organize"
+      ]
+    }
+  ],
+  "links": [
+    {
+      "title": "Resource drill-down",
+      "url": "/d/coraza-operator-resources/coraza-operator-resources?${__url_time_range}"
+    }
+  ],
+  "variables": [
+    {
+      "name": "DS_PROMETHEUS",
+      "type": "datasource"
+    }
+  ]
+}

--- a/tools/grafana-dashboards/testdata/golden/resources.semantic.json
+++ b/tools/grafana-dashboards/testdata/golden/resources.semantic.json
@@ -1,0 +1,251 @@
+{
+  "uid": "coraza-operator-resources",
+  "title": "Coraza Operator — Resources",
+  "tags": [
+    "control-plane",
+    "coraza",
+    "operator",
+    "waf"
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": 2,
+      "type": "row",
+      "title": "Selected Engine",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      }
+    },
+    {
+      "id": 3,
+      "type": "table",
+      "title": "Engine conditions",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "exprs": [
+        "label_join(coraza_engine_condition{namespace=~\"$namespace\", condition=~\"Ready|Progressing|Degraded|Accepted\"}, \"resource\", \"/\", \"namespace\", \"name\")"
+      ],
+      "transformationIds": [
+        "groupingToMatrix",
+        "renameByRegex",
+        "organize"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "Engine details",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "exprs": [
+        "coraza_engine_info{namespace=~\"$namespace\", name=~\"$engine\", ruleset_name=~\"$ruleset\"}"
+      ],
+      "transformationIds": [
+        "organize"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "RuleSets in namespace",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      }
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "RuleSet conditions",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "exprs": [
+        "label_join(coraza_ruleset_condition{namespace=~\"$namespace\", condition=~\"Ready|Progressing|Degraded\"}, \"resource\", \"/\", \"namespace\", \"name\")"
+      ],
+      "transformationIds": [
+        "groupingToMatrix",
+        "renameByRegex",
+        "organize"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "RuleSet composition",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "exprs": [
+        "coraza_ruleset_data_files{namespace=~\"$namespace\"}",
+        "coraza_ruleset_sources{namespace=~\"$namespace\"}"
+      ],
+      "transformationIds": [
+        "merge",
+        "organize"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Namespace inventory — Engines",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      }
+    },
+    {
+      "id": 9,
+      "type": "table",
+      "title": "Engines in namespace",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "exprs": [
+        "label_join(coraza_engine_condition{namespace=~\"$namespace\", condition=~\"Ready|Degraded\"}, \"resource\", \"/\", \"namespace\", \"name\")"
+      ],
+      "transformationIds": [
+        "groupingToMatrix",
+        "renameByRegex",
+        "organize"
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Namespace inventory — RuleSources",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      }
+    },
+    {
+      "id": 11,
+      "type": "table",
+      "title": "RuleSources",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "exprs": [
+        "label_join(coraza_rulesource_condition{namespace=~\"$namespace\", condition=~\"Ready|Degraded\"}, \"resource\", \"/\", \"namespace\", \"name\")"
+      ],
+      "transformationIds": [
+        "groupingToMatrix",
+        "renameByRegex",
+        "organize"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "row",
+      "title": "Operator-wide activity",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      }
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Reconcile rate (all controllers)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "exprs": [
+        "sum by (controller, result) (rate(controller_runtime_reconcile_total{controller=~\"ruleset|engine|rulesource\"}[5m]))"
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Cache request rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "exprs": [
+        "sum by (handler) (rate(coraza_cache_server_requests_total[5m]))"
+      ]
+    }
+  ],
+  "links": [
+    {
+      "title": "Overview",
+      "url": "/d/coraza-operator-overview/coraza-operator-overview?${__url_time_range}"
+    }
+  ],
+  "variables": [
+    {
+      "name": "DS_PROMETHEUS",
+      "type": "datasource"
+    },
+    {
+      "name": "engine",
+      "type": "query",
+      "definition": "label_values(coraza_engine_info{namespace=~\"$namespace\"}, name)",
+      "multi": true,
+      "includeAll": true
+    },
+    {
+      "name": "namespace",
+      "type": "query",
+      "definition": "label_values({__name__=~\"coraza_(engines|rulesets|rulesources|ruledatas|engine_info|ruleset_info|rulesource_info|ruledata_info)\"}, namespace)",
+      "multi": true,
+      "includeAll": true
+    },
+    {
+      "name": "ruleset",
+      "type": "query",
+      "definition": "label_values(coraza_ruleset_info{namespace=~\"$namespace\"}, name)",
+      "multi": true,
+      "includeAll": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Go-based Grafana dashboard generator (`tools/grafana-dashboards/`) with golden tests
- Helm dashboards: **Coraza Operator — Overview** and **Resources**
- KIND observability demo (`make observability.demo`) and docs

## Depends on

**Merge #423 first.** This branch includes #423's commit plus one dashboard commit (`9d4db06`). Diff vs `main` shows both; dashboard-only delta is the second commit.

## Test plan

- [x] `make observability.dashboard.validate`
- [x] `make test`

## Note

Replaces the dashboard portion of #405 — close #405 after both PRs merge.