### PR TITLE
docs: add KIND_EXPERIMENTAL_PROVIDER=podman note for cgroup v2 systems

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,6 +25,19 @@ Create the cluster:
 make cluster.kind
 ```
 
+> **Note**: On Linux systems using cgroup v2 (e.g. Fedora), `make cluster.kind`
+> may fail with Docker and the following error:
+>
+> ```
+> could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
+> ```
+>
+> Use Podman as the KIND provider instead:
+>
+> ```bash
+> KIND_EXPERIMENTAL_PROVIDER=podman make cluster.kind
+> ```
+
 This will have built the operator with your current changes and loaded the
 operator image into the cluster, and started the operator in the
 `coraza-system` namespace.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,14 +28,15 @@ make cluster.kind
 > **Note**: On Linux systems using cgroup v2 (e.g. Fedora), `make cluster.kind`
 > may fail with Docker and the following error:
 >
-> ```
+> ```text
 > could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
 > ```
 >
-> Use Podman as the KIND provider instead:
+> Use Podman instead by setting both `CONTAINER_TOOL` (for image build and load)
+> and `KIND_EXPERIMENTAL_PROVIDER` (for cluster creation):
 >
 > ```bash
-> KIND_EXPERIMENTAL_PROVIDER=podman make cluster.kind
+> CONTAINER_TOOL=podman KIND_EXPERIMENTAL_PROVIDER=podman make cluster.kind
 > ```
 
 This will have built the operator with your current changes and loaded the


### PR DESCRIPTION
## Summary

`make cluster.kind` fails silently on Linux systems using cgroup v2 (e.g. Fedora) when using Docker as the container runtime. The KIND node fails to boot with the following error:

```
 ✗ Preparing nodes 📦
Deleted nodes: ["coraza-kubernetes-operator-integration-control-plane"]
ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
```

## Root cause

Docker with the systemd cgroup driver does not correctly delegate cgroup hierarchy to `KIND` node containers on cgroup v2 systems. Podman handles this correctly!

## Fix

Using `KIND_EXPERIMENTAL_PROVIDER=podman` resolves the issue with no other changes required:

```
KIND_EXPERIMENTAL_PROVIDER=podman make cluster.kind
```

```
using podman due to KIND_EXPERIMENTAL_PROVIDER
enabling experimental podman provider
Creating cluster "coraza-kubernetes-operator-integration" ...
 ✓ Ensuring node image (kindest/node:v1.34.0) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-coraza-kubernetes-operator-integration"
```

This PR adds a note to `DEVELOPMENT.md` so contributors on cgroup v2 systems are not blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux cgroup v2 troubleshooting guidance for KIND.
  * Clarified the Docker error message formatting.
  * Added Podman workaround instructions, including the required environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->