### PR TITLE
fix(engine): clear stale token cache on Engine delete-recreate

### DIFF
--- a/internal/controller/engine_controller.go
+++ b/internal/controller/engine_controller.go
@@ -173,6 +173,12 @@ func (r *EngineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			if listErr := r.List(ctx, &list, client.InNamespace(req.Namespace)); listErr == nil {
 				r.Metrics.SetEnginesTotal(req.Namespace, len(list.Items))
 			}
+
+			// Remove cached tokens for this Engine so a recreated Engine
+			// with the same name does not reuse a token bound to the
+			// now-deleted ServiceAccount.
+			r.deleteTokensByPrefix(req.Namespace + "/" + req.Name + "/")
+
 			// Best-effort cleanup: remove any orphaned NetworkPolicy that may
 			// remain if the Engine was deleted before the finalizer was added
 			// (e.g., race during upgrade or legacy Engine without finalizer).

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -2481,10 +2481,12 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allSAs.Items, 2, "stale SA + new SA must both exist")
 
+	foundStale := false
 	for _, sa := range allSAs.Items {
 		ref := metav1.GetControllerOf(&sa)
 		require.NotNil(t, ref, "SA %s must have a controller owner reference", sa.Name)
 		if sa.Name == staleSAName {
+			foundStale = true
 			assert.Equal(t, staleUID, ref.UID,
 				"stale SA must still reference the old Engine UID")
 		} else {
@@ -2492,6 +2494,7 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 				"new SA must be owned by the recreated Engine")
 		}
 	}
+	require.True(t, foundStale, "stale SA %s must be present in the list", staleSAName)
 
 	// Verify fresh token was provisioned (not the stale one).
 	val, found = reconciler.tokenStore.Load(tokenKey)

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -2445,15 +2445,17 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, allSAs.Items, 2, "stale SA + new SA must both exist")
 
-	var newSAName string
 	for _, sa := range allSAs.Items {
-		if sa.Name != staleSAName {
-			newSAName = sa.Name
+		ref := metav1.GetControllerOf(&sa)
+		require.NotNil(t, ref, "SA %s must have a controller owner reference", sa.Name)
+		if sa.Name == staleSAName {
+			assert.Equal(t, staleUID, ref.UID,
+				"stale SA must still reference the old Engine UID")
+		} else {
+			assert.Equal(t, engine2.UID, ref.UID,
+				"new SA must be owned by the recreated Engine")
 		}
 	}
-	require.NotEmpty(t, newSAName, "a new SA must have been created")
-	assert.NotEqual(t, staleSAName, newSAName,
-		"recreated Engine must not reuse SA owned by previous Engine instance")
 }
 
 func TestEngineReconciler_MetricsForgetOnNotFound(t *testing.T) {

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -492,6 +492,48 @@ func getNestedString(obj map[string]any, key string) (string, bool, error) {
 	return strVal, true, nil
 }
 
+func assertWasmPluginCacheToken(t *testing.T, ctx context.Context, name, namespace, expectedToken string) {
+	t.Helper()
+	wasmPlugin := &unstructured.Unstructured{}
+	wasmPlugin.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "extensions.istio.io",
+		Version: "v1alpha1",
+		Kind:    "WasmPlugin",
+	})
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      wasmPluginName(name),
+		Namespace: namespace,
+	}, wasmPlugin)
+	require.NoError(t, err)
+
+	spec, found, err := getNestedMap(wasmPlugin.Object, "spec")
+	require.NoError(t, err)
+	require.True(t, found)
+	pluginConfig, found, err := getNestedMap(spec, "pluginConfig")
+	require.NoError(t, err)
+	require.True(t, found)
+	cacheToken, found, err := getNestedString(pluginConfig, "cache_token")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, expectedToken, cacheToken,
+		"WasmPlugin cache_token must match expected token")
+}
+
+func assertEngineCondition(t *testing.T, ctx context.Context, name, namespace, conditionType string, expectedStatus metav1.ConditionStatus) {
+	t.Helper()
+	var engine wafv1alpha1.Engine
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, &engine)
+	require.NoError(t, err)
+
+	cond := apimeta.FindStatusCondition(engine.Status.Conditions, conditionType)
+	require.NotNil(t, cond, "Engine must have %s condition", conditionType)
+	assert.Equal(t, expectedStatus, cond.Status,
+		"Engine condition %s expected %s", conditionType, expectedStatus)
+}
+
 func TestEngineReconciler_ImagePullSecretInWasmPlugin(t *testing.T) {
 	reconciler := &EngineReconciler{
 		Client:                    k8sClient,
@@ -1229,29 +1271,7 @@ func TestEngineReconciler_TokenStoreIntegration(t *testing.T) {
 	t.Run("token in WasmPlugin matches tokenStore", func(t *testing.T) {
 		val, _ := reconciler.tokenStore.Load(tokenKey)
 		storedToken := val.(*TokenEntry).Token
-
-		wasmPlugin := &unstructured.Unstructured{}
-		wasmPlugin.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "extensions.istio.io",
-			Version: "v1alpha1",
-			Kind:    "WasmPlugin",
-		})
-		err := k8sClient.Get(ctx, types.NamespacedName{
-			Name:      wasmPluginName(engine.Name),
-			Namespace: engine.Namespace,
-		}, wasmPlugin)
-		require.NoError(t, err)
-
-		spec, found, err := getNestedMap(wasmPlugin.Object, "spec")
-		require.NoError(t, err)
-		require.True(t, found)
-		pluginConfig, found, err := getNestedMap(spec, "pluginConfig")
-		require.NoError(t, err)
-		require.True(t, found)
-		cacheToken, found, err := getNestedString(pluginConfig, "cache_token")
-		require.NoError(t, err)
-		require.True(t, found)
-		assert.Equal(t, storedToken, cacheToken, "WasmPlugin cache_token should match tokenStore entry")
+		assertWasmPluginCacheToken(t, ctx, engine.Name, engine.Namespace, storedToken)
 	})
 
 	t.Run("second reconcile reuses cached token", func(t *testing.T) {
@@ -2333,46 +2353,9 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 	assert.NotEqual(t, originalToken, newToken,
 		"recreated Engine must get a fresh token, not reuse the stale one")
 
-	// Verify WasmPlugin cache_token matches the new token.
-	wasmPlugin := &unstructured.Unstructured{}
-	wasmPlugin.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "extensions.istio.io",
-		Version: "v1alpha1",
-		Kind:    "WasmPlugin",
-	})
-	err = k8sClient.Get(ctx, types.NamespacedName{
-		Name:      wasmPluginName(engine2.Name),
-		Namespace: engine2.Namespace,
-	}, wasmPlugin)
-	require.NoError(t, err)
-
-	spec, wpFound, err := getNestedMap(wasmPlugin.Object, "spec")
-	require.NoError(t, err)
-	require.True(t, wpFound)
-	pluginConfig, wpFound, err := getNestedMap(spec, "pluginConfig")
-	require.NoError(t, err)
-	require.True(t, wpFound)
-	cacheToken, wpFound, err := getNestedString(pluginConfig, "cache_token")
-	require.NoError(t, err)
-	require.True(t, wpFound)
-	assert.Equal(t, newToken, cacheToken,
-		"WasmPlugin cache_token must match the fresh token after delete-recreate")
-
-	// Verify the recreated Engine has Ready and Accepted conditions.
-	var updated wafv1alpha1.Engine
-	err = k8sClient.Get(ctx, types.NamespacedName{
-		Name:      engine2.Name,
-		Namespace: engine2.Namespace,
-	}, &updated)
-	require.NoError(t, err)
-
-	readyCond := apimeta.FindStatusCondition(updated.Status.Conditions, "Ready")
-	require.NotNil(t, readyCond, "recreated Engine must have Ready condition")
-	assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
-
-	acceptedCond := apimeta.FindStatusCondition(updated.Status.Conditions, "Accepted")
-	require.NotNil(t, acceptedCond, "recreated Engine must have Accepted condition")
-	assert.Equal(t, metav1.ConditionTrue, acceptedCond.Status)
+	assertWasmPluginCacheToken(t, ctx, engine2.Name, engine2.Namespace, newToken)
+	assertEngineCondition(t, ctx, engine2.Name, engine2.Namespace, "Ready", metav1.ConditionTrue)
+	assertEngineCondition(t, ctx, engine2.Name, engine2.Namespace, "Accepted", metav1.ConditionTrue)
 }
 
 // TestEngineReconciler_StaleOwnerSANotReused verifies that when an Engine is
@@ -2440,6 +2423,7 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 	val, found := reconciler.tokenStore.Load(tokenKey)
 	require.True(t, found, "token must be stored after initial provisioning")
 	originalToken := val.(*TokenEntry).Token
+	require.NotEmpty(t, originalToken)
 
 	var saList corev1.ServiceAccountList
 	err = k8sClient.List(ctx, &saList,
@@ -2515,46 +2499,9 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 	assert.NotEqual(t, originalToken, newToken,
 		"recreated Engine must get a fresh token, not reuse the stale one")
 
-	// Verify WasmPlugin cache_token matches the new token.
-	wasmPlugin := &unstructured.Unstructured{}
-	wasmPlugin.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "extensions.istio.io",
-		Version: "v1alpha1",
-		Kind:    "WasmPlugin",
-	})
-	err = k8sClient.Get(ctx, types.NamespacedName{
-		Name:      wasmPluginName(engine2.Name),
-		Namespace: engine2.Namespace,
-	}, wasmPlugin)
-	require.NoError(t, err)
-
-	spec, wpFound, err := getNestedMap(wasmPlugin.Object, "spec")
-	require.NoError(t, err)
-	require.True(t, wpFound)
-	pluginConfig, wpFound, err := getNestedMap(spec, "pluginConfig")
-	require.NoError(t, err)
-	require.True(t, wpFound)
-	cacheToken, wpFound, err := getNestedString(pluginConfig, "cache_token")
-	require.NoError(t, err)
-	require.True(t, wpFound)
-	assert.Equal(t, newToken, cacheToken,
-		"WasmPlugin cache_token must match the fresh token when stale SA is present")
-
-	// Verify the recreated Engine has Ready and Accepted conditions.
-	var updated wafv1alpha1.Engine
-	err = k8sClient.Get(ctx, types.NamespacedName{
-		Name:      engine2.Name,
-		Namespace: engine2.Namespace,
-	}, &updated)
-	require.NoError(t, err)
-
-	readyCond := apimeta.FindStatusCondition(updated.Status.Conditions, "Ready")
-	require.NotNil(t, readyCond, "recreated Engine must have Ready condition")
-	assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
-
-	acceptedCond := apimeta.FindStatusCondition(updated.Status.Conditions, "Accepted")
-	require.NotNil(t, acceptedCond, "recreated Engine must have Accepted condition")
-	assert.Equal(t, metav1.ConditionTrue, acceptedCond.Status)
+	assertWasmPluginCacheToken(t, ctx, engine2.Name, engine2.Namespace, newToken)
+	assertEngineCondition(t, ctx, engine2.Name, engine2.Namespace, "Ready", metav1.ConditionTrue)
+	assertEngineCondition(t, ctx, engine2.Name, engine2.Namespace, "Accepted", metav1.ConditionTrue)
 }
 
 // TestEngineReconciler_MetricsForgetOnNotFound verifies that a not-found

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -519,6 +519,7 @@ func assertWasmPluginCacheToken(t *testing.T, ctx context.Context, name, namespa
 		"WasmPlugin cache_token must match expected token")
 }
 
+//nolint:unparam // expectedStatus is intentionally parameterized for reuse with ConditionFalse
 func assertEngineCondition(t *testing.T, ctx context.Context, name, namespace, conditionType string, expectedStatus metav1.ConditionStatus) {
 	t.Helper()
 	var engine wafv1alpha1.Engine

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -69,7 +69,7 @@ func createTestGateway(t *testing.T, ctx context.Context, c client.Client, name,
 	}
 	require.NoError(t, c.Create(ctx, gw))
 	t.Cleanup(func() {
-		if err := c.Delete(ctx, gw); err != nil && !apierrors.IsNotFound(err) {
+		if err := c.Delete(context.Background(), gw); err != nil && !apierrors.IsNotFound(err) {
 			t.Logf("Failed to delete gateway: %v", err)
 		}
 	})
@@ -2217,7 +2217,7 @@ func TestEngineReconciler_MetricsRecordOnSuccess(t *testing.T) {
 // Engine and recreating it with the same name produces a fresh token bound to
 // a new ServiceAccount, not the stale token from the previous instance.
 func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const (
 		engineName  = "stale-token-engine"
@@ -2233,7 +2233,7 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 	})
 	require.NoError(t, k8sClient.Create(ctx, ruleset))
 	t.Cleanup(func() {
-		if err := k8sClient.Delete(ctx, ruleset); err != nil {
+		if err := k8sClient.Delete(context.Background(), ruleset); err != nil {
 			t.Logf("Failed to delete ruleset: %v", err)
 		}
 	})
@@ -2322,7 +2322,7 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 	})
 	require.NoError(t, k8sClient.Create(ctx, engine2))
 	t.Cleanup(func() {
-		if err := k8sClient.Delete(ctx, engine2); err != nil {
+		if err := k8sClient.Delete(context.Background(), engine2); err != nil {
 			t.Logf("Failed to delete engine: %v", err)
 		}
 	})
@@ -2363,7 +2363,7 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 // deleted and recreated with the same name, a ServiceAccount left behind by the
 // previous Engine (stale owner reference, different UID) is not reused.
 func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	const (
 		engineName  = "stale-owner-engine"
@@ -2379,7 +2379,7 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 	})
 	require.NoError(t, k8sClient.Create(ctx, ruleset))
 	t.Cleanup(func() {
-		if err := k8sClient.Delete(ctx, ruleset); err != nil {
+		if err := k8sClient.Delete(context.Background(), ruleset); err != nil {
 			t.Logf("Failed to delete ruleset: %v", err)
 		}
 	})
@@ -2461,7 +2461,7 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 	})
 	require.NoError(t, k8sClient.Create(ctx, engine2))
 	t.Cleanup(func() {
-		if err := k8sClient.Delete(ctx, engine2); err != nil {
+		if err := k8sClient.Delete(context.Background(), engine2); err != nil {
 			t.Logf("Failed to delete engine: %v", err)
 		}
 	})

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -2192,9 +2192,9 @@ func TestEngineReconciler_MetricsRecordOnSuccess(t *testing.T) {
 		"coraza_engine_condition must emit one series per engineConditionType")
 }
 
-// TestEngineReconciler_MetricsForgetOnNotFound verifies that a not-found
-// reconcile (simulating deletion) calls ForgetEngine and removes the info and
-// condition series from the registry.
+// TestEngineReconciler_DeleteRecreateGetsNewToken verifies that deleting an
+// Engine and recreating it with the same name produces a fresh token bound to
+// a new ServiceAccount, not the stale token from the previous instance.
 func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 	ctx, cleanup := setupTest(t)
 	defer cleanup()
@@ -2464,6 +2464,9 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 	}
 }
 
+// TestEngineReconciler_MetricsForgetOnNotFound verifies that a not-found
+// reconcile (simulating deletion) calls ForgetEngine and removes the info and
+// condition series from the registry.
 func TestEngineReconciler_MetricsForgetOnNotFound(t *testing.T) {
 	ctx, cleanup := setupTest(t)
 	defer cleanup()

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -2196,8 +2196,7 @@ func TestEngineReconciler_MetricsRecordOnSuccess(t *testing.T) {
 // Engine and recreating it with the same name produces a fresh token bound to
 // a new ServiceAccount, not the stale token from the previous instance.
 func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
-	ctx, cleanup := setupTest(t)
-	defer cleanup()
+	ctx := context.Background()
 
 	const (
 		engineName  = "stale-token-engine"
@@ -2333,14 +2332,54 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 	newToken := val.(*TokenEntry).Token
 	assert.NotEqual(t, originalToken, newToken,
 		"recreated Engine must get a fresh token, not reuse the stale one")
+
+	// Verify WasmPlugin cache_token matches the new token.
+	wasmPlugin := &unstructured.Unstructured{}
+	wasmPlugin.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "extensions.istio.io",
+		Version: "v1alpha1",
+		Kind:    "WasmPlugin",
+	})
+	err = k8sClient.Get(ctx, types.NamespacedName{
+		Name:      wasmPluginName(engine2.Name),
+		Namespace: engine2.Namespace,
+	}, wasmPlugin)
+	require.NoError(t, err)
+
+	spec, wpFound, err := getNestedMap(wasmPlugin.Object, "spec")
+	require.NoError(t, err)
+	require.True(t, wpFound)
+	pluginConfig, wpFound, err := getNestedMap(spec, "pluginConfig")
+	require.NoError(t, err)
+	require.True(t, wpFound)
+	cacheToken, wpFound, err := getNestedString(pluginConfig, "cache_token")
+	require.NoError(t, err)
+	require.True(t, wpFound)
+	assert.Equal(t, newToken, cacheToken,
+		"WasmPlugin cache_token must match the fresh token after delete-recreate")
+
+	// Verify the recreated Engine has Ready and Accepted conditions.
+	var updated wafv1alpha1.Engine
+	err = k8sClient.Get(ctx, types.NamespacedName{
+		Name:      engine2.Name,
+		Namespace: engine2.Namespace,
+	}, &updated)
+	require.NoError(t, err)
+
+	readyCond := apimeta.FindStatusCondition(updated.Status.Conditions, "Ready")
+	require.NotNil(t, readyCond, "recreated Engine must have Ready condition")
+	assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
+
+	acceptedCond := apimeta.FindStatusCondition(updated.Status.Conditions, "Accepted")
+	require.NotNil(t, acceptedCond, "recreated Engine must have Accepted condition")
+	assert.Equal(t, metav1.ConditionTrue, acceptedCond.Status)
 }
 
 // TestEngineReconciler_StaleOwnerSANotReused verifies that when an Engine is
 // deleted and recreated with the same name, a ServiceAccount left behind by the
 // previous Engine (stale owner reference, different UID) is not reused.
 func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
-	ctx, cleanup := setupTest(t)
-	defer cleanup()
+	ctx := context.Background()
 
 	const (
 		engineName  = "stale-owner-engine"
@@ -2390,11 +2429,17 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 		},
 	}
 
+	tokenKey := fmt.Sprintf("%s/%s/%s", testNamespace, engineName, rulesetName)
+
 	// --- Phase 1: provision Engine1 to create its SA ---
 	_, err = reconciler.Reconcile(ctx, req) // finalizer
 	require.NoError(t, err)
 	_, err = reconciler.Reconcile(ctx, req) // provisioning
 	require.NoError(t, err)
+
+	val, found := reconciler.tokenStore.Load(tokenKey)
+	require.True(t, found, "token must be stored after initial provisioning")
+	originalToken := val.(*TokenEntry).Token
 
 	var saList corev1.ServiceAccountList
 	err = k8sClient.List(ctx, &saList,
@@ -2462,6 +2507,54 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 				"new SA must be owned by the recreated Engine")
 		}
 	}
+
+	// Verify fresh token was provisioned (not the stale one).
+	val, found = reconciler.tokenStore.Load(tokenKey)
+	require.True(t, found, "recreated Engine must have a token in the store")
+	newToken := val.(*TokenEntry).Token
+	assert.NotEqual(t, originalToken, newToken,
+		"recreated Engine must get a fresh token, not reuse the stale one")
+
+	// Verify WasmPlugin cache_token matches the new token.
+	wasmPlugin := &unstructured.Unstructured{}
+	wasmPlugin.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "extensions.istio.io",
+		Version: "v1alpha1",
+		Kind:    "WasmPlugin",
+	})
+	err = k8sClient.Get(ctx, types.NamespacedName{
+		Name:      wasmPluginName(engine2.Name),
+		Namespace: engine2.Namespace,
+	}, wasmPlugin)
+	require.NoError(t, err)
+
+	spec, wpFound, err := getNestedMap(wasmPlugin.Object, "spec")
+	require.NoError(t, err)
+	require.True(t, wpFound)
+	pluginConfig, wpFound, err := getNestedMap(spec, "pluginConfig")
+	require.NoError(t, err)
+	require.True(t, wpFound)
+	cacheToken, wpFound, err := getNestedString(pluginConfig, "cache_token")
+	require.NoError(t, err)
+	require.True(t, wpFound)
+	assert.Equal(t, newToken, cacheToken,
+		"WasmPlugin cache_token must match the fresh token when stale SA is present")
+
+	// Verify the recreated Engine has Ready and Accepted conditions.
+	var updated wafv1alpha1.Engine
+	err = k8sClient.Get(ctx, types.NamespacedName{
+		Name:      engine2.Name,
+		Namespace: engine2.Namespace,
+	}, &updated)
+	require.NoError(t, err)
+
+	readyCond := apimeta.FindStatusCondition(updated.Status.Conditions, "Ready")
+	require.NotNil(t, readyCond, "recreated Engine must have Ready condition")
+	assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
+
+	acceptedCond := apimeta.FindStatusCondition(updated.Status.Conditions, "Accepted")
+	require.NotNil(t, acceptedCond, "recreated Engine must have Accepted condition")
+	assert.Equal(t, metav1.ConditionTrue, acceptedCond.Status)
 }
 
 // TestEngineReconciler_MetricsForgetOnNotFound verifies that a not-found

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -523,10 +523,8 @@ func assertEngineCondition(t *testing.T, ctx context.Context, name, namespace, c
 	}, &engine)
 	require.NoError(t, err)
 
-	cond := apimeta.FindStatusCondition(engine.Status.Conditions, conditionType)
-	require.NotNil(t, cond, "Engine must have %s condition", conditionType)
-	assert.Equal(t, expectedStatus, cond.Status,
-		"Engine condition %s expected %s", conditionType, expectedStatus)
+	assert.True(t, apimeta.IsStatusConditionPresentAndEqual(engine.Status.Conditions, conditionType, expectedStatus),
+		"Engine Condition %s expected %s", conditionType, expectedStatus)
 }
 
 func TestEngineReconciler_ImagePullSecretInWasmPlugin(t *testing.T) {

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -2332,6 +2332,130 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 		"recreated Engine must get a fresh token, not reuse the stale one")
 }
 
+// TestEngineReconciler_StaleOwnerSANotReused verifies that when an Engine is
+// deleted and recreated with the same name, a ServiceAccount left behind by the
+// previous Engine (stale owner reference, different UID) is not reused.
+func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	defer cleanup()
+
+	const (
+		engineName  = "stale-owner-engine"
+		rulesetName = "stale-owner-ruleset"
+	)
+
+	createTestGateway(t, ctx, k8sClient, "test-gw", testNamespace)
+
+	ruleset := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      rulesetName,
+		Namespace: testNamespace,
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleset))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(ctx, ruleset); err != nil {
+			t.Logf("Failed to delete ruleset: %v", err)
+		}
+	})
+
+	engine1 := utils.NewTestEngine(utils.EngineOptions{
+		Name:        engineName,
+		Namespace:   testNamespace,
+		RuleSetName: rulesetName,
+	})
+	require.NoError(t, k8sClient.Create(ctx, engine1))
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &EngineReconciler{
+		Client:                    k8sClient,
+		Scheme:                    scheme,
+		Recorder:                  utils.NewTestRecorder(),
+		Metrics:                   m,
+		kubeClient:                testKubeClient,
+		ruleSetCacheServerCluster: "test-cluster",
+		defaultWasmImage:          defaults.DefaultCorazaWasmOCIReference,
+		operatorNamespace:         testNamespace,
+	}
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      engineName,
+			Namespace: testNamespace,
+		},
+	}
+
+	// --- Phase 1: provision Engine1 to create its SA ---
+	_, err = reconciler.Reconcile(ctx, req) // finalizer
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(ctx, req) // provisioning
+	require.NoError(t, err)
+
+	var saList corev1.ServiceAccountList
+	err = k8sClient.List(ctx, &saList,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels(cacheClientSALabels(engineName)),
+	)
+	require.NoError(t, err)
+	require.Len(t, saList.Items, 1)
+	staleSAName := saList.Items[0].Name
+	staleUID := engine1.UID
+
+	// --- Phase 2: delete Engine1 but leave the SA behind ---
+	require.NoError(t, k8sClient.Delete(ctx, engine1))
+	_, err = reconciler.Reconcile(ctx, req) // finalizer removal
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(ctx, req) // IsNotFound cleanup
+	require.NoError(t, err)
+
+	// SA still exists (envtest has no GC controller).
+	var remainingSAs corev1.ServiceAccountList
+	err = k8sClient.List(ctx, &remainingSAs,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels(cacheClientSALabels(engineName)),
+	)
+	require.NoError(t, err)
+	require.Len(t, remainingSAs.Items, 1, "stale SA must still exist (no GC in envtest)")
+
+	// --- Phase 3: recreate Engine with the same name (different UID) ---
+	engine2 := utils.NewTestEngine(utils.EngineOptions{
+		Name:        engineName,
+		Namespace:   testNamespace,
+		RuleSetName: rulesetName,
+	})
+	require.NoError(t, k8sClient.Create(ctx, engine2))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(ctx, engine2); err != nil {
+			t.Logf("Failed to delete engine: %v", err)
+		}
+	})
+	require.NotEqual(t, staleUID, engine2.UID, "recreated Engine must have a different UID")
+
+	_, err = reconciler.Reconcile(ctx, req) // finalizer
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(ctx, req) // provisioning
+	require.NoError(t, err)
+
+	// Must have created a new SA, not reused the stale one.
+	var allSAs corev1.ServiceAccountList
+	err = k8sClient.List(ctx, &allSAs,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels(cacheClientSALabels(engineName)),
+	)
+	require.NoError(t, err)
+	require.Len(t, allSAs.Items, 2, "stale SA + new SA must both exist")
+
+	var newSAName string
+	for _, sa := range allSAs.Items {
+		if sa.Name != staleSAName {
+			newSAName = sa.Name
+		}
+	}
+	require.NotEmpty(t, newSAName, "a new SA must have been created")
+	assert.NotEqual(t, staleSAName, newSAName,
+		"recreated Engine must not reuse SA owned by previous Engine instance")
+}
+
 func TestEngineReconciler_MetricsForgetOnNotFound(t *testing.T) {
 	ctx, cleanup := setupTest(t)
 	defer cleanup()

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -506,13 +506,7 @@ func assertWasmPluginCacheToken(t *testing.T, ctx context.Context, name, namespa
 	}, wasmPlugin)
 	require.NoError(t, err)
 
-	spec, found, err := getNestedMap(wasmPlugin.Object, "spec")
-	require.NoError(t, err)
-	require.True(t, found)
-	pluginConfig, found, err := getNestedMap(spec, "pluginConfig")
-	require.NoError(t, err)
-	require.True(t, found)
-	cacheToken, found, err := getNestedString(pluginConfig, "cache_token")
+	cacheToken, found, err := unstructured.NestedString(wasmPlugin.Object, "spec", "pluginConfig", "cache_token")
 	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, expectedToken, cacheToken,

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -2202,9 +2202,10 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 	const (
 		engineName  = "stale-token-engine"
 		rulesetName = "stale-token-ruleset"
+		gatewayName = "delete-recreate-stale-token-gw"
 	)
 
-	createTestGateway(t, ctx, k8sClient, "test-gw", testNamespace)
+	createTestGateway(t, ctx, k8sClient, gatewayName, testNamespace)
 
 	ruleset := utils.NewTestRuleSet(utils.RuleSetOptions{
 		Name:      rulesetName,
@@ -2221,6 +2222,7 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 		Name:        engineName,
 		Namespace:   testNamespace,
 		RuleSetName: rulesetName,
+		GatewayName: gatewayName,
 	})
 	require.NoError(t, k8sClient.Create(ctx, engine))
 	// No t.Cleanup — this engine is deleted explicitly in Phase 2.
@@ -2284,7 +2286,7 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 	require.True(t, apierrors.IsNotFound(k8sClient.Get(ctx, req.NamespacedName, &gone)),
 		"Engine must be gone after finalizer removal")
 
-	// Reconcile the IsNotFound path — cleans up the tokenStore.
+	// Reconcile the IsNotFound path - cleans up the tokenStore.
 	_, err = reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
 
@@ -2296,6 +2298,7 @@ func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
 		Name:        engineName,
 		Namespace:   testNamespace,
 		RuleSetName: rulesetName,
+		GatewayName: gatewayName,
 	})
 	require.NoError(t, k8sClient.Create(ctx, engine2))
 	t.Cleanup(func() {
@@ -2342,9 +2345,10 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 	const (
 		engineName  = "stale-owner-engine"
 		rulesetName = "stale-owner-ruleset"
+		gatewayName = "stale-owner-gw"
 	)
 
-	createTestGateway(t, ctx, k8sClient, "test-gw", testNamespace)
+	createTestGateway(t, ctx, k8sClient, gatewayName, testNamespace)
 
 	ruleset := utils.NewTestRuleSet(utils.RuleSetOptions{
 		Name:      rulesetName,
@@ -2361,6 +2365,7 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 		Name:        engineName,
 		Namespace:   testNamespace,
 		RuleSetName: rulesetName,
+		GatewayName: gatewayName,
 	})
 	require.NoError(t, k8sClient.Create(ctx, engine1))
 
@@ -2422,6 +2427,7 @@ func TestEngineReconciler_StaleOwnerSANotReused(t *testing.T) {
 		Name:        engineName,
 		Namespace:   testNamespace,
 		RuleSetName: rulesetName,
+		GatewayName: gatewayName,
 	})
 	require.NoError(t, k8sClient.Create(ctx, engine2))
 	t.Cleanup(func() {

--- a/internal/controller/engine_controller_test.go
+++ b/internal/controller/engine_controller_test.go
@@ -2195,6 +2195,143 @@ func TestEngineReconciler_MetricsRecordOnSuccess(t *testing.T) {
 // TestEngineReconciler_MetricsForgetOnNotFound verifies that a not-found
 // reconcile (simulating deletion) calls ForgetEngine and removes the info and
 // condition series from the registry.
+func TestEngineReconciler_DeleteRecreateGetsNewToken(t *testing.T) {
+	ctx, cleanup := setupTest(t)
+	defer cleanup()
+
+	const (
+		engineName  = "stale-token-engine"
+		rulesetName = "stale-token-ruleset"
+	)
+
+	createTestGateway(t, ctx, k8sClient, "test-gw", testNamespace)
+
+	ruleset := utils.NewTestRuleSet(utils.RuleSetOptions{
+		Name:      rulesetName,
+		Namespace: testNamespace,
+	})
+	require.NoError(t, k8sClient.Create(ctx, ruleset))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(ctx, ruleset); err != nil {
+			t.Logf("Failed to delete ruleset: %v", err)
+		}
+	})
+
+	engine := utils.NewTestEngine(utils.EngineOptions{
+		Name:        engineName,
+		Namespace:   testNamespace,
+		RuleSetName: rulesetName,
+	})
+	require.NoError(t, k8sClient.Create(ctx, engine))
+	// No t.Cleanup — this engine is deleted explicitly in Phase 2.
+
+	reg := prometheus.NewRegistry()
+	m, err := NewCorazaMetrics(reg)
+	require.NoError(t, err)
+
+	reconciler := &EngineReconciler{
+		Client:                    k8sClient,
+		Scheme:                    scheme,
+		Recorder:                  utils.NewTestRecorder(),
+		Metrics:                   m,
+		kubeClient:                testKubeClient,
+		ruleSetCacheServerCluster: "test-cluster",
+		defaultWasmImage:          defaults.DefaultCorazaWasmOCIReference,
+		operatorNamespace:         testNamespace,
+	}
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      engine.Name,
+			Namespace: engine.Namespace,
+		},
+	}
+	tokenKey := fmt.Sprintf("%s/%s/%s", testNamespace, engineName, rulesetName)
+
+	// --- Phase 1: initial provision (finalizer + provisioning reconciles) ---
+	result, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.NotZero(t, result.RequeueAfter, "finalizer add must request requeue")
+
+	result, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.NotZero(t, result.RequeueAfter, "provisioning must schedule token renewal requeue")
+
+	val, found := reconciler.tokenStore.Load(tokenKey)
+	require.True(t, found, "token must be stored after initial provisioning")
+	originalToken := val.(*TokenEntry).Token
+	require.NotEmpty(t, originalToken)
+
+	var saList corev1.ServiceAccountList
+	err = k8sClient.List(ctx, &saList,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels(cacheClientSALabels(engineName)),
+	)
+	require.NoError(t, err)
+	require.Len(t, saList.Items, 1)
+	originalSAName := saList.Items[0].Name
+
+	// --- Phase 2: delete Engine and its SA (simulating GC) ---
+	require.NoError(t, k8sClient.Delete(ctx, engine))
+	require.NoError(t, k8sClient.Delete(ctx, &saList.Items[0]))
+
+	// Reconcile finalizer removal: Engine still exists (DeletionTimestamp
+	// set) — handleNetworkPolicyDeletion removes the finalizer.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// Verify the Engine is now fully deleted (finalizer removed → GC'd).
+	var gone wafv1alpha1.Engine
+	require.True(t, apierrors.IsNotFound(k8sClient.Get(ctx, req.NamespacedName, &gone)),
+		"Engine must be gone after finalizer removal")
+
+	// Reconcile the IsNotFound path — cleans up the tokenStore.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	_, found = reconciler.tokenStore.Load(tokenKey)
+	assert.False(t, found, "tokenStore entry must be cleaned up when Engine is deleted")
+
+	// --- Phase 3: recreate Engine with the same name ---
+	engine2 := utils.NewTestEngine(utils.EngineOptions{
+		Name:        engineName,
+		Namespace:   testNamespace,
+		RuleSetName: rulesetName,
+	})
+	require.NoError(t, k8sClient.Create(ctx, engine2))
+	t.Cleanup(func() {
+		if err := k8sClient.Delete(ctx, engine2); err != nil {
+			t.Logf("Failed to delete engine: %v", err)
+		}
+	})
+
+	// Reconcile the recreated Engine (finalizer + provisioning).
+	result, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.NotZero(t, result.RequeueAfter, "finalizer add must request requeue")
+
+	result, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.NotZero(t, result.RequeueAfter, "provisioning must schedule token renewal requeue")
+
+	// A new SA should have been created (the original was deleted).
+	var newSAList corev1.ServiceAccountList
+	err = k8sClient.List(ctx, &newSAList,
+		client.InNamespace(testNamespace),
+		client.MatchingLabels(cacheClientSALabels(engineName)),
+	)
+	require.NoError(t, err)
+	require.Len(t, newSAList.Items, 1)
+	assert.NotEqual(t, originalSAName, newSAList.Items[0].Name,
+		"recreated Engine must get a new SA, not reuse the deleted one")
+
+	// The recreated Engine must get a fresh token bound to the new SA.
+	val, found = reconciler.tokenStore.Load(tokenKey)
+	require.True(t, found, "recreated Engine must have a token")
+	newToken := val.(*TokenEntry).Token
+	assert.NotEqual(t, originalToken, newToken,
+		"recreated Engine must get a fresh token, not reuse the stale one")
+}
+
 func TestEngineReconciler_MetricsForgetOnNotFound(t *testing.T) {
 	ctx, cleanup := setupTest(t)
 	defer cleanup()

--- a/internal/controller/engine_controller_token.go
+++ b/internal/controller/engine_controller_token.go
@@ -112,11 +112,12 @@ func (r *EngineReconciler) ensureCacheClientServiceAccount(ctx context.Context, 
 		return "", fmt.Errorf("failed to list ServiceAccounts for engine %s: %w", engine.Name, err)
 	}
 
-	// Filter out terminating SAs — their tokens will become invalid
-	// once garbage collection completes.
+	// Filter to SAs that are non-terminating and owned by this Engine
+	// instance. The UID check prevents reusing an SA from a previous
+	// Engine with the same name whose GC hasn't completed yet.
 	var activeSAs []corev1.ServiceAccount
 	for i := range saList.Items {
-		if saList.Items[i].DeletionTimestamp.IsZero() {
+		if saList.Items[i].DeletionTimestamp.IsZero() && metav1.IsControlledBy(&saList.Items[i], engine) {
 			activeSAs = append(activeSAs, saList.Items[i])
 		}
 	}

--- a/internal/controller/engine_controller_token.go
+++ b/internal/controller/engine_controller_token.go
@@ -242,7 +242,7 @@ func (r *EngineReconciler) cleanupStaleTokens(namespace, engineName, currentRule
 func (r *EngineReconciler) tokenDeleteFunc(prefix, keep string) func(key, _ any) bool {
 	return func(key, _ any) bool {
 		if k, ok := key.(string); ok && strings.HasPrefix(k, prefix) && k != keep {
-			r.tokenStore.Delete(key)
+			r.tokenStore.Delete(k)
 		}
 		return true
 	}

--- a/internal/controller/engine_controller_token.go
+++ b/internal/controller/engine_controller_token.go
@@ -225,27 +225,25 @@ func (r *EngineReconciler) pruneExpiredTokens() {
 
 // deleteTokensByPrefix removes all token entries whose key starts with prefix.
 func (r *EngineReconciler) deleteTokensByPrefix(prefix string) {
-	r.tokenStore.Range(func(key, _ any) bool {
-		if k, ok := key.(string); ok && strings.HasPrefix(k, prefix) {
-			r.tokenStore.Delete(key)
-		}
-		return true
-	})
+	r.tokenStore.Range(r.tokenDeleteFunc(prefix, ""))
 }
 
 // cleanupStaleTokens removes token entries for RuleSets that an Engine no
 // longer references. When spec.ruleSet.name changes, the old token (keyed by
 // "namespace/engineName/oldRuleSet") would otherwise leak in the sync.Map
 // until it expires.
-// This intentionally duplicates the Range loop from deleteTokensByPrefix
-// because it must exclude the current RuleSet's key during iteration.
 func (r *EngineReconciler) cleanupStaleTokens(namespace, engineName, currentRuleSet string) {
 	prefix := fmt.Sprintf("%s/%s/", namespace, engineName)
-	keep := prefix + currentRuleSet
-	r.tokenStore.Range(func(key, _ any) bool {
+	r.tokenStore.Range(r.tokenDeleteFunc(prefix, prefix+currentRuleSet))
+}
+
+// tokenDeleteFunc returns a Range callback that deletes entries matching
+// prefix, optionally skipping the keep key.
+func (r *EngineReconciler) tokenDeleteFunc(prefix, keep string) func(key, _ any) bool {
+	return func(key, _ any) bool {
 		if k, ok := key.(string); ok && strings.HasPrefix(k, prefix) && k != keep {
 			r.tokenStore.Delete(key)
 		}
 		return true
-	})
+	}
 }

--- a/internal/controller/engine_controller_token.go
+++ b/internal/controller/engine_controller_token.go
@@ -111,17 +111,27 @@ func (r *EngineReconciler) ensureCacheClientServiceAccount(ctx context.Context, 
 	); err != nil {
 		return "", fmt.Errorf("failed to list ServiceAccounts for engine %s: %w", engine.Name, err)
 	}
-	if len(saList.Items) > 0 {
-		if len(saList.Items) > 1 {
+
+	// Filter out terminating SAs — their tokens will become invalid
+	// once garbage collection completes.
+	var activeSAs []corev1.ServiceAccount
+	for i := range saList.Items {
+		if saList.Items[i].DeletionTimestamp.IsZero() {
+			activeSAs = append(activeSAs, saList.Items[i])
+		}
+	}
+
+	if len(activeSAs) > 0 {
+		if len(activeSAs) > 1 {
 			log.Info("Multiple ServiceAccounts match cache-client labels, using first",
 				"engine", req.Name,
 				"namespace", req.Namespace,
-				"matchCount", len(saList.Items),
-				"selectedSA", saList.Items[0].Name,
+				"matchCount", len(activeSAs),
+				"selectedSA", activeSAs[0].Name,
 			)
 		}
 		logDebug(log, req, "Engine", "ServiceAccount already exists")
-		return saList.Items[0].Name, nil
+		return activeSAs[0].Name, nil
 	}
 
 	sa := &corev1.ServiceAccount{
@@ -212,16 +222,28 @@ func (r *EngineReconciler) pruneExpiredTokens() {
 	})
 }
 
+// deleteTokensByPrefix removes all token entries whose key starts with prefix.
+func (r *EngineReconciler) deleteTokensByPrefix(prefix string) {
+	r.tokenStore.Range(func(key, _ any) bool {
+		if k, ok := key.(string); ok && strings.HasPrefix(k, prefix) {
+			r.tokenStore.Delete(key)
+		}
+		return true
+	})
+}
+
 // cleanupStaleTokens removes token entries for RuleSets that an Engine no
 // longer references. When spec.ruleSet.name changes, the old token (keyed by
 // "namespace/engineName/oldRuleSet") would otherwise leak in the sync.Map
 // until it expires.
+// This intentionally duplicates the Range loop from deleteTokensByPrefix
+// because it must exclude the current RuleSet's key during iteration.
 func (r *EngineReconciler) cleanupStaleTokens(namespace, engineName, currentRuleSet string) {
 	prefix := fmt.Sprintf("%s/%s/", namespace, engineName)
+	keep := prefix + currentRuleSet
 	r.tokenStore.Range(func(key, _ any) bool {
-		k := key.(string)
-		if strings.HasPrefix(k, prefix) && !strings.HasSuffix(k, "/"+currentRuleSet) {
-			r.tokenStore.Delete(k)
+		if k, ok := key.(string); ok && strings.HasPrefix(k, prefix) && k != keep {
+			r.tokenStore.Delete(key)
 		}
 		return true
 	})

--- a/internal/controller/engine_controller_token_test.go
+++ b/internal/controller/engine_controller_token_test.go
@@ -282,6 +282,80 @@ func TestCleanupStaleTokens_EmptyStore(t *testing.T) {
 	assert.Equal(t, 0, count)
 }
 
+func TestDeleteTokensByPrefix(t *testing.T) {
+	r := &EngineReconciler{}
+	now := time.Now()
+
+	r.tokenStore.Store("ns/engine1/ruleset-a", &TokenEntry{
+		Token:     "ta",
+		IssuedAt:  now,
+		ExpiresAt: now.Add(1 * time.Hour),
+	})
+	r.tokenStore.Store("ns/engine1/ruleset-b", &TokenEntry{
+		Token:     "tb",
+		IssuedAt:  now,
+		ExpiresAt: now.Add(1 * time.Hour),
+	})
+	r.tokenStore.Store("ns/engine2/other", &TokenEntry{
+		Token:     "unrelated",
+		IssuedAt:  now,
+		ExpiresAt: now.Add(1 * time.Hour),
+	})
+
+	r.deleteTokensByPrefix("ns/engine1/")
+
+	_, hasA := r.tokenStore.Load("ns/engine1/ruleset-a")
+	assert.False(t, hasA, "entry matching prefix should be deleted")
+
+	_, hasB := r.tokenStore.Load("ns/engine1/ruleset-b")
+	assert.False(t, hasB, "entry matching prefix should be deleted")
+
+	_, hasOther := r.tokenStore.Load("ns/engine2/other")
+	assert.True(t, hasOther, "entry with different prefix should remain")
+
+	count := 0
+	r.tokenStore.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 1, count)
+}
+
+func TestDeleteTokensByPrefix_NoMatch(t *testing.T) {
+	r := &EngineReconciler{}
+	now := time.Now()
+
+	r.tokenStore.Store("ns/engine1/rs1", &TokenEntry{
+		Token:     "t1",
+		IssuedAt:  now,
+		ExpiresAt: now.Add(1 * time.Hour),
+	})
+
+	r.deleteTokensByPrefix("ns/engine99/")
+
+	_, has := r.tokenStore.Load("ns/engine1/rs1")
+	assert.True(t, has, "entry should remain when no keys match prefix")
+
+	count := 0
+	r.tokenStore.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 1, count)
+}
+
+func TestDeleteTokensByPrefix_EmptyStore(t *testing.T) {
+	r := &EngineReconciler{}
+	r.deleteTokensByPrefix("any/prefix/")
+
+	count := 0
+	r.tokenStore.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 0, count)
+}
+
 func TestCacheClientSALabels(t *testing.T) {
 	labels := cacheClientSALabels("my-engine")
 	assert.Equal(t, "coraza-kubernetes-operator", labels["app.kubernetes.io/managed-by"])


### PR DESCRIPTION
When an Engine is deleted and recreated with the same name, the tokenStore could serve a stale token bound to the now-deleted ServiceAccount. Clear all cached tokens for the Engine in the IsNotFound path and filter out terminating ServiceAccounts when discovering existing ones.

Extract deleteTokensByPrefix helper to share prefix-matching logic with cleanupStaleTokens and unify the matching style.

Add unit test for the full delete-recreate lifecycle verifying token and ServiceAccount renewal.

Fixes #467
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Zdenek Kraus <zkraus@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed cached authentication tokens when an Engine is no longer found, preventing stale credentials from being reused.
  * Ignored terminating or previously owned ServiceAccounts when selecting an active account.
  * Ensured recreated Engines receive fresh ServiceAccounts and tokens.
  * Improved outdated-token cleanup while preserving the current token.

* **Tests**
  * Added coverage for Engine recreation, token cleanup, fresh token generation, and stale ServiceAccount handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->