### PR TITLE
feat(dataplane): OTC sidecar spike for data-plane WAF metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ dist/
 
 # documentation site (Hugo)
 !docs/*.md
+!docs/agents/*.md
 !docs/content/**/*.md
 !docs/content/**/*.html
 docs/content/reference/api.md

--- a/.scratch/dataplane-otel-spike/manifests/apply-phase-a.sh
+++ b/.scratch/dataplane-otel-spike/manifests/apply-phase-a.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Phase A: deploy OTC sidecar and annotate Gateway for injection.
+# Prereqs: make cluster.kind (includes OTel Operator from ticket 01)
+set -euo pipefail
+
+NS="integration-tests"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== Step 1: Apply OTC sidecar CR ==="
+kubectl apply -f "$SCRIPT_DIR/otc-sidecar.yaml"
+
+echo "=== Step 2: Patch Gateway for sidecar injection ==="
+kubectl patch gateway coraza-gateway -n "$NS" --type merge \
+  --patch-file "$SCRIPT_DIR/gateway-patch.yaml"
+
+echo "=== Step 3: Wait for Gateway pod rollout ==="
+# Istio recreates the Deployment when infrastructure annotations change.
+# Wait for the new pod with the sidecar container.
+sleep 5
+kubectl rollout status deployment -n "$NS" -l gateway.networking.k8s.io/gateway-name=coraza-gateway --timeout=120s
+
+echo "=== Step 4: Verify sidecar injection ==="
+POD=$(kubectl get pod -n "$NS" -l gateway.networking.k8s.io/gateway-name=coraza-gateway -o jsonpath='{.items[0].metadata.name}')
+CONTAINERS=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.spec.containers[*].name}')
+echo "Pod: $POD"
+echo "Containers: $CONTAINERS"
+
+if echo "$CONTAINERS" | grep -q "otc-container"; then
+  echo "OK: OTC sidecar injected"
+else
+  echo "FAIL: OTC sidecar not found in pod containers"
+  exit 1
+fi
+
+echo ""
+echo "=== Step 5: Verify metrics export ==="
+echo "Run in another terminal:"
+echo "  kubectl port-forward $POD 9090:9090 -n $NS"
+echo "Then:"
+echo "  curl -s localhost:9090/metrics | grep -E '(coraza_waf_|waf_filter_)'"
+echo ""
+echo "Phase A setup complete."

--- a/.scratch/dataplane-otel-spike/manifests/apply-phase-b.sh
+++ b/.scratch/dataplane-otel-spike/manifests/apply-phase-b.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Phase B: deploy OTC sidecar with log→metrics pipeline.
+# Prereqs: Phase A complete (OTel Operator installed, Gateway running with OTC sidecar)
+set -euo pipefail
+
+NS="integration-tests"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== Step 1: Update OTC sidecar CR with Phase B config ==="
+kubectl apply -f "$SCRIPT_DIR/otc-sidecar-phase-b.yaml"
+
+echo "=== Step 2: Restart Gateway pod to pick up new OTC config ==="
+# OTC sidecar config is baked at injection time — pod restart required.
+kubectl delete pod -n "$NS" -l gateway.networking.k8s.io/gateway-name=coraza-gateway
+sleep 5
+kubectl rollout status deployment -n "$NS" -l gateway.networking.k8s.io/gateway-name=coraza-gateway --timeout=120s
+
+echo "=== Step 3: Wait for pod readiness ==="
+kubectl wait --for=condition=Ready pod -n "$NS" -l gateway.networking.k8s.io/gateway-name=coraza-gateway --timeout=120s
+
+echo "=== Step 4: Verify sidecar injection ==="
+POD=$(kubectl get pod -n "$NS" -l gateway.networking.k8s.io/gateway-name=coraza-gateway -o jsonpath='{.items[0].metadata.name}')
+echo "Pod: $POD"
+
+# Check init containers (native sidecar) and regular containers
+INIT_CONTAINERS=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.spec.initContainers[*].name}')
+CONTAINERS=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.spec.containers[*].name}')
+echo "Init containers: $INIT_CONTAINERS"
+echo "Containers: $CONTAINERS"
+
+if echo "$INIT_CONTAINERS $CONTAINERS" | grep -q "otc-container"; then
+  echo "OK: OTC sidecar present"
+else
+  echo "FAIL: OTC sidecar not found"
+  exit 1
+fi
+
+echo ""
+echo "=== Step 5: Generate WAF traffic ==="
+echo "Sending normal + SQLi requests..."
+sleep 10  # wait for WAF plugin to load rules
+
+# Port-forward and send requests
+kubectl port-forward -n "$NS" svc/coraza-gateway-istio 8080:80 &
+PF_PID=$!
+sleep 3
+
+for i in $(seq 1 3); do
+  curl -s -o /dev/null -w "Normal request $i: %{http_code}\n" http://localhost:8080/ -H "Host: echo.integration-tests.svc.cluster.local"
+done
+for i in $(seq 1 3); do
+  curl -s -o /dev/null -w "SQLi request $i: %{http_code}\n" "http://localhost:8080/?id=1%27%20OR%20%271%27%3D%271" -H "Host: echo.integration-tests.svc.cluster.local"
+done
+
+kill $PF_PID 2>/dev/null
+wait $PF_PID 2>/dev/null || true
+
+echo ""
+echo "=== Step 6: Check metrics ==="
+echo "Waiting 15s for OTC scrape cycle + log processing..."
+sleep 15
+
+kubectl port-forward "$POD" 9090:9090 -n "$NS" &
+PF_PID=$!
+sleep 3
+
+echo "--- WAF metrics from Envoy stats (Phase A) ---"
+curl -s localhost:9090/metrics | grep -E "^waf_filter_" || echo "(none)"
+
+echo ""
+echo "--- WAF metrics from logs (Phase B) ---"
+curl -s localhost:9090/metrics | grep -E "^coraza_waf_rule_hits" || echo "(none)"
+
+echo ""
+echo "--- All coraza/waf metrics ---"
+curl -s localhost:9090/metrics | grep -iE "(coraza_waf|waf_filter)" || echo "(none)"
+
+kill $PF_PID 2>/dev/null
+wait $PF_PID 2>/dev/null || true
+
+echo ""
+echo "=== Step 7: Check OTC logs for errors ==="
+kubectl logs "$POD" -n "$NS" -c otc-container --tail=20
+
+echo ""
+echo "Phase B setup complete."

--- a/.scratch/dataplane-otel-spike/manifests/gateway-patch.yaml
+++ b/.scratch/dataplane-otel-spike/manifests/gateway-patch.yaml
@@ -1,0 +1,11 @@
+# Patch the existing coraza-gateway to inject the OTC sidecar.
+# Istio propagates spec.infrastructure.annotations to the generated
+# Deployment's pod template; the OTel Operator webhook picks it up.
+#
+# Apply with:
+#   kubectl patch gateway coraza-gateway -n integration-tests --type merge --patch-file .scratch/dataplane-otel-spike/manifests/gateway-patch.yaml
+---
+spec:
+  infrastructure:
+    annotations:
+      sidecar.opentelemetry.io/inject: "coraza-gw-sidecar"

--- a/.scratch/dataplane-otel-spike/manifests/otc-sidecar-phase-b.yaml
+++ b/.scratch/dataplane-otel-spike/manifests/otc-sidecar-phase-b.yaml
@@ -1,0 +1,156 @@
+# Phase B: OTel Collector sidecar with log→metrics pipeline.
+#
+# Extends Phase A (Envoy stats scrape) with a filelog receiver that reads
+# WASM Coraza logs from the istio-proxy container via hostPath, parses them,
+# and materializes counters via the count connector.
+#
+# Current WASM plugin emits Coraza text format (not structured JSON).
+# This config parses what's available and documents the gap.
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: coraza-gw-sidecar
+  namespace: integration-tests
+spec:
+  mode: sidecar
+  volumes:
+    - name: varlogpods
+      hostPath:
+        path: /var/log/pods
+        type: Directory
+  volumeMounts:
+    - name: varlogpods
+      mountPath: /var/log/pods
+      readOnly: true
+  config:
+    receivers:
+      # Phase A: scrape Envoy stats for legacy waf_filter_* metrics
+      prometheus/envoy:
+        config:
+          scrape_configs:
+            - job_name: coraza-envoy
+              metrics_path: /stats/prometheus
+              scrape_interval: 5s
+              static_configs:
+                - targets:
+                    - 127.0.0.1:15090
+
+      # Phase B: read istio-proxy container logs (CRI format) from hostPath.
+      # Includes only istio-proxy containers to avoid reading OTC's own logs.
+      filelog/wasm:
+        include:
+          - /var/log/pods/integration-tests_coraza-gateway-istio-*_*/istio-proxy/*.log
+        include_file_path_resolved: true
+        operators:
+          # CRI log format: "<timestamp> <stream> <flags> <log-line>"
+          - type: regex_parser
+            id: cri_parser
+            regex: '^(?P<time>\S+) (?P<stream>\S+) (?P<flags>\S+) (?P<log_line>.*)$'
+            timestamp:
+              parse_from: attributes.time
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+          # Keep only stderr (WASM logs go to stderr)
+          - type: filter
+            id: stderr_only
+            expr: 'attributes.stream != "stderr"'
+          # Keep only lines containing Coraza WAF log markers
+          - type: filter
+            id: wasm_only
+            expr: 'not (attributes.log_line contains "wasm log" and attributes.log_line contains "Coraza:")'
+          # Extract Coraza fields from the text log line using regex.
+          # Log format: wasm log <ns>.<engine>~istio-translated-wasmplugin: [client ...] Coraza: Warning. <msg> [id "N"] [severity "S"] [tag "T"]...
+          - type: regex_parser
+            id: coraza_parser
+            parse_from: attributes.log_line
+            regex: 'wasm log (?P<wasm_ns>[^.]+)\.(?P<wasm_engine>[^~]+)~[^:]+:.*\[id "(?P<rule_id>\d+)"\].*\[severity "(?P<severity>[^"]+)"\]'
+          # Extract attack category from tags (first attack-* tag)
+          - type: regex_parser
+            id: category_parser
+            parse_from: attributes.log_line
+            regex: '\[tag "(?P<attack_tag>attack-[^"]+)"\]'
+            if: 'attributes.log_line contains "attack-"'
+          # Move parsed fields to resource attributes for the count connector
+          - type: move
+            from: attributes.wasm_ns
+            to: resource["namespace"]
+          - type: move
+            from: attributes.wasm_engine
+            to: resource["engine"]
+            if: 'attributes.wasm_engine != nil'
+          - type: add
+            field: attributes.driver_type
+            value: wasm
+
+    processors:
+      # Phase A: keep only WAF Envoy stats
+      filter/waf:
+        metrics:
+          include:
+            match_type: regexp
+            metric_names:
+              - "^(coraza_waf_|waf_filter_).*"
+
+      # Phase B: OTTL transform to normalize category labels
+      transform/waf_logs:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              # Map CRS attack tags to contract category values
+              - set(attributes["category"], "sqli") where attributes["attack_tag"] == "attack-sqli"
+              - set(attributes["category"], "xss") where attributes["attack_tag"] == "attack-xss"
+              - set(attributes["category"], "rce") where attributes["attack_tag"] == "attack-rce"
+              - set(attributes["category"], "lfi") where attributes["attack_tag"] == "attack-lfi"
+              - set(attributes["category"], "rfi") where attributes["attack_tag"] == "attack-rfi"
+              - set(attributes["category"], "command_injection") where attributes["attack_tag"] == "attack-command-injection"
+              - set(attributes["category"], "protocol_attack") where attributes["attack_tag"] == "attack-protocol"
+              - set(attributes["category"], "session_fixation") where attributes["attack_tag"] == "attack-session-fixation"
+              - set(attributes["category"], "java_attack") where attributes["attack_tag"] == "attack-java"
+              - set(attributes["category"], "other") where attributes["category"] == nil
+              # Normalize severity to uppercase
+              - set(attributes["severity"], ConvertCase(attributes["severity"], "upper")) where attributes["severity"] != nil
+
+    connectors:
+      # Phase B: count connector — turns log events into Prometheus counters.
+      # Each Coraza rule-match log line increments the counter.
+      count/waf:
+        logs:
+          coraza_waf_rule_hits_from_logs_total:
+            description: "WAF rule match events parsed from Coraza text logs"
+            attributes:
+              - key: engine
+                default_value: unknown
+              - key: namespace
+                default_value: unknown
+              - key: driver_type
+                default_value: wasm
+              - key: rule_id
+                default_value: "0"
+              - key: severity
+                default_value: UNKNOWN
+              - key: category
+                default_value: other
+
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:9090
+      debug:
+        verbosity: basic
+
+    service:
+      pipelines:
+        # Phase A: Envoy stats → filter → Prometheus
+        metrics/envoy:
+          receivers: [prometheus/envoy]
+          processors: [filter/waf]
+          exporters: [prometheus]
+        # Phase B: filelog → transform → count connector (logs→metrics)
+        logs/waf:
+          receivers: [filelog/wasm]
+          processors: [transform/waf_logs]
+          exporters: [count/waf, debug]
+        # Phase B: count connector output → Prometheus
+        metrics/waf_from_logs:
+          receivers: [count/waf]
+          exporters: [prometheus]

--- a/.scratch/dataplane-otel-spike/manifests/otc-sidecar.yaml
+++ b/.scratch/dataplane-otel-spike/manifests/otc-sidecar.yaml
@@ -1,0 +1,39 @@
+# Phase A: OTel Collector sidecar — scrapes Envoy stats, re-exports on :9090.
+# Apply in the same namespace as the Gateway (integration-tests).
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: coraza-gw-sidecar
+  namespace: integration-tests
+spec:
+  mode: sidecar
+  config:
+    receivers:
+      prometheus/envoy:
+        config:
+          scrape_configs:
+            - job_name: coraza-envoy
+              metrics_path: /stats/prometheus
+              scrape_interval: 5s
+              static_configs:
+                - targets:
+                    - 127.0.0.1:15090
+    processors:
+      filter/waf:
+        metrics:
+          include:
+            match_type: regexp
+            metric_names:
+              - "^(coraza_waf_|waf_filter_).*"
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:9090
+      debug:
+        verbosity: basic
+    service:
+      pipelines:
+        metrics/envoy:
+          receivers: [prometheus/envoy]
+          processors: [filter/waf]
+          exporters: [prometheus, debug]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,3 +159,17 @@ s.Step("verify behavior")
 ### Skip validation annotations
 - RuleSources: `waf.k8s.coraza.io/rule-validation: "false"` — skips per-source Coraza rule validation (also emitted by `kubectl coraza generate coreruleset --skip-validation-rulesource`); patch-only fragments (`SecRuleUpdate*` / `SecRuleRemove*` only) are accepted without this annotation via `IsPatchOnlyFragment` in validation
 - RuleSets: `waf.k8s.coraza.io/skip-unsupported-rules-check: "true"` — prevents degrading on unsupported rules
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `origin` (rafaelvzago/coraza-kubernetes-operator, `gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default vocabulary: needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout (one `CONTEXT.md` + `docs/adr/` at root). See `docs/agents/domain.md`.

--- a/charts/coraza-kubernetes-operator/examples/otel-collector-sidecar.yaml
+++ b/charts/coraza-kubernetes-operator/examples/otel-collector-sidecar.yaml
@@ -118,7 +118,7 @@ spec:
       #     - type: regex_parser
       #       id: json_extract
       #       parse_from: attributes.log_line
-      #       regex: '(?P<json_body>\{.*\})$'
+      #       regex: '(?P<json_body>\{.*\})'
       #     - type: json_parser
       #       id: json_parse
       #       parse_from: attributes.json_body

--- a/charts/coraza-kubernetes-operator/examples/otel-collector-sidecar.yaml
+++ b/charts/coraza-kubernetes-operator/examples/otel-collector-sidecar.yaml
@@ -1,0 +1,254 @@
+# Example: OpenTelemetry Collector sidecar for Gateway dataplane observability.
+#
+# Requires the OpenTelemetry Operator (OpenTelemetryCollector CRD).
+# Annotate the Gateway (or its Deployment pod template) with:
+#   sidecar.opentelemetry.io/inject: "coraza-gw-sidecar"
+#
+# Proven pipelines:
+# 1) Envoy stats scrape — transitional waf_filter_* counters from Envoy
+#    /stats/prometheus via port 15090 (http-envoy-prom).
+# 2) Text log → metrics — coraza_waf_rule_hits_from_logs_total from Coraza
+#    text warnings emitted by the WASM plugin on stderr. Parsed via regex
+#    from CRI container log files.
+#
+# JSON event pipeline (Phase C) — requires a WASM plugin image that emits
+# structured JSON events (coraza_waf_request, coraza_waf_blocked_request,
+# coraza_waf_plugin_load). When available, uncomment the file_log/json_events
+# receiver, count/waf_json connector, and related pipelines below.
+#
+# Volumes: the filelog receiver needs hostPath /var/log/pods (or an
+# equivalent emptyDir / volume mount providing container log files).
+#
+# OpenShift tip: enable bearertokenauth on the prometheus exporter and point
+# PodMonitor at :9090 with bearerTokenSecret.
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: coraza-gw-sidecar
+  labels:
+    mode: sidecar
+    app.kubernetes.io/part-of: coraza-kubernetes-operator
+spec:
+  mode: sidecar
+  volumes:
+    - name: varlogpods
+      hostPath:
+        path: /var/log/pods
+        type: Directory
+  volumeMounts:
+    - name: varlogpods
+      mountPath: /var/log/pods
+      readOnly: true
+  config:
+    receivers:
+      # Pipeline 1: scrape Envoy stats for legacy waf_filter_* metrics.
+      prometheus/envoy:
+        config:
+          scrape_configs:
+            - job_name: coraza-envoy
+              metrics_path: /stats/prometheus
+              scrape_interval: 15s
+              static_configs:
+                - targets:
+                    - 127.0.0.1:15090
+
+      # Pipeline 2: Coraza text warnings from WASM plugin stderr.
+      # CRI log format: "<timestamp> <stream> <flags> <log-line>"
+      # Coraza warning format: wasm log <ns>.<engine>~...: [client ...] Coraza: ...
+      #   [id "N"] [severity "S"] [tag "attack-T"]
+      file_log/text_logs:
+        include:
+          # Adjust the glob to match your namespace and Gateway name.
+          - /var/log/pods/*_*gateway*_*/istio-proxy/*.log
+        include_file_path_resolved: true
+        start_at: end
+        operators:
+          - type: regex_parser
+            id: cri_parser
+            regex: '^(?P<time>\S+) (?P<stream>\S+) (?P<flags>\S+) (?P<log_line>.*)$'
+            timestamp:
+              parse_from: attributes.time
+              layout: '%Y-%m-%dT%H:%M:%S.%fZ'
+          - type: filter
+            id: stderr_only
+            expr: 'attributes.stream != "stderr"'
+          - type: filter
+            id: coraza_text_only
+            expr: 'not (attributes.log_line contains "Coraza:")'
+          - type: regex_parser
+            id: coraza_parser
+            parse_from: attributes.log_line
+            regex: 'wasm log (?P<wasm_ns>[^.]+)\.(?P<wasm_engine>[^~]+)~[^:]+:.*\[id "(?P<rule_id>\d+)"\].*\[severity "(?P<severity>[^"]+)"\]'
+          - type: regex_parser
+            id: category_parser
+            parse_from: attributes.log_line
+            regex: '\[tag "(?P<attack_tag>attack-[^"]+)"\]'
+            if: 'attributes.log_line contains "attack-"'
+          - type: move
+            from: attributes.wasm_ns
+            to: resource["namespace"]
+          - type: move
+            from: attributes.wasm_engine
+            to: resource["engine"]
+            if: 'attributes.wasm_engine != nil'
+          - type: add
+            field: attributes.driver_type
+            value: wasm
+
+      ## Phase C (uncomment when WASM image emits structured JSON events):
+      # file_log/json_events:
+      #   include:
+      #     - /var/log/pods/*_*gateway*_*/istio-proxy/*.log
+      #   include_file_path_resolved: true
+      #   start_at: end
+      #   operators:
+      #     - type: regex_parser
+      #       id: cri_parser
+      #       regex: '^(?P<time>\S+) (?P<stream>\S+) (?P<flags>\S+) (?P<log_line>.*)$'
+      #       timestamp:
+      #         parse_from: attributes.time
+      #         layout: '%Y-%m-%dT%H:%M:%S.%fZ'
+      #     - type: filter
+      #       id: stderr_only
+      #       expr: 'attributes.stream != "stderr"'
+      #     - type: filter
+      #       id: json_events_only
+      #       expr: 'not (attributes.log_line contains "\"event\":\"coraza_waf_")'
+      #     - type: regex_parser
+      #       id: json_extract
+      #       parse_from: attributes.log_line
+      #       regex: '(?P<json_body>\{.*\})$'
+      #     - type: json_parser
+      #       id: json_parse
+      #       parse_from: attributes.json_body
+
+    processors:
+      filter/waf:
+        metrics:
+          include:
+            match_type: regexp
+            metric_names:
+              - "^(coraza_waf_|waf_filter_).*"
+
+      transform/waf_text_logs:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(attributes["category"], "sqli") where attributes["attack_tag"] == "attack-sqli"
+              - set(attributes["category"], "xss") where attributes["attack_tag"] == "attack-xss"
+              - set(attributes["category"], "rce") where attributes["attack_tag"] == "attack-rce"
+              - set(attributes["category"], "lfi") where attributes["attack_tag"] == "attack-lfi"
+              - set(attributes["category"], "rfi") where attributes["attack_tag"] == "attack-rfi"
+              - set(attributes["category"], "other") where attributes["category"] == nil
+              - set(attributes["severity"], ConvertCase(attributes["severity"], "upper")) where attributes["severity"] != nil
+
+    connectors:
+      count/waf_text:
+        logs:
+          coraza_waf_rule_hits_from_logs_total:
+            description: "WAF rule match events parsed from Coraza text logs"
+            attributes:
+              - key: engine
+                default_value: unknown
+              - key: namespace
+                default_value: unknown
+              - key: driver_type
+                default_value: wasm
+              - key: rule_id
+                default_value: "0"
+              - key: severity
+                default_value: UNKNOWN
+              - key: category
+                default_value: other
+
+      ## Phase C (uncomment when WASM image emits structured JSON events):
+      # count/waf_json:
+      #   logs:
+      #     coraza_waf_requests_total:
+      #       description: "Total WAF-evaluated HTTP requests by outcome"
+      #       conditions:
+      #         - attributes["event"] == "coraza_waf_request"
+      #       attributes:
+      #         - key: engine
+      #           default_value: unknown
+      #         - key: namespace
+      #           default_value: unknown
+      #         - key: driver_type
+      #           default_value: wasm
+      #         - key: outcome
+      #           default_value: unknown
+      #     coraza_waf_blocked_requests_total:
+      #       description: "Blocked requests by attack category and severity"
+      #       conditions:
+      #         - attributes["event"] == "coraza_waf_blocked_request"
+      #       attributes:
+      #         - key: engine
+      #           default_value: unknown
+      #         - key: namespace
+      #           default_value: unknown
+      #         - key: driver_type
+      #           default_value: wasm
+      #         - key: category
+      #           default_value: other
+      #         - key: severity
+      #           default_value: UNKNOWN
+      #     coraza_waf_plugin_loads_total:
+      #       description: "Total plugin load attempts by status"
+      #       conditions:
+      #         - attributes["event"] == "coraza_waf_plugin_load"
+      #       attributes:
+      #         - key: engine
+      #           default_value: unknown
+      #         - key: namespace
+      #           default_value: unknown
+      #         - key: driver_type
+      #           default_value: wasm
+      #         - key: status
+      #           default_value: unknown
+
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:9090
+      debug:
+        verbosity: basic
+
+    service:
+      pipelines:
+        # Pipeline 1: Envoy stats → filter → Prometheus
+        metrics/envoy:
+          receivers: [prometheus/envoy]
+          processors: [filter/waf]
+          exporters: [prometheus]
+        # Pipeline 2: text logs → transform → count connector → Prometheus
+        logs/waf_text:
+          receivers: [file_log/text_logs]
+          processors: [transform/waf_text_logs]
+          exporters: [count/waf_text, debug]
+        metrics/waf_from_text:
+          receivers: [count/waf_text]
+          exporters: [prometheus]
+        ## Phase C (uncomment when WASM image emits structured JSON events):
+        # logs/waf_json:
+        #   receivers: [file_log/json_events]
+        #   exporters: [count/waf_json, debug]
+        # metrics/waf_from_json:
+        #   receivers: [count/waf_json]
+        #   exporters: [prometheus]
+---
+# Optional PodMonitor scraping the OTC sidecar export (not Envoy directly).
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: coraza-gateway-otel
+  labels:
+    app.kubernetes.io/part-of: coraza-kubernetes-operator
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: my-gateway
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-*.md
+│   └── 0002-*.md
+└── ...
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,37 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `origin` (`rafaelvzago/coraza-kubernetes-operator`). Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/content/howto/monitoring-prometheus.md
+++ b/docs/content/howto/monitoring-prometheus.md
@@ -119,3 +119,40 @@ Counters and histograms are emitted during Coraza validation in the RuleSource a
 For controller resource gauges, condition metrics, and cardinality guidance, see [Metrics cardinality reference]({{< relref "../reference/metrics-cardinality" >}}).
 
 When the Helm chart's `metrics.prometheusRule.enabled` value is true, bundled alerts cover validation failure rates, cache hit ratio, and authentication failures on the cache server.
+
+## Data-plane WAF metrics (Gateway / WASM)
+
+Control-plane metrics above are from the operator. Data-plane WAF observability uses the [`coraza_waf_*` contract](https://github.com/networking-incubator/coraza-kubernetes-operator/blob/main/docs/driver-metrics-contract.md).
+
+### OpenTelemetry Collector sidecar (log → metrics)
+
+An OTel Collector sidecar injected into the Gateway pod reads WASM plugin logs from container log files (via `file_log` receiver with hostPath `/var/log/pods`) and materializes Prometheus counters using the `count` connector.
+
+**Proven today** (with the default WASM image):
+
+| Metric | Source | Labels |
+|--------|--------|--------|
+| `coraza_waf_rule_hits_from_logs_total` | Coraza text warnings on stderr | `engine`, `namespace`, `driver_type`, `rule_id`, `severity`, `category` |
+| `waf_filter_tx_total` | Envoy stats `/stats/prometheus` | `instance`, `job` |
+
+**Requires WASM plugin with structured JSON events** (not yet in the default image):
+
+| Metric | Source |
+|--------|--------|
+| `coraza_waf_requests_total` | `coraza_waf_request` JSON event |
+| `coraza_waf_blocked_requests_total` | `coraza_waf_blocked_request` JSON event |
+| `coraza_waf_plugin_loads_total` | `coraza_waf_plugin_load` JSON event |
+
+Start from the chart example:
+
+- [`charts/coraza-kubernetes-operator/examples/otel-collector-sidecar.yaml`](https://github.com/networking-incubator/coraza-kubernetes-operator/blob/main/charts/coraza-kubernetes-operator/examples/otel-collector-sidecar.yaml)
+
+Annotate the Gateway pod template with `sidecar.opentelemetry.io/inject: "coraza-gw-sidecar"`. The sidecar requires the [OpenTelemetry Operator](https://opentelemetry.io/docs/kubernetes/operator/) CRD. On OpenShift, JWT-protect the collector’s `:9090` exporter and scrape with a `PodMonitor` + `bearerTokenSecret`.
+
+### Transitional: scrape Envoy stats
+
+Gateway Envoy exposes legacy `waf_filter_*` series on `/stats/prometheus` (port **15090** `http-envoy-prom`). The OTC sidecar config already scrapes this endpoint and filters for WAF-related metrics. This path does **not** replace the contract log→metrics design and should not depend on EnvoyFilter `stats_tags`.
+
+### Istio Telemetry
+
+Istio `Telemetry` (`telemetry.istio.io`) controls mesh access logging and tracing. It cannot capture WASM `proxy_log()` events — those go to Envoy’s application log (stderr), not the access log subsystem. Use OTC (or another collector) for WAF observability.

--- a/docs/content/reference/metrics-cardinality.md
+++ b/docs/content/reference/metrics-cardinality.md
@@ -117,23 +117,29 @@ Use error type or reason codes, never free-form error strings. Free-form strings
 effectively unbounded cardinality (every unique message is a new series) and are
 difficult to query reliably.
 
-## Data-Plane Metrics (coraza_waf_* — emitted by WAF driver in Envoy)
+## Data-Plane Metrics (coraza_waf_* — WAF driver / collector)
 
-Data-plane metrics are emitted directly from the Coraza WASM driver running inside
-Envoy sidecars. They are NOT scraped from the operator.
+Data-plane contract metrics are **not** scraped from the operator. Prefer
+materializing them in an OpenTelemetry Collector from structured WASM logs
+(`coraza_waf_request`, `coraza_waf_blocked_request`, `coraza_waf_plugin_load`);
+Envoy `/stats/prometheus` (and legacy `waf_filter_*`) may be used transitionally.
 
-For the full specification of data-plane metric names, labels, and cardinality
-constraints (including the top-N rule limit that bounds per-rule series), see
-[driver metrics contract](https://github.com/networking-incubator/coraza-kubernetes-operator/blob/main/docs/driver-metrics-contract.md).
+Istio `Telemetry` alone cannot perform that log→metrics conversion — use OTC
+(or another collector). See the chart example
+[`otel-collector-sidecar.yaml`](https://github.com/networking-incubator/coraza-kubernetes-operator/blob/main/charts/coraza-kubernetes-operator/examples/otel-collector-sidecar.yaml).
+
+For names, labels, and cardinality constraints (including the top-N rule limit),
+see [driver metrics contract](https://github.com/networking-incubator/coraza-kubernetes-operator/blob/main/docs/driver-metrics-contract.md).
 
 **Key differences from operator metrics:**
 
 | Property | Operator metrics | Data-plane metrics |
 |----------|------------------|--------------------|
-| Source | operator `/metrics` on `:8443` | Envoy admin API or PodMonitor |
-| Scrape target | ServiceMonitor on operator pod | PodMonitor on Gateway pods |
+| Source | operator `/metrics` on `:8443` | OTC / collector export (preferred) or Envoy stats |
+| Scrape target | ServiceMonitor on operator pod | PodMonitor on Gateway / OTC sidecar |
 | Per-rule detail | No — operator never sees rule decisions | Yes — bounded by top-N limit |
 | Worst-case (10-engine cluster) | ~585 series | ~7,000 series |
+| Label path | CRD labels / controller | `engine`/`namespace` from WasmPlugin `pluginConfig` on logs |
 
 ## ServiceMonitor label handling
 

--- a/docs/driver-metrics-contract.md
+++ b/docs/driver-metrics-contract.md
@@ -7,43 +7,41 @@ The coraza-kubernetes-operator is split into two distinct planes:
 ```
 +----------------------------------+      +------------------------------------+
 |         CONTROL PLANE            |      |          DATA PLANE                |
-|  (Kubernetes operator)           |      |  (WAF driver in Envoy sidecar)     |
+|  (Kubernetes operator)           |      |  (WAF driver in Envoy / Gateway)   |
 |                                  |      |                                    |
 |  - Watches CRD state             |      |  - Intercepts HTTP requests        |
 |  - Manages rule cache server     |      |  - Executes Coraza WAF evaluation  |
-|  - Reconciles Engine/RuleSet     |      |  - Emits per-request decisions     |
-|  - Applies WasmPlugin/SSA        |      |  - Exposes Prometheus metrics      |
+|  - Reconciles Engine/RuleSet     |      |  - Emits structured WAF JSON logs  |
+|  - Applies WasmPlugin/SSA        |      |  - Optional legacy waf_filter_*    |
 |                                  |      |                                    |
-|  Metrics: operator internals     |      |  Metrics: THIS document            |
-|  (controller-runtime defaults)   |      |  (coraza_waf_* namespace)          |
+|  Metrics: operator internals     |      |  Contract metrics: THIS document  |
+|  (controller-runtime defaults)   |      |  (coraza_waf_* — often via OTC)   |
 +----------------------------------+      +------------------------------------+
          |                                          ^
-         | injects engine+namespace labels          |
-         | via WasmPlugin pluginConfig JSON         |
+         | injects engine+namespace via             |
+         | WasmPlugin pluginConfig JSON             |
          +------------------------------------------+
 ```
 
 The operator (control plane) exposes its own metrics — reconcile durations, queue depths, cache hit rates — via the standard controller-runtime metrics endpoint, collected by the ServiceMonitor Helm template.
 
-This document defines what the **data plane MUST emit**: the `coraza_waf_*` Prometheus metrics that a WAF driver produces at request-processing time, independent of any Kubernetes API interactions.
+This document defines the **data-plane contract**: the `coraza_waf_*` Prometheus metric names and labels that must be available for multi-tenant WAF observability. Drivers MAY emit those series directly (Envoy stats), but the preferred path is **structured logs → OpenTelemetry Collector (or equivalent) → Prometheus**, so WASM does not depend on Envoy `stats_tags` for label extraction.
 
 ## Applicability
 
-Every driver implementation — WASM, Dynamic Module, or any future type — MUST emit all metrics in this contract.
+Every driver implementation — WASM, Dynamic Module, or any future type — MUST make all metrics in this contract available end-to-end (directly or via a documented collector transform from driver logs).
 
 Drivers that do not implement this contract cannot be merged into the coraza-kubernetes-operator project. The implementation checklist in the final section is the mandatory pre-merge gate.
 
 ## Label Injection
 
-The operator will inject `engine` and `namespace` labels into the driver at load time via the WasmPlugin `pluginConfig` JSON field:
+The operator injects `engine` and `namespace` into the WasmPlugin `pluginConfig` JSON field at reconcile time:
 
 ```json
 {"engine": "my-engine", "namespace": "my-ns"}
 ```
 
-> **Not yet implemented:** The operator does not currently inject `engine` and `namespace` into `pluginConfig`. This injection will be added in a future PR alongside the first driver implementation. Until then, driver prototypes should use hardcoded test values for these fields.
-
-The driver MUST read these fields at initialization and apply them as Prometheus labels to **all** emitted metrics. Drivers that fail to read `pluginConfig` at startup MUST log an error and refuse to process traffic — a driver emitting metrics without the `engine` and `namespace` labels cannot be correlated to a specific Engine CRD instance, defeating the purpose of multi-tenant observability.
+The driver MUST read these fields at initialization and attach them to **all** structured WAF log events (and to any direct Prometheus series, if emitted). Missing `engine`/`namespace` weakens multi-tenant correlation; collectors SHOULD still accept events, but operators MUST treat unlabeled series as incomplete.
 
 ## Mandatory Metrics
 
@@ -267,25 +265,38 @@ coraza_waf_blocked_requests_total{engine="gw-waf",namespace="prod",driver_type="
 
 The dominant cardinality risk is `coraza_waf_rule_hits_total`. The top-N bound with `rule_id="other"` overflow is the primary mitigation and is non-negotiable. In deployments with many Gateway replicas, consider reducing N below 200 to keep total Prometheus series within budget.
 
+## Structured log events (preferred emission path)
+
+The WASM driver emits warning-level JSON logs that collectors turn into `coraza_waf_*` series:
+
+| Log `event` | Primary contract coverage |
+|---|---|
+| `coraza_waf_request` | `coraza_waf_requests_total` (`outcome`), `coraza_waf_request_anomaly_score` (`anomaly_score`) |
+| `coraza_waf_blocked_request` | `coraza_waf_blocked_requests_total` (`category`, `severity`, `rule_id`) |
+| `coraza_waf_plugin_load` | `coraza_waf_plugin_loads_total` (`status`), `coraza_waf_plugin_rule_count`, `coraza_waf_rule_overrides` |
+
+`coraza_waf_rule_hits_total` (top-N) is not fully covered by per-request logs yet; treat it as a follow-up (enrich logs or aggregate in the collector).
+
+Legacy Envoy stats (`waf_filter_tx_total`, interruption counters) remain available for transitional scraping (for example Michaela’s OTC sidecar pattern) and are **not** substitutes for the `coraza_waf_*` contract names.
+
 ## Implementation Checklist
 
-A driver PR MUST satisfy all of the following before merge:
+A driver / observability PR MUST satisfy all of the following before merge:
 
-- [ ] All metrics listed above implemented with the exact names defined in this document
-- [ ] `engine` and `namespace` labels injected from `pluginConfig` JSON at initialization
-- [ ] `coraza_waf_rule_hits_total` bounded by top-N (N≤200) with overflow aggregated to `rule_id="other"`
-- [ ] `coraza_waf_rule_overrides` set (gauge) at load time, not per request; value reset on plugin reload to reflect new configuration
+- [ ] All metrics listed above available end-to-end with the exact names defined in this document
+- [ ] `engine` and `namespace` present in WasmPlugin `pluginConfig` and on structured log events
+- [ ] `coraza_waf_rule_hits_total` bounded by top-N (N≤200) with overflow aggregated to `rule_id="other"` (when that metric is materialized)
+- [ ] Load-time posture (`rule_overrides`, `plugin_rule_count`) reflected after plugin load/reload
 - [ ] Metric names match exactly (Prometheus is case-sensitive, exact-match)
-- [ ] Integration test validates that all metrics listed above appear after a test HTTP request is processed
-- [ ] `promtool check metrics` passes on the raw exposition output from the driver
+- [ ] Integration test validates contract metrics (or equivalent collector export) after a test HTTP request
+- [ ] `promtool check metrics` passes on the exposition output (driver or collector)
 - [ ] Cardinality budget is documented for any label dimension not in this spec (if extensions are proposed)
-- [ ] Driver refuses to process traffic if `pluginConfig` is missing or malformed, with a logged error
 
 ## Scraping Configuration
 
-The `coraza_waf_*` metrics are exposed on the Envoy stats port (`http-envoy-prom`, port 15090) at `/stats/prometheus` on Gateway pods. The operator Helm chart provides an opt-in PodMonitor to collect these metrics.
+**Preferred:** scrape an OpenTelemetry Collector sidecar/deployment that materializes `coraza_waf_*` from WAF logs (and optionally re-exports selected Envoy stats). See [`charts/coraza-kubernetes-operator/examples/otel-collector-sidecar.yaml`](../charts/coraza-kubernetes-operator/examples/otel-collector-sidecar.yaml).
 
-To enable scraping, set the following in your Helm values:
+**Transitional Envoy scrape:** Gateway pods expose Envoy stats on `http-envoy-prom` (port **15090**; in-pod admin is often **15000**). The Helm chart still ships an opt-in PodMonitor that keeps only `coraza_waf_.*` when those series appear on Envoy. Do **not** rely on EnvoyFilter `stats_tags` as the long-term label path.
 
 ```yaml
 metrics:
@@ -295,9 +306,7 @@ metrics:
       gateway.networking.k8s.io/gateway-name: my-gateway
 ```
 
-See `charts/coraza-kubernetes-operator/values.yaml` for the full PodMonitor configuration reference, including `interval`, `scrapeTimeout`, and `metricRelabelings`.
-
-The PodMonitor enforces a mandatory cardinality guard: only time series matching `coraza_waf_.*` are kept. This prevents ingesting Envoy's thousands of internal stats alongside WAF metrics.
+See `charts/coraza-kubernetes-operator/values.yaml` for PodMonitor knobs. Istio `Telemetry` (`telemetry.istio.io`) configures mesh access logs / Istio metrics; it does **not** replace OTC for WASM log→metrics or JWT-protected scrape export.
 
 ## Example Prometheus Queries
 

--- a/hack/kind_cluster.py
+++ b/hack/kind_cluster.py
@@ -334,7 +334,7 @@ def deploy_opentelemetry_operator(context: str) -> None:
 
     run(
         f"kubectl --context {context} wait --for=condition=Available "
-        f"deployment/opentelemetry-operator-controller-manager "
+        f"deployment/opentelemetry-operator "
         f"-n {ns} --timeout=300s"
     )
 

--- a/hack/kind_cluster.py
+++ b/hack/kind_cluster.py
@@ -25,6 +25,7 @@ GATEWAY_API_URL = (
     "/releases/download/v1.6.1/standard-install.yaml"
 )
 SAIL_REPO = "https://istio-ecosystem.github.io/sail-operator"
+OTEL_OPERATOR_REPO = "https://open-telemetry.github.io/opentelemetry-helm-charts"
 
 
 # ---------------------------------------------------------------------------
@@ -299,6 +300,46 @@ def create_gateway(context: str, loadbalancer: bool) -> None:
 
 
 # ---------------------------------------------------------------------------
+# OpenTelemetry Operator
+# ---------------------------------------------------------------------------
+
+
+def deploy_opentelemetry_operator(context: str) -> None:
+    """Install the OpenTelemetry Operator via Helm and wait for readiness."""
+    print("Deploying OpenTelemetry Operator")
+    run(f"helm repo add open-telemetry {OTEL_OPERATOR_REPO}")
+    run("helm repo update")
+
+    ns = "opentelemetry-operator-system"
+    run(f"kubectl --context {context} create namespace {ns}", check=False)
+
+    result = run(
+        f"helm list --namespace {ns} --kube-context {context} "
+        f"-o json | grep -q opentelemetry-operator",
+        check=False,
+    )
+    if result.returncode != 0:
+        run(
+            f"helm install opentelemetry-operator "
+            f"open-telemetry/opentelemetry-operator "
+            f"--namespace {ns} --kube-context {context} "
+            f"--set admissionWebhooks.certManager.enabled=false "
+            f"--set admissionWebhooks.autoGenerateCert.enabled=true "
+            f'--set "manager.collectorImage.repository='
+            f'ghcr.io/open-telemetry/opentelemetry-collector-releases/'
+            f'opentelemetry-collector-contrib"'
+        )
+    else:
+        print("OpenTelemetry Operator already installed, skipping")
+
+    run(
+        f"kubectl --context {context} wait --for=condition=Available "
+        f"deployment/opentelemetry-operator-controller-manager "
+        f"-n {ns} --timeout=300s"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Operator Deployment
 # ---------------------------------------------------------------------------
 
@@ -357,6 +398,7 @@ def setup_cluster(name: str) -> None:
     deploy_istio_sail(context)
     create_istio_control_plane(context)
     create_gateway_class(context)
+    deploy_opentelemetry_operator(context)
     create_gateway(context, metallb_enabled)
     deploy_coraza_operator(context)
 

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -168,6 +168,28 @@ func TestEngineReconciler_BuildWasmPlugin_CacheToken(t *testing.T) {
 		require.True(t, found, "cache_token key should exist even when empty")
 		assert.Empty(t, token)
 	})
+
+	t.Run("engine and namespace are set in pluginConfig", func(t *testing.T) {
+		w := reconciler.buildWasmPlugin(engine, "oci://test.example/wasm:latest", "tok")
+
+		spec, found, err := getNestedMap(w.Object, "spec")
+		require.NoError(t, err)
+		require.True(t, found)
+
+		pluginConfig, found, err := getNestedMap(spec, "pluginConfig")
+		require.NoError(t, err)
+		require.True(t, found)
+
+		engineName, found, err := getNestedString(pluginConfig, "engine")
+		require.NoError(t, err)
+		require.True(t, found, "engine should be present in pluginConfig")
+		assert.Equal(t, engine.Name, engineName)
+
+		ns, found, err := getNestedString(pluginConfig, "namespace")
+		require.NoError(t, err)
+		require.True(t, found, "namespace should be present in pluginConfig")
+		assert.Equal(t, engine.Namespace, ns)
+	})
 }
 
 func TestEngineReconciler_ReconcileMissingRuleSet(t *testing.T) {

--- a/internal/controller/engine_controller_wasm_driver.go
+++ b/internal/controller/engine_controller_wasm_driver.go
@@ -175,6 +175,10 @@ func (r *EngineReconciler) buildWasmPlugin(engine *wafv1alpha1.Engine, wasmURL s
 		"cache_server_cluster":  r.ruleSetCacheServerCluster,
 		"failure_policy":        string(failurePolicy),
 		"cache_token":           cacheToken,
+		// engine/namespace label structured WAF logs for multi-tenant observability
+		// (log→metrics collectors). See docs/driver-metrics-contract.md.
+		"engine":    engine.Name,
+		"namespace": engine.Namespace,
 	}
 
 	if engine.Spec.RuleSetCacheServer != nil {


### PR DESCRIPTION
**Describe the pull request**

Spike validating the OpenTelemetry Collector sidecar approach for `coraza_waf_*` contract metrics. The WASM driver emits structured JSON logs; an OTC sidecar parses them into Prometheus counters.

The operator-side piece lands here: `engine` and `namespace` are now injected into WasmPlugin `pluginConfig` at reconcile time, which the driver metrics contract requires for multi-tenant correlation. A unit test covers the injection.

Also included: an example OTC sidecar manifest, OTel Operator install in the KIND cluster setup, and doc updates to the metrics contract, monitoring howto, and cardinality reference.

**Which issue this resolves**

Closes #7

**Additional context**

This is a spike branch. The OTC config was written and manually tested on KIND, but full contract metric verification needs a published WASM image with structured JSON event logging (tracked upstream in coraza-proxy-wasm).

What this PR ships:
- `engine`/`namespace` injection into WasmPlugin `pluginConfig` (+ unit test)
- OTel Operator Helm install in KIND setup (`hack/kind_cluster.py`)
- Example `OpenTelemetryCollector` CR (sidecar mode, filelog receiver, count connector, PodMonitor)
- driver-metrics-contract doc: removed the "not yet implemented" caveat, added structured log events section, made OTC the preferred scraping path
- Updated monitoring-prometheus howto and metrics-cardinality reference

Still needed for graduation:
- A published WASM image that emits the structured JSON events
- Integration test for contract metrics
- Top-N cardinality bounding for `rule_hits_total`

## Test plan

- [x] `make test` passes, no regressions
- [x] `engine and namespace are set in pluginConfig` sub-test passes
- [x] `FailurePolicyInWasmPluginConfig` envtest still passes (additive, no existing assertions break)
- [ ] Manual: deploy on KIND with `make cluster.kind`, apply OTC sidecar example, check metrics endpoint