### PR TITLE
docs: add JSON body processor directive to base RuleSource example

### DIFF
--- a/docs/content/howto/creating-firewall-rules.md
+++ b/docs/content/howto/creating-firewall-rules.md
@@ -26,7 +26,19 @@ spec:
     SecAuditLog /dev/stdout
     SecAuditLogFormat JSON
     SecAuditEngine RelevantOnly
+    # Enable JSON body parsing so that ARGS-based rules inspect application/json request bodies.
+    # Without this, JSON request bodies are read as raw bytes and are invisible to ARGS rules.
+    SecRule REQUEST_HEADERS:Content-Type "@rx application/json" \
+      "id:900,phase:1,pass,nolog,ctl:requestBodyProcessor=JSON"
 ```
+
+{{% alert title="JSON body inspection" color="info" %}}
+`SecRequestBodyAccess On` enables body reading but does **not** automatically parse JSON.
+Coraza requires an explicit `requestBodyProcessor` directive per content type before `ARGS`
+rules can inspect the body (see [corazawaf/coraza#438](https://github.com/corazawaf/coraza/issues/438)).
+The example above adds a JSON processor — add equivalent rules for other content types
+(e.g. `application/xml`) as needed.
+{{% /alert %}}
 
 A RuleSource with a SQL injection detection rule:
 


### PR DESCRIPTION
## Summary

The base RuleSource example in `creating-firewall-rules.md` configures `SecRequestBodyAccess On`
but omits the `requestBodyProcessor=JSON` directive. This means ARGS-based rules silently skip
`application/json` request bodies — a common attack surface for modern APIs.

## Reproduction

Following the guide as-written, the SQLi rule blocks query param attacks but passes JSON body
attacks through undetected:

```bash
# Blocked ✅ (query param — WAF inspects this)
curl "http://app/?q=select FROM users"
# → 403

# Not blocked ❌ (JSON body — WAF is blind without the processor)
curl -X POST http://app/ \
  -H "Content-Type: application/json" \
  -d '{"q":"select FROM users"}'
# → 200
```

## Fix

Adding `requestBodyProcessor=JSON` causes Coraza to parse the JSON body and expose its
fields as `ARGS`, so the existing SQLi rule blocks both attack vectors:

```bash
# Both blocked ✅ after adding the JSON processor directive
curl "http://app/?q=select FROM users"
# → 403

curl -X POST http://app/ \
  -H "Content-Type: application/json" \
  -d '{"q":"select FROM users"}'
# → 403

# Normal JSON requests still pass through ✅
curl -X POST http://app/ \
  -H "Content-Type: application/json" \
  -d '{"name":"alice","page":1}'
# → 200
```

## Notes

This is consistent with the Coraza core team's position that body processors must be
configured explicitly per content type (see [corazawaf/coraza#438](https://github.com/corazawaf/coraza/issues/438)).
`SecRequestBodyAccess On` enables body reading but does not imply parsing — the distinction
is easy to miss when testing only with form data or query params.

## Changes

- Added `requestBodyProcessor=JSON` directive to the base-rules RuleSource example
- Added an info callout explaining the behaviour and linking to the upstream issue

## Test plan
- [x] Deployed the updated base-config RuleSource in a KIND cluster (Fedora 43, Istio 1.30.3)
- [x] Verified JSON body SQLi attack blocked (403) after adding the directive
- [x] Verified query param SQLi attack still blocked (403)
- [x] Verified normal JSON requests still allowed (200)