### PR TITLE
fix(kind): derive KIND_EXPERIMENTAL_PROVIDER from CONTAINER_TOOL

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,12 +32,19 @@ make cluster.kind
 > could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
 > ```
 >
-> Use Podman instead by setting both `CONTAINER_TOOL` (for image build and load)
-> and `KIND_EXPERIMENTAL_PROVIDER` (for cluster creation):
+> Use Podman instead by setting `CONTAINER_TOOL`:
 >
 > ```bash
-> CONTAINER_TOOL=podman KIND_EXPERIMENTAL_PROVIDER=podman make cluster.kind
+> export CONTAINER_TOOL=podman
 > ```
+> or
+> ```bash
+> CONTAINER_TOOL=podman make cluster.kind
+> ```
+>
+> `KIND_EXPERIMENTAL_PROVIDER=podman` is derived automatically from the
+> container runtime, so you no longer need to set it yourself. Set it
+> explicitly only to override the detected provider.
 
 This will have built the operator with your current changes and loaded the
 operator image into the cluster, and started the operator in the

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,15 @@ endif
 
 CONTAINER_TOOL ?= docker
 
+# Derive the kind provider from the container runtime so callers only need to
+# set CONTAINER_TOOL. The kind binary (used directly by the Go test targets via
+# `kind get kubeconfig`, and by hack/kind_cluster.py) reads this from the
+# environment. Exported so it reaches every recipe; an explicit value wins.
+ifeq ($(CONTAINER_TOOL),podman)
+KIND_EXPERIMENTAL_PROVIDER ?= podman
+endif
+export KIND_EXPERIMENTAL_PROVIDER
+
 # KIND_CLUSTER_NAME is used to detect if tests are running locally via kind.
 # Use a non-empty default for kind-based integration tests; override or clear
 # it when running against an external cluster like OCP.

--- a/hack/kind_cluster.py
+++ b/hack/kind_cluster.py
@@ -50,8 +50,24 @@ def get_kind_context(name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def sync_kind_provider() -> None:
+    """Set KIND_EXPERIMENTAL_PROVIDER from the detected container runtime.
+
+    The kind binary reads this env var to choose its provider. When podman is
+    the runtime, kind needs KIND_EXPERIMENTAL_PROVIDER=podman for both create
+    and delete. Deriving it here (from CONTAINER_TOOL / autodetection) means
+    users no longer have to set it alongside CONTAINER_TOOL. An explicit value
+    already in the environment is left untouched.
+    """
+    if os.environ.get("KIND_EXPERIMENTAL_PROVIDER"):
+        return
+    if detect_container_runtime() == "podman":
+        os.environ["KIND_EXPERIMENTAL_PROVIDER"] = "podman"
+
+
 def create_cluster(name: str) -> None:
     """Create a KIND cluster (no-op if it already exists)."""
+    sync_kind_provider()
     print(f"Creating kind cluster: {name}")
     result = run(f"kind get clusters | grep -q '^{name}$'", check=False)
     if result.returncode == 0:
@@ -61,6 +77,7 @@ def create_cluster(name: str) -> None:
 
 
 def delete_cluster(name: str) -> None:
+    sync_kind_provider()
     print(f"Deleting kind cluster: {name}")
     run(f"kind delete cluster --name {name}", check=False)
 

--- a/hack/lib.py
+++ b/hack/lib.py
@@ -1,6 +1,6 @@
 """Shared utilities for hack/ scripts."""
 
-import json
+import os
 import subprocess
 import sys
 
@@ -72,17 +72,21 @@ def detect_container_runtime() -> str:
     if _container_runtime:
         return _container_runtime
 
-    # Try docker first
-    result = run("docker version --format json", check=False, capture_output=True)
+    # Honor an explicit CONTAINER_TOOL override (matches the Makefile variable).
+    # This lets callers force a runtime instead of relying on autodetection.
+    override = os.environ.get("CONTAINER_TOOL", "").strip()
+    if override:
+        _container_runtime = override
+        return _container_runtime
+
+    # Prefer docker if its daemon is reachable. Some Docker CLI builds omit
+    # Client.Platform.Name from `docker version --format json`, so checking
+    # daemon availability directly (rather than parsing that field) avoids
+    # misdetecting a working Docker install as podman when both are present.
+    result = run("docker info", check=False, capture_output=True)
     if result.returncode == 0:
-        try:
-            info = json.loads(result.stdout)
-            platform = info.get("Client", {}).get("Platform", {}).get("Name", "")
-            if "Docker Engine" in platform:
-                _container_runtime = "docker"
-                return _container_runtime
-        except (json.JSONDecodeError, KeyError, AttributeError):
-            pass
+        _container_runtime = "docker"
+        return _container_runtime
 
     # Fall back to podman
     result = run("podman version", check=False, capture_output=True)


### PR DESCRIPTION
Using podman for kind previously required setting both CONTAINER_TOOL (image build/load) and KIND_EXPERIMENTAL_PROVIDER (used by the kind binary for cluster and kubeconfig operations). Forgetting the latter made `make test.e2e` / test.integration / test.conformance fail, since the Go framework calls `kind get kubeconfig` directly.

Now callers only set CONTAINER_TOOL:

- hack/lib.py: detect_container_runtime honors the CONTAINER_TOOL override before autodetecting, and probes `docker info` (daemon reachability) instead of parsing Client.Platform.Name, which some Docker CLI builds omit. -- This may have caused metallb not to be deployed.
- hack/kind_cluster.py: derive KIND_EXPERIMENTAL_PROVIDER from the detected runtime for direct script invocation (create and delete).
- Makefile: derive and export KIND_EXPERIMENTAL_PROVIDER for podman so it reaches every recipe, including the Go test targets.

An explicit KIND_EXPERIMENTAL_PROVIDER always wins.

Related to: #480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting Podman as the container runtime through `CONTAINER_TOOL`.
  - Automatically configures KIND to use Podman when selected, while preserving explicit provider settings.
  - Improved container runtime detection, including Docker availability checks.

- **Documentation**
  - Updated Linux KIND setup instructions for cgroup v2 environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->