### PR TITLE
ci: set GOMAXPROCS=1 globally for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  GOMAXPROCS: "1"
+
 jobs:
   build:
     name: build and generate


### PR DESCRIPTION
Reduce CPU contention across parallel CI jobs by limiting Go to a single OS thread.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Zdenek Kraus <zkraus@redhat.com>