### PR TITLE
docs(dev): document GOMAXPROCS for integration and e2e tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,6 +79,7 @@ These tests validate the operator's behavior on a live cluster, including:
 Environment variables:
 - `KIND_CLUSTER_NAME` - Name of the KIND cluster to use (default: `coraza-kubernetes-operator-integration`)
 - `ISTIO_VERSION` - Istio version for testing (default: from Makefile)
+- `GOMAXPROCS` - Maximum number of OS threads for Go's runtime; also sets the default for `-parallel` (concurrent `t.Parallel()` tests). (default: CPU core count)
 
 ### Conformance Tests
 
@@ -128,6 +129,9 @@ make test.e2e
 ```
 
 These tests validate complete user workflows on a live cluster.
+
+Environment variables:
+- `GOMAXPROCS` - Maximum number of OS threads for Go's runtime; also sets the default for `-parallel` (concurrent `t.Parallel()` tests). (default: CPU core count)
 
 ### Tools Tests
 


### PR DESCRIPTION
Describe GOMAXPROCS as an environment variable that controls Go runtime thread count and the default for -parallel (concurrent t.Parallel() tests) in the integration and e2e test sections of DEVELOPMENT.md.


Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

