### PR TITLE
bump proxy-wasm to version with CRS 4.28

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,12 @@ make manifests generate helm.sync  # Regenerate CRDs, RBAC, and sync to Helm cha
 
 Run a single unit test:
 ```bash
-ISTIO_VERSION=1.28.2 go test -v -run TestMyFunction ./internal/controller/...
+ISTIO_VERSION=1.30.3 go test -v -run TestMyFunction ./internal/controller/...
 ```
 
 Verify test files compile (go build silently ignores `_test.go`):
 ```bash
-ISTIO_VERSION=1.28.2 go test -run ^$ ./...
+ISTIO_VERSION=1.30.3 go test -run ^$ ./...
 ```
 
 ### Test tiers (require build tags and a cluster)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -511,9 +511,9 @@ make helm.sync
 | `IMAGE_REGISTRY` | Registry and org prefix for all images | `ghcr.io/networking-incubator` |
 | `CONTROLLER_MANAGER_CONTAINER_IMAGE` | Full operator image reference | `$(IMAGE_REGISTRY)/coraza-kubernetes-operator:v0.0.0-dev` |
 | `KIND_CLUSTER_NAME` | KIND cluster name for tests | `coraza-kubernetes-operator-integration` |
-| `ISTIO_VERSION` | Istio version for deployment | `1.28.2` |
-| `METALLB_VERSION` | MetalLB version for KIND | `0.15.3` |
-| `CORERULESET_VERSION` | CoreRuleSet version | `v4.24.1` |
+| `ISTIO_VERSION` | Istio version for deployment | `1.30.3` |
+| `METALLB_VERSION` | MetalLB version for KIND | `0.16.1` |
+| `CORERULESET_VERSION` | CoreRuleSet version | `v4.28.0` |
 | `CORAZA_WASM_IMAGE` | WASM plugin image for tests | (See `test/framework/resources.go`) |
 | `NAMESPACE` | Target namespace for deployments | `default` |
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -117,7 +117,7 @@ Paranoia Level 4 generates false positives due to Envoy populating the `:path` p
 
 ---
 
-## Coraza/WASM Bugs (13 tests)
+## Coraza/WASM Bugs (20 tests)
 
 These issues should be fixed in Coraza or coraza-proxy-wasm.
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -25,18 +25,18 @@ Both tiers are rejected by default. For the complete list of affected rule IDs, 
 
 ## Overview
 
-Out of approximately 4,600 CoreRuleSet conformance tests, 53 tests are currently ignored and 42 are overridden with adjusted expectations, resulting in a ~98% pass rate. These fall into four categories:
+Out of approximately 4,600 CoreRuleSet conformance tests, 60 tests are currently ignored and 43 are overridden with adjusted expectations, resulting in a ~98% pass rate. These fall into four categories:
 
 | Category | Tests | Type | Impact |
 |----------|-------|------|--------|
-| Enhanced Security | 42 | Overridden | Positive - Envoy provides additional protection |
+| Enhanced Security | 43 | Overridden | Positive - Envoy provides additional protection |
 | Tool Limitations | 21 | Ignored | Requires alternative controls or monitoring |
-| Coraza/WASM Bugs | 13 | Ignored | Requires fixes in Coraza or coraza-proxy-wasm |
+| Coraza/WASM Bugs | 20 | Ignored | Requires fixes in Coraza or coraza-proxy-wasm |
 | Under Investigation | 19 | Ignored | Requires further analysis |
 
 ---
 
-## Enhanced Security (42 overridden tests)
+## Enhanced Security (43 overridden tests)
 
 These tests are overridden with adjusted expectations (in `.ftw-overrides.yml`) rather than ignored. Envoy blocks or sanitizes attacks before they reach the WAF. This represents defense-in-depth, not a security gap.
 
@@ -61,11 +61,11 @@ Envoy normalizes missing or empty HTTP headers during HTTP/2 processing to enfor
 
 **Impact:** Positive. Ensures protocol compliance and prevents attacks relying on missing headers.
 
-### Malicious Header Sanitization (20 tests)
+### Malicious Header Sanitization (21 tests)
 
 Envoy sanitizes HTTP headers containing malicious payloads (XSS, SQLi, RCE) before they reach the WAF.
 
-**Affected rules:** 932161, 932207, 932237, 932239, 941101, 941110, 941120, 942280
+**Affected rules:** 932161, 932207, 932237, 932239, 932390, 941101, 941110, 941120, 942280
 
 **Examples:**
 - Referer headers with invalid characters: Removed
@@ -153,6 +153,20 @@ Some rules fail only when multiphase evaluation is enabled.
 
 **Impact:** RCE and PHP injection attacks may bypass detection with multiphase evaluation.
 
+### CRS 4.28 Regressions (7 tests)
+
+New CRS 4.28.0 rules and rule updates introduced test failures against Coraza 3.7.0 that require investigation.
+
+**Affected rules:** 920540, 931130, 941310
+
+**Examples:**
+- Log target not formatted as `ARGS:<name>` (920540, 931130)
+- `REQBODY_PROCESSOR` not set to JSON for empty-body JSON requests, so `ctl:ruleRemoveById=920540` never triggers (920540)
+- Raw non-ASCII bytes in the request body not matched by `\x{bc}`/`\x{be}` against the RE2-based regex engine, which requires valid UTF-8 rune matching (941310)
+- XML attribute values (`XML://@*`) not inspected — added in the CRS 4.28 GHSA-6jp8 fix (941310)
+
+**Impact:** Attack patterns using non-ASCII byte sequences or XML attribute injection may bypass detection. The log-target formatting issues do not affect blocking behavior, only anomaly-log accuracy.
+
 ---
 
 ## Under Investigation (19 tests)
@@ -172,11 +186,11 @@ These require further analysis to determine appropriate action:
 
 ## Version Information
 
-- **Coraza**: v3.6.0
-- **CoreRuleSet**: v4.24.1
+- **Coraza**: v3.7.0
+- **CoreRuleSet**: v4.28.0
 - **Envoy/Istio**: WASM filter environment
 - **coraza-proxy-wasm**: Latest
-- **Documentation Date**: 2026-04-16
-- **Test Coverage**: ~98% pass rate (53 ignored + 42 overridden / ~4,600 total)
+- **Documentation Date**: 2026-07-22
+- **Test Coverage**: ~98% pass rate (60 ignored + 43 overridden / ~4,600 total)
 
 For configuration details of ignored tests, see [test/conformance/ftw.yml](test/conformance/ftw.yml).

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ KIND_CLUSTER_NAME ?= coraza-kubernetes-operator-integration
 # Default coraza matches kind + operator Helm in hack/kind_cluster.py. For OpenShift,
 # use openshift-gateway (match operator istio.revision) or empty for default-revision Istio.
 ISTIO_GATEWAY_REVISION ?= coraza
-ISTIO_VERSION ?= 1.28.2
+ISTIO_VERSION ?= 1.30.3
 # Pin kube-prometheus-stack chart version (https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack).
 # Override at install time: make observability.prometheus.deploy KUBE_PROM_STACK_VERSION=x.y.z
 KUBE_PROM_STACK_VERSION ?= 86.2.3
@@ -33,7 +33,7 @@ GRAFANA_ADMIN_PASSWORD ?= coraza-demo
 # Used by promtool in CI and: make observability.promtool.install
 PROM_VERSION ?= 3.12.0
 PROM_SHA256_LINUX_AMD64 ?= 20da47f8e5303f74aecb78edd7f7e39041dac08ac4939dba75efd7a900ae8867
-METALLB_VERSION ?= 0.15.3
+METALLB_VERSION ?= 0.16.1
 METALLB_POOL_SIZE ?= 128 # Defines the size of MetalLB pool, when being used
 
 VERSION ?= v0.0.0-dev
@@ -301,7 +301,7 @@ test.tools:
 # Coraza Coreruleset targets
 # -------------------------------------------------------------------------------
 
-CORERULESET_VERSION ?= v4.24.1
+CORERULESET_VERSION ?= v4.28.0
 LOCALRULES ?= $(shell pwd)/tmp/rules
 CORERULESET_DIR ?= $(shell pwd)/tmp/coreruleset
 TMP_DOWNLOAD_DIR ?= $(shell pwd)/tmp/download

--- a/cmd/kubectl-coraza/README.md
+++ b/cmd/kubectl-coraza/README.md
@@ -17,7 +17,7 @@ kubectl coraza --version
 ```bash
 kubectl coraza generate coreruleset \
   --rules-dir /path/to/rules \
-  --version 4.24.1 \
+  --version 4.28.0 \
   [--namespace my-ns] \
   [--ruleset-name default-ruleset] \
   [flags...]
@@ -30,7 +30,7 @@ Reads `*.conf` and optional `*.data` from a single directory (non-recursive). Ou
 | Flag | Description |
 |------|-------------|
 | `--rules-dir` | Directory with `*.conf` / `*.data` (required) |
-| `--version` | CRS version, e.g. `4.24.1` (required) |
+| `--version` | CRS version, e.g. `4.28.0` (required) |
 | `-n`, `--namespace` | Set `metadata.namespace` on every object |
 | `--ruleset-name` | RuleSet name (default `default-ruleset`) |
 | `--data-source-name` | `RuleData` name for `*.data` files (default `coreruleset-data`) |
@@ -48,11 +48,11 @@ Reads `*.conf` and optional `*.data` from a single directory (non-recursive). Ou
 Generation logic lives in [`../../tools/corerulesetgen`](../../tools/corerulesetgen) and can be used directly without the kubectl wrapper.
 
 ```go
-ver, _ := corerulesetgen.ParseCRSVersion("4.24.1")
+ver, _ := corerulesetgen.ParseCRSVersion("4.28.0")
 scan, _ := corerulesetgen.Scan("/path/to/rules")
 bundle, _ := corerulesetgen.Build(corerulesetgen.Options{
     RulesDir:    "/path/to/rules",
-    Version:     "4.24.1",
+    Version:     "4.28.0",
     RuleSetName: "my-ruleset",
 }, scan, ver)
 corerulesetgen.WriteManifests(os.Stdout, bundle)

--- a/cmd/kubectl-coraza/main.go
+++ b/cmd/kubectl-coraza/main.go
@@ -70,7 +70,7 @@ namespace as the RuleSet; set --namespace when you need metadata.namespace on ev
 	flags := coreruleset.Flags()
 	flags.String("rules-dir", "", "directory containing CoreRuleSet *.conf (and optional *.data) [required]")
 	_ = coreruleset.MarkFlagRequired("rules-dir")
-	flags.String("version", "", "CoreRuleSet version (e.g. 4.24.1 or v4.24.1) [required]")
+	flags.String("version", "", "CoreRuleSet version (e.g. 4.28.0 or v4.28.0) [required]")
 	_ = coreruleset.MarkFlagRequired("version")
 	flags.String("ignore-rules", "", "comma-separated rule IDs to drop")
 	flags.Bool("ignore-pmFromFile", false, "strip SecRule lines that use @pmFromFile")

--- a/cmd/kubectl-coraza/main_test.go
+++ b/cmd/kubectl-coraza/main_test.go
@@ -38,7 +38,7 @@ import (
 func TestGenCRS_minimalFixture(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestGenCRS_minimalFixture(t *testing.T) {
 func TestGenCRS_ignoreRules(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ignore-rules", "100"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ignore-rules", "100"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestGenCRS_ignoreRules(t *testing.T) {
 func TestGenCRS_ignoreRulesMultiple(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ignore-rules", " 200 , 100 , "})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ignore-rules", " 200 , 100 , "})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestGenCRS_ignoreRulesMultiple(t *testing.T) {
 func TestGenCRS_ignoreRulesEmpty(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, _, stderr := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ignore-rules", " , , "})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ignore-rules", " , , "})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestGenCRS_ignoreRulesEmpty(t *testing.T) {
 func TestGenCRS_ignoreRulesWritesToCmdStderr(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, _, stderr := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ignore-rules", "100"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ignore-rules", "100"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestGenCRS_ignoreRulesWritesToCmdStderr(t *testing.T) {
 func TestGenCRS_dryRun(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--dry-run", "client"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--dry-run", "client"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestGenCRS_dryRun(t *testing.T) {
 func TestGenCRS_dryRunCaseInsensitive(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--dry-run", " CLIENT "})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--dry-run", " CLIENT "})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestGenCRS_dryRunCaseInsensitive(t *testing.T) {
 func TestGenCRS_namespace(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "-n", "waf-system"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "-n", "waf-system"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestGenCRS_namespace(t *testing.T) {
 func TestGenCRS_customRulesetName(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ruleset-name", "my-ruleset"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ruleset-name", "my-ruleset"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestGenCRS_customRulesetName(t *testing.T) {
 
 func TestGenCRS_invalidRulesDir(t *testing.T) {
 	cmd, _, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", "/nonexistent/path", "--version", "4.24.1"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", "/nonexistent/path", "--version", "4.28.0"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -162,7 +162,7 @@ func TestGenCRS_invalidVersion(t *testing.T) {
 func TestGenCRS_invalidRulesetName(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, _, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ruleset-name", "INVALID NAME!"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ruleset-name", "INVALID NAME!"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -192,7 +192,7 @@ func TestGenCRS_excludesUnsupportedByDefault(t *testing.T) {
 			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644))
 
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0"})
 
 	require.NoError(t, cmd.Execute())
 	assert.NotContains(t, stdout.String(), "id:922110,")
@@ -207,7 +207,7 @@ func TestGenCRS_ignoreUnsupportedRulesNone(t *testing.T) {
 			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644))
 
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ignore-unsupported-rules=none"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ignore-unsupported-rules=none"})
 
 	require.NoError(t, cmd.Execute())
 	assert.Contains(t, stdout.String(), "id:922110,")
@@ -222,7 +222,7 @@ func TestGenCRS_ignoreUnsupportedRulesExplicitWASM(t *testing.T) {
 			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644))
 
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ignore-unsupported-rules=wasm"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ignore-unsupported-rules=wasm"})
 
 	require.NoError(t, cmd.Execute())
 	assert.NotContains(t, stdout.String(), "id:922110,")
@@ -236,7 +236,7 @@ func TestGenCRS_unknownIgnoreUnsupportedProfileKeepsRegistryRule(t *testing.T) {
 		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"), 0o644))
 
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ignore-unsupported-rules=ext_proc"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ignore-unsupported-rules=ext_proc"})
 
 	require.NoError(t, cmd.Execute())
 	assert.Contains(t, stdout.String(), "id:922110,", "unknown profile should not apply WASM registry until implemented")
@@ -249,7 +249,7 @@ func TestGenCRS_ignoreUnsupportedRulesWASMAllowsMixedCase(t *testing.T) {
 		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"), 0o644))
 
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.24.1", "--ignore-unsupported-rules=WaSm"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "4.28.0", "--ignore-unsupported-rules=WaSm"})
 
 	require.NoError(t, cmd.Execute())
 	assert.NotContains(t, stdout.String(), "id:922110,")
@@ -265,7 +265,7 @@ func TestGenCRS_skipValidationRuleSourceFlag(t *testing.T) {
 	cmd.SetArgs([]string{
 		"generate", "coreruleset",
 		"--rules-dir", dir,
-		"--version", "4.24.1",
+		"--version", "4.28.0",
 		"--skip-validation-rulesource=patch",
 	})
 
@@ -284,7 +284,7 @@ func TestGenCRS_missingRequiredFlags(t *testing.T) {
 func TestGenCRS_versionWithPrefix(t *testing.T) {
 	dir := testdataDir(t, "minimal")
 	cmd, stdout, _ := newTestCommand(t)
-	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "v4.24.1"})
+	cmd.SetArgs([]string{"generate", "coreruleset", "--rules-dir", dir, "--version", "v4.28.0"})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -297,7 +297,7 @@ func TestGenCRS_generatedManifestsParseAsYAML(t *testing.T) {
 		fixture string
 		version string
 	}{
-		{"minimal", "minimal", "4.24.1"},
+		{"minimal", "minimal", "4.28.0"},
 		{"withRuleData", "withdata", "4.0.0"},
 	}
 	for _, tc := range cases {

--- a/config/samples/echo.yaml
+++ b/config/samples/echo.yaml
@@ -25,6 +25,6 @@ spec:
     spec:
       containers:
         - name: echo
-          image: registry.k8s.io/gateway-api/echo-basic:v20251204-v1.4.1
+          image: registry.k8s.io/gateway-api/conformance/echo-basic:v0.1.0
           ports:
             - containerPort: 3000

--- a/docs/content/howto/using-coreruleset.md
+++ b/docs/content/howto/using-coreruleset.md
@@ -38,7 +38,7 @@ kubectl coraza --help
 Download the CoreRuleSet release archive and extract the rules:
 
 ```bash
-export CRS_VERSION=4.24.1
+export CRS_VERSION=4.28.0
 curl -fsSL "https://github.com/coreruleset/coreruleset/archive/refs/tags/v${CRS_VERSION}.tar.gz" \
   | tar xz
 ```

--- a/docs/content/reference/kubectl-coraza.md
+++ b/docs/content/reference/kubectl-coraza.md
@@ -38,7 +38,7 @@ Generate **RuleSource** resources (one per `*.conf` file), an optional **RuleDat
 | Flag | Description |
 |------|-------------|
 | `--rules-dir` | Directory containing CoreRuleSet `*.conf` and optional `*.data` files. The directory is not traversed recursively. |
-| `--version` | CoreRuleSet version (e.g., `4.24.1` or `v4.24.1`). The leading `v` is normalized automatically. |
+| `--version` | CoreRuleSet version (e.g., `4.28.0` or `v4.28.0`). The leading `v` is normalized automatically. |
 
 #### Optional Flags
 
@@ -71,7 +71,7 @@ Generate rules with default settings:
 ```bash
 kubectl coraza generate coreruleset \
   --rules-dir /path/to/coreruleset/rules \
-  --version 4.24.1
+  --version 4.28.0
 ```
 
 Generate rules for a specific namespace, excluding certain rule IDs:
@@ -79,7 +79,7 @@ Generate rules for a specific namespace, excluding certain rule IDs:
 ```bash
 kubectl coraza generate coreruleset \
   --rules-dir /path/to/coreruleset/rules \
-  --version 4.24.1 \
+  --version 4.28.0 \
   --namespace production \
   --ignore-rules 949110,980130
 ```
@@ -89,7 +89,7 @@ Generate rules without `@pmFromFile` directives:
 ```bash
 kubectl coraza generate coreruleset \
   --rules-dir /path/to/coreruleset/rules \
-  --version 4.24.1 \
+  --version 4.28.0 \
   --ignore-pmFromFile
 ```
 
@@ -98,6 +98,6 @@ Preview output without applying:
 ```bash
 kubectl coraza generate coreruleset \
   --rules-dir /path/to/coreruleset/rules \
-  --version 4.24.1 \
+  --version 4.28.0 \
   --dry-run=client
 ```

--- a/docs/content/tutorials/getting-started-kubernetes.md
+++ b/docs/content/tutorials/getting-started-kubernetes.md
@@ -75,7 +75,7 @@ spec:
     spec:
       containers:
         - name: echo
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/conformance/echo-basic:v0.1.0
           ports:
             - containerPort: 3000
 ---

--- a/docs/content/tutorials/getting-started-openshift.md
+++ b/docs/content/tutorials/getting-started-openshift.md
@@ -101,7 +101,7 @@ spec:
     spec:
       containers:
         - name: echo
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          image: registry.k8s.io/gateway-api/conformance/echo-basic:v0.1.0
           ports:
             - containerPort: 3000
 ---

--- a/hack/kind_cluster.py
+++ b/hack/kind_cluster.py
@@ -22,7 +22,7 @@ from lib import (
 DEFAULT_NAMESPACE = "integration-tests"
 GATEWAY_API_URL = (
     "https://github.com/kubernetes-sigs/gateway-api"
-    "/releases/download/v1.4.1/standard-install.yaml"
+    "/releases/download/v1.6.1/standard-install.yaml"
 )
 SAIL_REPO = "https://istio-ecosystem.github.io/sail-operator"
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -315,7 +315,7 @@ func downloadIstioCRDs() (string, error) {
 func downloadGatewayAPICRDs() (string, error) {
 	// Use the standard Gateway API CRDs. The version should be compatible with
 	// the Istio version used in tests.
-	const gatewayAPICRDURL = "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml"
+	const gatewayAPICRDURL = "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml"
 
 	tmpDir, err := os.MkdirTemp("", "gateway-api-crds-*")
 	if err != nil {

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -20,4 +20,4 @@ package defaults
 // DefaultCorazaWasmOCIReference is the built-in default OCI URL for the Coraza WASM
 // plugin when an Engine omits spec.driver.wasm.image. Override at runtime via
 // --default-wasm-image, CORAZA_DEFAULT_WASM_IMAGE, or per-Engine spec.
-const DefaultCorazaWasmOCIReference = "oci://ghcr.io/networking-incubator/coraza-proxy-wasm:9ca29e4f4cf3a8c1710a7ed7a8ec399b56cb7296"
+const DefaultCorazaWasmOCIReference = "oci://ghcr.io/networking-incubator/coraza-proxy-wasm:64800ac102924d1205097ba6efc95fbd5a99f9d3"

--- a/internal/rulesets/unsupported.go
+++ b/internal/rulesets/unsupported.go
@@ -33,7 +33,7 @@ import (
 var ruleIDPattern = regexp.MustCompile(`\bid:['"]?(\d+)['"]?`)
 
 // unsupportedRules is the registry of all known unsupported rule IDs.
-// Coupled to CoreRuleSet v4.24.1 (source: LIMITATIONS.md, test/conformance/ftw.yml).
+// Coupled to CoreRuleSet v4.28.0 (source: LIMITATIONS.md, test/conformance/ftw.yml).
 var unsupportedRules = buildRegistry()
 
 // -----------------------------------------------------------------------------
@@ -197,6 +197,14 @@ func buildRegistry() map[int]UnsupportedRule {
 		Description: "fails with multiphase evaluation enabled (Coraza bug)",
 	}
 
+	// CRS 4.28 regressions (Coraza 3.7.0 + CRS 4.28.0)
+	r[941310] = UnsupportedRule{
+		ID:          941310,
+		Category:    "regex/XML attribute inspection",
+		Tier:        TierIncompatible,
+		Description: "raw non-ASCII bytes in body not matched by RE2-based regex engine, and XML attribute values (XML://@*) not inspected (Coraza bug, CRS 4.28 GHSA-6jp8 fix)",
+	}
+
 	// -------------------------------------------------------------------------
 	// Under Investigation - incompatible rules with unclear cause
 	// -------------------------------------------------------------------------
@@ -258,7 +266,7 @@ func buildRegistry() map[int]UnsupportedRule {
 	}
 
 	// Header sanitization: Envoy sanitizes malicious payloads in headers.
-	for _, id := range []int{932161, 932207, 932237, 932239, 941101, 941110, 941120, 942280} {
+	for _, id := range []int{932161, 932207, 932237, 932239, 932390, 941101, 941110, 941120, 942280} {
 		r[id] = UnsupportedRule{
 			ID:          id,
 			Category:    "header sanitization",

--- a/internal/rulesets/unsupported_test.go
+++ b/internal/rulesets/unsupported_test.go
@@ -31,9 +31,9 @@ func TestRegistryCompleteness(t *testing.T) {
 	total := len(incompatible) + len(redundant)
 
 	assert.Equal(t, total, len(unsupportedRules), "total registry size should equal sum of tiers")
-	assert.Len(t, incompatible, 16, "incompatible tier count")
-	assert.Len(t, redundant, 21, "redundant tier count")
-	assert.Equal(t, 37, total, "total unsupported rules")
+	assert.Len(t, incompatible, 17, "incompatible tier count")
+	assert.Len(t, redundant, 22, "redundant tier count")
+	assert.Equal(t, 39, total, "total unsupported rules")
 }
 
 func TestAllUnsupportedRuleIDs(t *testing.T) {
@@ -82,6 +82,7 @@ func TestCheckUnsupportedRules_CorazaWASMBugs(t *testing.T) {
 		934120: "enclosed alphanumerics HTTP/2",
 		932300: "multiphase evaluation",
 		933120: "multiphase evaluation",
+		941310: "regex/XML attribute inspection",
 	}
 
 	for id, expectedCategory := range bugIDs {
@@ -146,7 +147,7 @@ func TestCheckUnsupportedRules_HTTP2Normalization(t *testing.T) {
 }
 
 func TestCheckUnsupportedRules_HeaderSanitization(t *testing.T) {
-	for _, id := range []int{932161, 932207, 932237, 932239, 941101, 941110, 941120, 942280} {
+	for _, id := range []int{932161, 932207, 932237, 932239, 932390, 941101, 941110, 941120, 942280} {
 		t.Run(fmt.Sprintf("rule_%d", id), func(t *testing.T) {
 			found := CheckUnsupportedRules(secRuleWithID(id))
 			require.Len(t, found, 1)

--- a/test/conformance/.ftw-overrides.yml
+++ b/test/conformance/.ftw-overrides.yml
@@ -250,3 +250,11 @@ test_overrides:
       status: 200
       log:
         no_expect_ids: [942280]
+
+  - rule_id: 932390
+    test_ids: [9]
+    reason: "Referer header sanitized by Envoy (invalid characters removed)"
+    output:
+      status: 200
+      log:
+        no_expect_ids: [932390]

--- a/test/conformance/ftw.yml
+++ b/test/conformance/ftw.yml
@@ -77,6 +77,16 @@ testoverride:
     '932300-10': 'CORAZA BUG: Failing only with multiphase evaluation'
     '933120-2': 'CORAZA BUG: Failing only with multiphase evaluation'
 
+    # CRS 4.28 Regressions - Coraza 3.7.0 + CRS 4.28.0 (7 tests)
+    # See: https://github.com/corazawaf/coraza-proxy-wasm/blob/main/ftw/ftw.yml
+    '920540-4': 'CORAZA/WASM BUG: Log target not formatted as ARGS:<name>'
+    '920540-5': 'CORAZA/WASM BUG: REQBODY_PROCESSOR not set to JSON for empty-body JSON requests, ctl:ruleRemoveById=920540 never triggers'
+    '931130-24': 'CORAZA/WASM BUG: Log target not formatted as ARGS:<name>'
+    '941310-1': 'CORAZA/WASM BUG: Raw non-ASCII bytes in body not matched by RE2-based regex engine (requires valid UTF-8 rune matching)'
+    '941310-3': 'CORAZA/WASM BUG: Raw non-ASCII bytes in body not matched by RE2-based regex engine (requires valid UTF-8 rune matching)'
+    '941310-12': 'CORAZA/WASM BUG: Raw non-ASCII bytes in body not matched by RE2-based regex engine (requires valid UTF-8 rune matching)'
+    '941310-13': 'CORAZA/WASM BUG: XML attribute values (XML://@*) not inspected - added in CRS 4.28 GHSA-6jp8 fix'
+
     # ---------------------------------------------------------------------------
     # CATEGORY 4: UNDER INVESTIGATION - Edge cases and behavioral differences
     # These tests may be fixable or may be acceptable differences
@@ -120,9 +130,9 @@ testoverride:
     '980170-3': 'INVESTIGATE: retry_once mechanism not working in environment'
 
     # =============================================================================
-    # Summary of Ignored Tests by Category (Total: 53 tests):
+    # Summary of Ignored Tests by Category (Total: 60 tests):
     #
-    # NOTE: 42 ENHANCED SECURITY tests moved to .ftw-overrides.yml as platform
+    # NOTE: 43 ENHANCED SECURITY tests moved to .ftw-overrides.yml as platform
     # overrides (they now run with adjusted expectations instead of being skipped).
     #
     # CATEGORY 2: TOOL LIMITATION (21 tests)
@@ -130,12 +140,13 @@ testoverride:
     #   - Multipart charset detection: 17 tests
     #   - PL4 false positives: 4 tests
     #
-    # CATEGORY 3: CORAZA/WASM ISSUES (13 tests)
+    # CATEGORY 3: CORAZA/WASM ISSUES (20 tests)
     #   - Bugs that need fixing in Coraza or coraza-proxy-wasm
     #   - GET/HEAD with body: 2 tests
     #   - Protocol version: 4 tests
     #   - Enclosed alphanumerics: 5 tests
     #   - Multiphase evaluation: 2 tests
+    #   - CRS 4.28 regressions (log target formatting, RE2/XML): 7 tests
     #
     # CATEGORY 4: UNDER INVESTIGATION (19 tests)
     #   - Edge cases, behavioral differences, needs investigation
@@ -148,5 +159,5 @@ testoverride:
     #   - PL4 false positives: 2 tests
     #   - retry_once: 5 tests
     #
-    # Test Pass Rate: ~98% (53 ignored + 42 overridden out of ~4,600 total tests)
+    # Test Pass Rate: ~98% (60 ignored + 43 overridden out of ~4,600 total tests)
     # =============================================================================

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -21,7 +21,7 @@ behavior (reconciliation, status updates).
 # Kind cluster
 make test.e2e \
   KIND_CLUSTER_NAME=coraza-kubernetes-operator-integration \
-  ISTIO_VERSION=1.28.2
+  ISTIO_VERSION=1.30.3
 
 # OpenShift (override default GatewayClass)
 GATEWAY_CLASS=openshift-default make test.e2e

--- a/test/framework/resources.go
+++ b/test/framework/resources.go
@@ -124,7 +124,7 @@ func defaultWasmImage() string {
 	return defaults.DefaultCorazaWasmOCIReference
 }
 
-const fallbackEchoImage = "registry.k8s.io/gateway-api/echo-basic:v20251204-v1.4.1"
+const fallbackEchoImage = "registry.k8s.io/gateway-api/conformance/echo-basic:v0.1.0"
 
 func defaultEchoImage() string {
 	if img := os.Getenv("ECHO_IMAGE"); img != "" {

--- a/tools/corerulesetgen/build_test.go
+++ b/tools/corerulesetgen/build_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestBuild_minimal_statsAndConfResults(t *testing.T) {
 	dir := filepath.Join("testdata", "minimal", "rules")
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(dir)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:       dir,
-		Version:        "4.24.1",
+		Version:        "4.28.0",
 		RuleSetName:    "default-ruleset",
 		DataSourceName: "coreruleset-data",
 	}, scan, ver)
@@ -37,7 +37,7 @@ func TestBuild_minimal_statsAndConfResults(t *testing.T) {
 	require.NotEmpty(t, bundle.ConfFileResults[1].YAML)
 	require.Equal(t, "simple", bundle.ConfFileResults[1].SourceName)
 
-	require.Contains(t, bundle.BaseRuleSourceYAML, "ver:'OWASP_CRS/4.24.1'")
+	require.Contains(t, bundle.BaseRuleSourceYAML, "ver:'OWASP_CRS/4.28.0'")
 	require.Contains(t, bundle.RuleSetDoc, "name: default-ruleset")
 	require.Contains(t, bundle.RuleSetDoc, "- name: base-rules")
 	require.Contains(t, bundle.RuleSetDoc, "- name: simple")
@@ -153,13 +153,13 @@ SecRule ARGS "@rx b" "id:200,phase:2,pass,nolog"
 `), 0o644)
 	require.NoError(t, err)
 
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(tmp)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:       tmp,
-		Version:        "4.24.1",
+		Version:        "4.28.0",
 		RuleSetName:    "default-ruleset",
 		DataSourceName: "coreruleset-data",
 		IgnoreRuleIDs:  map[string]struct{}{"100": {}},
@@ -223,13 +223,13 @@ func TestBuild_excludesUnsupportedRulesWithWASMProfile(t *testing.T) {
 			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644)
 	require.NoError(t, err)
 
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(tmp)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:               tmp,
-		Version:                "4.24.1",
+		Version:                "4.28.0",
 		RuleSetName:            "rs",
 		DataSourceName:         "ds",
 		IgnoreUnsupportedRules: "wasm",
@@ -249,13 +249,13 @@ func TestBuild_includesUnsupportedRulesWhenProfileNone(t *testing.T) {
 			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644)
 	require.NoError(t, err)
 
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(tmp)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:               tmp,
-		Version:                "4.24.1",
+		Version:                "4.28.0",
 		RuleSetName:            "rs",
 		DataSourceName:         "ds",
 		IgnoreUnsupportedRules: "none",
@@ -276,13 +276,13 @@ func TestBuild_profileMergesWithUserIgnoreIDs(t *testing.T) {
 			"SecRule ARGS \"@rx c\" \"id:99,phase:2,pass,nolog\"\n"), 0o644)
 	require.NoError(t, err)
 
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(tmp)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:               tmp,
-		Version:                "4.24.1",
+		Version:                "4.28.0",
 		RuleSetName:            "rs",
 		DataSourceName:         "ds",
 		IgnoreRuleIDs:          map[string]struct{}{"42": {}},
@@ -334,13 +334,13 @@ func TestBuild_unknownProfileSkipsRegistryMerge(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(
 		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"), 0o644))
 
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(tmp)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:               tmp,
-		Version:                "4.24.1",
+		Version:                "4.28.0",
 		RuleSetName:            "rs",
 		DataSourceName:         "ds",
 		IgnoreUnsupportedRules: "ext_proc",
@@ -357,13 +357,13 @@ func TestBuild_emptyIgnoreUnsupportedRulesSkipsRegistryMerge(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(
 		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"), 0o644))
 
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(tmp)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:       tmp,
-		Version:        "4.24.1",
+		Version:        "4.28.0",
 		RuleSetName:    "rs",
 		DataSourceName: "ds",
 	}, scan, ver)
@@ -380,13 +380,13 @@ func TestBuild_redundantTierWASMUnsupportedStripped(t *testing.T) {
 		"SecRule ARGS \"@rx a\" \"id:920100,phase:2,pass,nolog\"\n"+
 			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644))
 
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(tmp)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:               tmp,
-		Version:                "4.24.1",
+		Version:                "4.28.0",
 		RuleSetName:            "rs",
 		DataSourceName:         "ds",
 		IgnoreUnsupportedRules: "wasm",
@@ -405,13 +405,13 @@ func TestBuild_wasmProfileTrimmedAndCaseInsensitive(t *testing.T) {
 		"SecRule ARGS \"@rx a\" \"id:922110,phase:2,pass,nolog\"\n"+
 			"SecRule ARGS \"@rx b\" \"id:42,phase:2,pass,nolog\"\n"), 0o644))
 
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(tmp)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:               tmp,
-		Version:                "4.24.1",
+		Version:                "4.28.0",
 		RuleSetName:            "rs",
 		DataSourceName:         "ds",
 		IgnoreUnsupportedRules: "  WaSm  ",
@@ -429,13 +429,13 @@ func TestBuild_explicitSkipValidationRuleSourceAnnotation(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(
 		"SecRule ARGS \"@rx a\" \"id:42,phase:2,pass,nolog\"\n"), 0o644))
 
-	ver := mustParseCRSVersion(t, "4.24.1")
+	ver := mustParseCRSVersion(t, "4.28.0")
 	scan, err := Scan(tmp)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:                  tmp,
-		Version:                   "4.24.1",
+		Version:                   "4.28.0",
 		RuleSetName:               "rs",
 		DataSourceName:            "ds",
 		SkipValidationRuleSources: map[string]struct{}{"simple": {}},

--- a/tools/corerulesetgen/generator_test.go
+++ b/tools/corerulesetgen/generator_test.go
@@ -16,7 +16,7 @@ func TestGenerate_minimalFixture(t *testing.T) {
 	var errBuf bytes.Buffer
 	_, err := Generate(&out, Options{
 		RulesDir: filepath.Join(dir, "rules"),
-		Version:  "4.24.1",
+		Version:  "4.28.0",
 		Stderr:   &errBuf,
 	})
 	require.NoError(t, err)
@@ -45,14 +45,14 @@ func TestGenerate_withDataSource(t *testing.T) {
 func TestBuildPipeline_minimalFixture(t *testing.T) {
 	dir := filepath.Join("testdata", "minimal")
 	rulesPath := filepath.Join(dir, "rules")
-	ver, err := ParseCRSVersion("4.24.1")
+	ver, err := ParseCRSVersion("4.28.0")
 	require.NoError(t, err)
 	scan, err := Scan(rulesPath)
 	require.NoError(t, err)
 
 	bundle, err := Build(Options{
 		RulesDir:       rulesPath,
-		Version:        "4.24.1",
+		Version:        "4.28.0",
 		RuleSetName:    "default-ruleset",
 		DataSourceName: "coreruleset-data",
 	}, scan, ver)
@@ -95,7 +95,7 @@ func TestGenerate_ignoreRuleID(t *testing.T) {
 	var out bytes.Buffer
 	_, err := Generate(&out, Options{
 		RulesDir:      dir,
-		Version:       "4.24.1",
+		Version:       "4.28.0",
 		IgnoreRuleIDs: map[string]struct{}{"100": {}},
 		Stderr:        io.Discard,
 	})
@@ -104,10 +104,10 @@ func TestGenerate_ignoreRuleID(t *testing.T) {
 }
 
 func TestParseCRSVersion(t *testing.T) {
-	ver, err := ParseCRSVersion("v4.24.1")
+	ver, err := ParseCRSVersion("v4.28.0")
 	require.NoError(t, err)
-	require.Equal(t, "4.24.1", ver.Normalized)
-	require.Equal(t, "4241", ver.Setup)
+	require.Equal(t, "4.28.0", ver.Normalized)
+	require.Equal(t, "4280", ver.Setup)
 
 	_, err = ParseCRSVersion("not-a-version")
 	require.Error(t, err)

--- a/tools/corerulesetgen/testdata/coreruleset_parity.sha256
+++ b/tools/corerulesetgen/testdata/coreruleset_parity.sha256
@@ -1,1 +1,1 @@
-493eb46b15c31078f7dd3f2bf9a557b3f97c45042adadcef304aa0c71c4d6b92  tmp/rules/rules.yaml
+79b2236029eb325d5cf340e4379bcf81a0550335e2debdbf87b28bc9f8970f00  tmp/rules/rules.yaml

--- a/tools/corerulesetgen/testdata/minimal/golden.yaml
+++ b/tools/corerulesetgen/testdata/minimal/golden.yaml
@@ -69,7 +69,7 @@ spec:
      t:none,\
      nolog,\
      tag:'OWASP_CRS',\
-     ver:'OWASP_CRS/4.24.1',\
+     ver:'OWASP_CRS/4.28.0',\
      setvar:tx.early_blocking=1"
     SecAction \
      "id:900990,\
@@ -78,8 +78,8 @@ spec:
      t:none,\
      nolog,\
      tag:'OWASP_CRS',\
-     ver:'OWASP_CRS/4.24.1',\
-     setvar:tx.crs_setup_version=4241"
+     ver:'OWASP_CRS/4.28.0',\
+     setvar:tx.crs_setup_version=4280"
 ---
 apiVersion: waf.k8s.coraza.io/v1alpha1
 kind: RuleSource

--- a/tools/corerulesetgen/validate.go
+++ b/tools/corerulesetgen/validate.go
@@ -27,7 +27,7 @@ type CRSVersion struct {
 	Setup      string
 }
 
-// ParseCRSVersion parses a CoreRuleSet version (e.g. "4.24.1" or "v4.24.1").
+// ParseCRSVersion parses a CoreRuleSet version (e.g. "4.28.0" or "v4.28.0").
 func ParseCRSVersion(v string) (CRSVersion, error) {
 	norm, setup, err := normalizeCRSVersion(v)
 	if err != nil {
@@ -39,7 +39,7 @@ func ParseCRSVersion(v string) (CRSVersion, error) {
 func normalizeCRSVersion(v string) (normalized, setupDigits string, err error) {
 	normalized = strings.TrimPrefix(strings.TrimSpace(v), "v")
 	if !validVersionRe.MatchString(normalized) {
-		return "", "", fmt.Errorf("invalid CoreRuleSet version format %q: expected digits and dots (e.g. 4.24.1 or v4.24.1)", v)
+		return "", "", fmt.Errorf("invalid CoreRuleSet version format %q: expected digits and dots (e.g. 4.28.0 or v4.28.0)", v)
 	}
 	setupDigits = strings.ReplaceAll(normalized, ".", "")
 	return normalized, setupDigits, nil


### PR DESCRIPTION
**Describe the pull request**

This PR is a very much expected one, that bumps Proxy WASM to a newer version supporting Coraza 3.7.0 and CRS 4.28

Additionally, we will bump on this same PR: 
* CRS for 4.28 and fix FTW tests
* MetalLB to 0.16.1
* Istio to 1.30.3
