### PR TITLE
DRAFT: ci/jobs tier architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  GOMAXPROCS: "1"
+
 jobs:
   build:
     name: build and generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  GOMAXPROCS: "1"
-
 jobs:
   build:
     name: build and generate
@@ -162,7 +159,7 @@ jobs:
   unit-tests:
     name: unit tests
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [build]
     steps:
       - name: checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -225,7 +222,7 @@ jobs:
     name: Coreruleset conformance test
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [build]
+    needs: [integration-tests]
     steps:
       - name: checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -280,7 +277,7 @@ jobs:
     name: integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [lint, build]
+    needs: [unit-tests]
     steps:
       - name: checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION

Run all non-cluster jobs (lint, unit-tests, tools-tests,
bundle-validate, chart-lint, helm-validate) in parallel after build.
Chain KIND-requiring jobs sequentially after unit-tests:
integration-tests → conformance-tests.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Zdenek Kraus <zkraus@redhat.com>