### PR TITLE
fix(lint): set GOTOOLCHAIN when building golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -702,6 +702,8 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
+# golangci-lint ships with older Go; force project's Go version until upstream catches up
+$(GOLANGCI_LINT): export GOTOOLCHAIN = go$(shell sed -n 's/^go //p' go.mod)
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 


### PR DESCRIPTION
## Summary

golangci-lint v2.5.0's own go.mod pins `go 1.24`, so Go's toolchain switching builds it with Go 1.24 even when the developer has Go 1.26 installed. Since the project targets Go 1.26.2, the linter errors out immediately:

```
Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26.2)
```

This adds a target-specific `GOTOOLCHAIN` override on the golangci-lint build rule, derived from go.mod, so the binary gets compiled with the project's Go version.

## Test plan

- [ ] `rm -f bin/golangci-lint*` then `make lint` passes with zero issues
- [ ] `bin/golangci-lint version` reports `built with go1.26.2`

Generated with the help of [Claude Code](https://claude.ai/code)