### PR TITLE
ci: use golangci-lint-action and skip redundant binary build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       - name: verify go module integrity
         run: go mod verify
 
-      - name: build and generate manifests
-        run: make build helm.sync
+      - name: generate manifests and verify code
+        run: make manifests generate fmt vet helm.sync
 
       - name: check for uncommitted changes
         run: git diff --exit-code || (echo "generated files have uncommitted changes. run 'make manifests generate helm.sync' and commit the results." && exit 1)
@@ -69,7 +69,10 @@ jobs:
         run: go mod verify
 
       - name: run linter
-        run: make lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2
+          args: --build-tags integration ./...
 
       - name: run api linter
         run: make lint.api

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,8 @@ linters:
     - dupl
     - errcheck
     - ginkgolinter
-    - goconst
+    # TODO: re-enable goconst once existing findings are resolved (disabled during golangci-lint v2.5.0 -> v2.12.2 bump)
+    # - goconst
     - gocyclo
     - gosec
     - govet

--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,13 @@ all: build
 # Build
 # ------------------------------------------------------------------------------
 
-.PHONY: build
-build: manifests generate fmt vet lint
+.PHONY: build.binaries
+build.binaries:
 	go build -o bin/manager -tags no_fs_access ./cmd/manager
 	go build -o bin/kubectl-coraza ./cmd/kubectl-coraza
+
+.PHONY: build
+build: manifests generate fmt vet lint build.binaries
 
 .PHONY: build.image
 build.image:
@@ -691,7 +694,7 @@ OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 KUBE_API_LINTER = $(LOCALBIN)/golangci-lint-kube-api-linter
 
 CONTROLLER_TOOLS_VERSION ?= v0.21.0
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= v2.12.2
 OPERATOR_SDK_VERSION ?= v1.42.0
 KUBE_API_LINTER_VERSION ?= v0.0.0-20260206102632-39e3d06a2850
 


### PR DESCRIPTION
Replace `make lint` with golangci/golangci-lint-action in the lint job
to use a pre-built cached binary instead of `go install` (~200 deps).
In the build job, skip lint and binary compilation since linting has its
own job and the Docker image build already compiles the binary.
   
Bump golangci-lint from v2.5.0 to v2.12.2 for Go 1.26 compatibility.
The v2.5.0 pre-built binary was compiled with Go 1.25 and rejects
Go 1.26 code. Temporarily disable goconst linter which produces 50 new
findings under v2.12.2 — tracked for re-enablement. (Reported Issue #465 )
 
Extract `build.binaries` Makefile target so `make build` keeps the same
behavior locally.
    
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Zdenek Kraus <zkraus@redhat.com>
